### PR TITLE
docs: reorg for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ The `decrypt` function returns a string containing the plaintext data.
 > [!TIP]
 > You can get significantly better decryption performance by using the [`bulkDecrypt` function](#bulk-decrypting-data).
 
+### Storing encrypted data in a database
+
+To store the encrypted data in PostgreSQL, you will need to specify the column type as `jsonb`.
+
+```sql
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email jsonb NOT NULL,
+);
+```
+
 ## Identity-aware encryption
 
 Protect.js can add an additional layer of protection to your data by requiring a valid JWT to perform a decryption.

--- a/README.md
+++ b/README.md
@@ -177,127 +177,18 @@ const lc = new LockContext()
 > [!NOTE]
 > When initializing a `LockContext`, the default context is set to use the `sub` Identity Claim.
 
-**Custom context**
+### Identify a user for a lock context
 
-If you want to override the default context, you can pass a custom context to the `LockContext` constructor.
-
-```typescript
-import { LockContext } from '@cipherstash/protect/identify'
-
-// protectClient from the previous steps
-const lc = new LockContext({
-  context: {
-    identityClaim: ['sub'], // this is the default context
-  },
-})
-```
-
-**Context and identity claim options**
-
-The context object contains an `identityClaim` property.
-The `identityClaim` property must be an array of strings that correspond to the Identity Claim(s) you want to lock the encryption operation to.
-
-Currently supported Identity Claims are:
-
-| Identity Claim | Description |
-| -------------- | ----------- |
-| `sub`          | The user's subject identifier. |
-| `scopes`       | The user's scopes set by your IDP policy. |
-
-#### Identifying the user
-
-The lock context needs to be tied to a specific user.
-To identify the user, call the `identify` method on the lock context object.
+A lock context needs to be locked to a user.
+To identify the user, call the `identify` method on the lock context object, and pass a valid JWT from a user's session:
 
 ```typescript
-const lockContext = await lc.identify('jwt_token_from_identiti_provider')
-```
-
-The `jwt_token_from_identiti_provider` is the JWT token from your identity provider, and can be retrieved from the user's session.
-
-### Lock context with Next.js and Clerk
-
-If you're using [Clerk](https://clerk.com/) as your identity provider, you can use the `protectClerkMiddleware` function to automatically set the CTS token for every user session.
-
-Install the `@cipherstash/nextjs` package:
-
-```bash
-npm install @cipherstash/nextjs
-# or
-yarn add @cipherstash/nextjs
-# or
-pnpm add @cipherstash/nextjs
-```
-
-In your `middleware.ts` file, add the following code:
-
-```typescript
-import { clerkMiddleware } from '@clerk/nextjs/server'
-import { protectClerkMiddleware } from '@cipherstash/nextjs/clerk'
-
-export default clerkMiddleware(async (auth, req: NextRequest) => {
-  return protectClerkMiddleware(auth, req)
-})
-```
-
-#### Retrieving the CTS token in Next.js 
-
-You can then use the `getCtsToken` function to retrieve the CTS token for the current user session.
-
-```typescript
-import { getCtsToken } from '@cipherstash/nextjs'
-
-export default async function Page() {
-  const ctsToken = await getCtsToken()
-
-  // getCtsToken returns either
-  // ---
-  // { success: true, ctsToken: CtsToken }
-  // or
-  // { success: false, error: string }
-
-  if (!ctsToken.success) {
-    // handle error
-  }
-
-  return (
-    <div>
-      <h1>Server side rendered page</h1>
-    </div>
-  )
-}
-```
-
-#### Contructing a LockContext with an existing CTS token
-
-Since the CTS token is already available, you can construct a `LockContext` object with the existing CTS token.
-
-```typescript
-import { LockContext } from '@cipherstash/protect/identify'
-import { getCtsToken } from '@cipherstash/nextjs'
-
-export default async function Page() {
-  const ctsToken = await getCtsToken()
-
-  if (!ctsToken.success) {
-    // handle error
-  }
-
-  const lockContext = new LockContext({
-    ctsToken
-  })
-
-  return (
-    <div>
-      <h1>Server side rendered page</h1>
-    </div>
-  )
-}
+const lockContext = await lc.identify(jwt)
 ```
 
 ### Encrypting data with a lock context
 
-To encrypt data with a lock context, call the optional `withLockContext` method on the `encrypt` function and pass the lock context object as a parameter.
+To encrypt data with a lock context, call the optional `withLockContext` method on the `encrypt` function and pass the lock context object as a parameter:
 
 ```typescript
 const ciphertext = await protectClient.encrypt('plaintext', {
@@ -308,7 +199,7 @@ const ciphertext = await protectClient.encrypt('plaintext', {
 
 ### Decrypting data with a lock context
 
-To decrypt data with a lock context, call the optional `withLockContext` method on the `decrypt` function and pass the lock context object as a parameter.
+To decrypt data with a lock context, call the optional `withLockContext` method on the `decrypt` function and pass the lock context object as a parameter:
 
 ```typescript
 const plaintext = await protectClient.decrypt(ciphertext).withLockContext(lockContext)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This enables every encrypted value, in every column, in every row in your databa
 
 ## Installation
 
-Install `@cipherstash/protect` via one of the following methods:
+Install the [`@cipherstash/protect` package](https://www.npmjs.com/package/@cipherstash/protect) with your package manager of choice:
 
 ```bash
 npm install @cipherstash/protect

--- a/README.md
+++ b/README.md
@@ -51,11 +51,8 @@ yarn add @cipherstash/protect
 pnpm add @cipherstash/protect
 ```
 
-### Bun (experimental)
-
-[Bun](https://bun.sh/) is an alternate JavaScript runtime that targets Node compatibility.
-The underlying [CipherStash Client](#cipherstash-client) is written in Rust and adpated to JavaScript using [Neon](https://github.com/neon-bindings/neon).
-At the moment, Bun is not supported due to the lack of Node API compatibility.
+> [!TIP]
+> [Bun](https://bun.sh/) is not currently supported due to a lack of [Node-API compatibility](https://github.com/oven-sh/bun/issues/158). Under the hood, Protect.js uses [CipherStash Client](#cipherstash-client) which is written in Rust and embedded using [Neon](https://github.com/neon-bindings/neon).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -73,21 +73,24 @@ Lastly, install the CipherStash CLI:
 ### Configuration
 
 > [!IMPORTANT]
-> These values are required to use the `@cipherstash/protect` package.
-> The names of the variables must match the values above or the package will not work.
+> Make sure you have [installed the CipherStash CLI](#installation) before following these steps.
 
-#### client keys
+To set up all the configuration and credentials required for Protect.js:
 
-At the time of this writing, you will need to use the [CipherStash CLI to generate a new client key](https://cipherstash.com/docs/how-to/client-keys).
+```bash
+stash setup
+```
 
-#### workspace id
+If you have not already signed up for a CipherStash account, this will prompt you to do so along the way.
 
-`CS_WORKSPACE_ID` is the ID of the workspace you want to use, and can be found in the [CipherStash dashboard](  https://dashboard.cipherstash.com/).
+At the end of `stash setup`, you will have two files in your project:
 
-#### access key
+- `cipherstash.toml` which contains the configuration for Protect.js
+- `cipherstash.secret.toml`: which contains the credentials for Protect.js
 
-`CS_CLIENT_ACCESS_KEY` is used to authenticate with the CipherStash API.
-You can generate an access token in the dashboard or the CLI.
+> [!WARNING]
+> `cipherstash.secret.toml` should not be committed to git, because it contains sensitive credentials.
+
 
 ### Initialize the EQL client
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Lastly, install the CipherStash CLI:
     - [Linux x86_64](https://github.com/cipherstash/cli-releases/releases/latest/download/stash-x86_64-unknown-linux-gnu)
 
 
-## Usage
+## Getting started
 
 ### Configuration
 
@@ -360,7 +360,7 @@ If you're interested in using `@cipherstash/protect` with a specific ORM, please
 
 ## CipherStash Client
 
-Protect.js is built on top of the CipherStash Client Rust SDK which is integrated with the `@cipherstash/protect-ffi` package.
+Protect.js is built on top of the CipherStash Client Rust SDK which is embedded with the `@cipherstash/protect-ffi` package.
 The `@cipherstash/protect-ffi` source code is available on [GitHub](https://github.com/cipherstash/protectjs-ffi).
 
 The Cipherstash Client is configured by environment variables, which are used to initialize the client when the `protect` function is called:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ The `decrypt` function returns a string containing the plaintext data.
 'secret@squirrel.example'
 ```
 
+## Identity-aware encryption
+
+Protect.js can add an additional layer of protection to your data by requiring a valid JWT to perform a decryption.
+
+This ensures that only the user who encrypted data is able to decrypt it.
+
+Protect.js does this through a mechanism called a _lock context_.
+
 ### Lock context
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -349,38 +349,6 @@ PROTECT_LOG_LEVEL=info   # Enable info logging
 PROTECT_LOG_LEVEL=error  # Enable error logging
 ```
 
-## Builds and bundling
-
-`@cipherstash/protect` is a native Node.js module, and relies on native Node.js `require` to load the package.
-
-### Next.js
-
-Using `@cipherstash/protect` with Next.js? You need to opt-out from the Server Components bundling and use native Node.js `require` instead.
-
-#### Using version 15 or later
-
-`next.config.ts` [configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages):
-
-```js
-const nextConfig = {
-  ...
-  serverExternalPackages: ['@cipherstash/protect'],
-}
-```
-
-#### Using version 14
-
-`next.config.mjs` [configuration](https://nextjs.org/docs/14/app/api-reference/next-config-js/serverComponentsExternalPackages):
-
-```js
-const nextConfig = {
-  ...
-  experimental: {
-    serverComponentsExternalPackages: ['@cipherstash/protect'],
-  },
-}
-```
-
 ## Examples
 
 - [Basic example](/apps/basic)
@@ -411,6 +379,12 @@ The Cipherstash Client is configured by environment variables, which are used to
 
 - If you've created a Workspace in a region other than `ap-southeast-2`, you will need to set the `CS_ZEROKMS_HOST` environment variable to the appropriate region. For example, if you are using ZeroKMS in the `eu-central-1` region, you need to set the `CS_ZEROKMS_HOST` variable to `https://eu-central-1.aws.viturhosted.net`. This is a known usability issue that will be addressed.
 - In most hosting environments, the `CS_CONFIG_PATH` environment variable will need to be set to a path that the user running the application has permission to write to. Setting `CS_CONFIG_PATH` to `/tmp/.cipherstash` will work in most cases, and has been tested on [Vercel](https://vercel.com/), [AWS Lambda](https://aws.amazon.com/lambda/), and other hosting environments.
+
+## Builds and bundling
+
+`@cipherstash/protect` is a native Node.js module, and relies on native Node.js `require` to load the package.
+
+If you are using `@cipherstash/protect` with Next.js, you must opt out from the Server Components bundling and [use native Node.js `require` instead](./docs/nextjs.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ At the end of `stash setup`, you will have two files in your project:
 
 ### Initialize the EQL client
 
-Import the `protect` function from the `@cipherstash/protect` package and initialize a client with your CipherStash credentials.
+In your application, import the `protect` function from the `@cipherstash/protect` package, and initialize a client with your CipherStash credentials.
 
 ```typescript
 const { protect } = require('@cipherstash/protect')
 const protectClient = await protect()
 ```
 
-.. or using ES6?
+If you are using ES6:
 
 ```typescript
 import { protect } from '@cipherstash/protect'
@@ -110,12 +110,12 @@ const protectClient = await protect()
 
 ### Encrypting data
 
-To encrypt data, use the `encrypt` function.
-This function takes a plaintext string and an object with the table and column name as parameters.
+Use the `encrypt` function to encrypt data.
+`encrypt` takes a plaintext string, and an object with the table and column name as parameters.
 
 ```typescript
-const ciphertext = await protectClient.encrypt('plaintext', {
-  column: 'column_name',
+const ciphertext = await protectClient.encrypt('secret@squirrel.example', {
+  column: 'email',
   table: 'users',
 })
 ```
@@ -124,20 +124,24 @@ The `encrypt` function returns an object with a `c` key, and the value is the en
 
 ```typescript
 {
-  c: 'encrypted-data'
+  c: '\\\\\\\\\\\\\\\\x61202020202020472aaf602219d48c4a...'
 }
 ```
 
 ### Decrypting data
 
-To decrypt data, use the `decrypt` function.
-This function takes an encrypted data object and an object with the lock context as parameters.
+Use the `decrypt` function to decrypt data.
+`decrypt` takes an encrypted data object, and an object with the lock context as parameters.
 
 ```typescript
 const plaintext = await protectClient.decrypt(ciphertext)
 ```
 
-The `decrypt` function returns a string with the plaintext data.
+The `decrypt` function returns a string containing the plaintext data.
+
+```typescript
+'secret@squirrel.example'
+```
 
 ### Lock context
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ This enables every encrypted value, in every column, in every row in your databa
 - **Meet compliance requirements faster:** achieve and exceed the data encryption requirements of SOC2 and ISO27001.
 - **Reduce the blast radius of data breaches:** limit the impact of exploited vulnerabilities to only the data your end-users can decrypt.
 
+## Example applications
+
+New to Protect.js?
+Check out the example applications:
+
+- [Basic example](/apps/basic) demonstrates how to perform encryption operations
+- [Drizzle example](/apps/drizzle) demonstrates how to use Protect.js with an ORM
+- [Next.js and lock contexts example using Clerk](/apps/nextjs-clerk) demonstrates how to protect data with identity-aware encryption
+
+`@cipherstash/protect` can be used with most ORMs that support PostgreSQL.
+If you're interested in using `@cipherstash/protect` with a specific ORM, please [create an issue](https://github.com/cipherstash/protectjs/issues/new).
+
 ## Installation
 
 Install the [`@cipherstash/protect` package](https://www.npmjs.com/package/@cipherstash/protect) with your package manager of choice:
@@ -348,15 +360,6 @@ PROTECT_LOG_LEVEL=debug  # Enable debug logging
 PROTECT_LOG_LEVEL=info   # Enable info logging
 PROTECT_LOG_LEVEL=error  # Enable error logging
 ```
-
-## Examples
-
-- [Basic example](/apps/basic)
-- [Drizzle example](/apps/drizzle)
-- [Next.js and Lock Contexts example using Clerk](/apps/nextjs-clerk)
-
-`@cipherstash/protect` can be used with most ORMs that support PostgreSQL.
-If you're interested in using `@cipherstash/protect` with a specific ORM, please [create an issue](https://github.com/cipherstash/protectjs/issues/new).
 
 ## CipherStash Client
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Under the hood Protect.js uses CipherStash [Encrypt Query Language (EQL)](https:
 
 ## Features
 
-Protect.js is built on to protect data in a PostgreSQL database using industry standard encryption, and a key management service called [ZeroKMS](https://cipherstash.com/products/zerokms) that's built to work with data at scale.
+Protect.js protects data in PostgreSQL databases using industry standard AES encryption.
+Protect.js uses [ZeroKMS](https://cipherstash.com/products/zerokms) for bulk encryption and decryption operations.
+This enables every encrypted value, in every column, in every row in your database to have a unique key — without sacrificing performance.
 
 **Features:**
 - **Bulk encryption and decryption**: Protect.js uses [ZeroKMS](https://cipherstash.com/products/zerokms) for encrypting and decrypting thousands of records at once, while using a unique key for every value.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ The `encrypt` function returns an object with a `c` key, and the value is the en
 }
 ```
 
+> [!TIP]
+> You can get significantly better encryption performance by using the [`bulkEncrypt` function](#bulk-encrypting-data).
+
 ### Decrypting data
 
 Use the `decrypt` function to decrypt data.
@@ -143,6 +146,9 @@ The `decrypt` function returns a string containing the plaintext data.
 'secret@squirrel.example'
 ```
 
+> [!TIP]
+> You can get significantly better decryption performance by using the [`bulkDecrypt` function](#bulk-decrypting-data).
+
 ## Identity-aware encryption
 
 Protect.js can add an additional layer of protection to your data by requiring a valid JWT to perform a decryption.
@@ -153,11 +159,12 @@ Protect.js does this through a mechanism called a _lock context_.
 
 ### Lock context
 
-> [!CAUTION]
-> If you use a lock context to encrypt data, you must also use the same lock context to decrypt the data.
-> Otherwise, you will receive a `400` error from ZeroKMS indicating that the request was unable to generate a data key, and you will be unable to decrypt the data.
+Lock contexts ensure that only specific users can access sensitive data.
 
-`@cipherstash/protect` supports lock contexts to ensure that only the intended users can access sensitive data.
+> [!CAUTION]
+> You must use the same lock context to encrypt and decrypt data.
+> If you use different lock contexts, you will be unable to decrypt the data.
+
 To use a lock context, initialize a `LockContext` object with the identity claims.
 
 ```typescript
@@ -168,7 +175,7 @@ const lc = new LockContext()
 ```
 
 > [!NOTE]
-> When initializing a `LockContext` the default context is set to use the `sub` Identity Claim.
+> When initializing a `LockContext`, the default context is set to use the `sub` Identity Claim.
 
 **Custom context**
 

--- a/README.md
+++ b/README.md
@@ -54,20 +54,23 @@ pnpm add @cipherstash/protect
 > [!TIP]
 > [Bun](https://bun.sh/) is not currently supported due to a lack of [Node-API compatibility](https://github.com/oven-sh/bun/issues/158). Under the hood, Protect.js uses [CipherStash Client](#cipherstash-client) which is written in Rust and embedded using [Neon](https://github.com/neon-bindings/neon).
 
+
+Lastly, install the CipherStash CLI:
+
+- On macOS:
+
+  ```bash
+  brew install cipherstash/tap/stash
+  ```
+
+- On Linux, download the binary for your platform, and put it on your `PATH`:
+    - [Linux ARM64](https://github.com/cipherstash/cli-releases/releases/latest/download/stash-aarch64-unknown-linux-gnu)
+    - [Linux x86_64](https://github.com/cipherstash/cli-releases/releases/latest/download/stash-x86_64-unknown-linux-gnu)
+
+
 ## Usage
 
-### Define environment variables
-
-Create an account with [CipherStash](https://cipherstash.com) and get your `client id`, `client key`, `workspace id`, and `access key` from the [CipherStash dashboard](https://dashboard.cipherstash.com/).
-
-Create a `.env` file in the root directory of your project with the following contents:
-
-```
-CS_CLIENT_ID=your-client-id
-CS_CLIENT_KEY=your-client-key
-CS_WORKSPACE_ID=your-workspace-id
-CS_CLIENT_ACCESS_KEY=your-client-access-key
-```
+### Configuration
 
 > [!IMPORTANT]
 > These values are required to use the `@cipherstash/protect` package.

--- a/README.md
+++ b/README.md
@@ -9,21 +9,25 @@ Encryption operations happen directly in your app, and the ciphertext is stored 
 Every value you encrypt with Protect.js has a unique key, made possible by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms)'s blazing fast bulk key operations.
 Under the hood Protect.js uses CipherStash [Encrypt Query Language (EQL)](https://github.com/cipherstash/encrypt-query-language), and all ZeroKMS data keys are backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html).
 
-## Table of Contents
+## Table of contents
 
 - [Features](#features)
-- [Installation](#installation)
-- [Platform Support](#platform-support)
-- [Usage](#usage)
+- [Example applications](#example-applications)
+- [Installing Protect.js](#installing-protectjs)
+- [Getting started](#getting-started)
+- [Identity-aware encryption](#identity-aware-decryption)
+- [Bulk encryption and decryption](#bulk-encryption-and-decryption)
+- [Supported data types](#supported-data-types)
+- [Searchable encryption](#searchable-encryption)
 - [Logging](#logging)
-- [Examples](#examples)
 - [CipherStash Client](#cipherstash-client)
+- [Builds and bundling](#builds-and-bundling)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Features
 
-Protect.js protects data in PostgreSQL databases using industry standard AES encryption.
+Protect.js protects data in PostgreSQL databases using industry-standard AES encryption.
 Protect.js uses [ZeroKMS](https://cipherstash.com/products/zerokms) for bulk encryption and decryption operations.
 This enables every encrypted value, in every column, in every row in your database to have a unique key — without sacrificing performance.
 
@@ -51,7 +55,7 @@ Check out the example applications:
 `@cipherstash/protect` can be used with most ORMs that support PostgreSQL.
 If you're interested in using `@cipherstash/protect` with a specific ORM, please [create an issue](https://github.com/cipherstash/protectjs/issues/new).
 
-## Installation
+## Installing Protect.js
 
 Install the [`@cipherstash/protect` package](https://www.npmjs.com/package/@cipherstash/protect) with your package manager of choice:
 
@@ -104,7 +108,7 @@ At the end of `stash setup`, you will have two files in your project:
 > `cipherstash.secret.toml` should not be committed to git, because it contains sensitive credentials.
 
 
-### Initialize the EQL client
+### Initializing the EQL client
 
 In your application, import the `protect` function from the `@cipherstash/protect` package, and initialize a client with your CipherStash credentials.
 
@@ -141,7 +145,7 @@ The `encrypt` function returns an object with a `c` key, and the value is the en
 ```
 
 > [!TIP]
-> You can get significantly better encryption performance by using the [`bulkEncrypt` function](#bulk-encrypting-data).
+> Get significantly better encryption performance by using the [`bulkEncrypt` function](#bulk-encrypting-data).
 
 ### Decrypting data
 
@@ -159,7 +163,7 @@ The `decrypt` function returns a string containing the plaintext data.
 ```
 
 > [!TIP]
-> You can get significantly better decryption performance by using the [`bulkDecrypt` function](#bulk-decrypting-data).
+> Get significantly better decryption performance by using the [`bulkDecrypt` function](#bulk-decrypting-data).
 
 ### Storing encrypted data in a database
 
@@ -200,7 +204,7 @@ const lc = new LockContext()
 > [!NOTE]
 > When initializing a `LockContext`, the default context is set to use the `sub` Identity Claim.
 
-### Identify a user for a lock context
+### Identifying a user for a lock context
 
 A lock context needs to be locked to a user.
 To identify the user, call the `identify` method on the lock context object, and pass a valid JWT from a user's session:
@@ -335,7 +339,7 @@ Other data types like booleans, dates, ints, floats, and JSON are extremely well
 Until support for other data types are available in `@cipherstash/protect`, you can:
 
 - Read [about how these data types work in EQL](https://github.com/cipherstash/encrypt-query-language/blob/main/docs/reference/INDEX.md)
-- Vote for this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/protectjs/issues/48).
+- Express interest in this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/protectjs/issues/48).
 
 ## Searchable encryption
 
@@ -344,7 +348,7 @@ Searchable encryption is an extremely well supported capability in other CipherS
 Until searchable encryption support is released in `@cipherstash/protect`, you can:
 
 - Read [about how searchable encryption works in EQL](https://github.com/cipherstash/encrypt-query-language)
-- Vote for this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/protectjs/issues/46).
+- Express interest in this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/protectjs/issues/46).
 
 ## Logging
 
@@ -353,7 +357,7 @@ Until searchable encryption support is released in `@cipherstash/protect`, you c
 > This is by design to prevent sensitive data from leaking into logs.
 
 `@cipherstash/protect` and `@cipherstash/nextjs` will log to the console with a log level of `info` by default.
-You can enable the logger by configuring the following environment variable:
+To enable the logger, configure the following environment variable:
 
 ```bash
 PROTECT_LOG_LEVEL=debug  # Enable debug logging
@@ -368,7 +372,7 @@ The `@cipherstash/protect-ffi` source code is available on [GitHub](https://gith
 
 The Cipherstash Client is configured by environment variables, which are used to initialize the client when the `protect` function is called:
 
-|      Variable Name     |                           Description                           | Required |                    Default                   |
+|      Variable name     |                           Description                           | Required |                    Default                   |
 |:----------------------:|:---------------------------------------------------------------:|:--------:|:--------------------------------------------:|
 | `CS_CLIENT_ID`         | The client ID for your CipherStash account.                     | Yes      |                                              |
 | `CS_CLIENT_KEY`        | The client key for your CipherStash account.                    | Yes      |                                              |

--- a/docs/bulk-encryption-decryption.md
+++ b/docs/bulk-encryption-decryption.md
@@ -1,0 +1,146 @@
+## Bulk encryption and decryption
+
+If you have a large list of items to encrypt or decrypt, you can use the **`bulkEncrypt`** and **`bulkDecrypt`** methods to batch encryption/decryption.
+`bulkEncrypt` and `bulkDecrypt` give your app significantly better throughput than the single-item [`encrypt`](../README.md#encrypting-data) / [`decrypt`](../README.md#decrypting-data) methods.
+
+#### Bulk encrypting data
+
+```ts
+const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
+  column: 'email',
+  table: 'Users',
+})
+
+// or with lock context
+
+const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
+  column: 'email',
+  table: 'Users',
+}).withLockContext(lockContext)
+```
+
+**Parameters**
+
+1. **`plaintexts`**
+   - **Type**: `{ plaintext: string; id: string }[]`
+   - **Description**:
+     An array of objects containing the **plaintext** and an **id**.
+     - **plaintext**: The string you want encrypted.
+     - **id**: A unique identifier you can use to map the returned ciphertext back to its source. For example, if you have a `User` with `id: 1`, you might pass `id: '1'`.
+
+2. **`column`**
+   - **Type**: `string`
+   - **Description**:
+     The name of the column you’re encrypting (e.g., "email"). This is typically used in logging or contextual purposes when constructing the payload for the encryption engine.
+
+3. **`table`**
+   - **Type**: `string`
+   - **Description**:
+     The name of the table you’re encrypting data in (e.g., "Users").
+
+**Return Value**
+
+- **Type**: `Promise<Array<{ c: string; id: string }> | null>`
+- Returns an array of objects, where:
+  - **`c`** is the ciphertext.
+  - **`id`** is the same **id** you passed in, so you can correlate which ciphertext matches which original plaintext.
+- If `plaintexts` is an empty array, it returns `null`.
+
+### Example Usage
+
+```ts
+// 1) Gather your data. For example, a list of users with plaintext fields.
+const users = [
+  { id: '1', name: 'CJ', email: 'cj@example.com' },
+  { id: '2', name: 'Alex', email: 'alex@example.com' },
+]
+
+// 2) Prepare the array for bulk encryption (only encrypting the "email" field here).
+const plaintextsToEncrypt = users.map((user) => ({
+  plaintext: user.email, // The data to encrypt
+  id: user.id,           // Keep track by user ID
+}))
+
+// 3) Call bulkEncrypt
+const encryptedResults = await bulkEncrypt(plaintextsToEncrypt, {
+  column: 'email',
+  table: 'Users',
+})
+
+// encryptedResults might look like:
+// [
+//   { c: 'ENCRYPTED_VALUE_1', id: '1' },
+//   { c: 'ENCRYPTED_VALUE_2', id: '2' },
+// ]
+
+// 4) Reassemble data by matching IDs
+if (encryptedResults) {
+  encryptedResults.forEach((result) => {
+    // Find the corresponding user
+    const user = users.find((u) => u.id === result.id)
+    if (user) {
+      user.email = result.c  // Store ciphertext back into the user object
+    }
+  })
+}
+```
+
+#### Bulk decrypting data
+
+```ts
+const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads)
+
+// or with lock context
+
+const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads).withLockContext(lockContext)
+```
+
+**Parameters**
+
+1. **`encryptedPayloads`**
+   - **Type**: `Array<{ c: string; id: string }> | null`
+   - **Description**:
+     An array of objects containing the **ciphertext** (`c`) and the **id**. If this array is empty or `null`, the function returns `null`.
+
+### Return Value
+
+- **Type**: `Promise<Array<{ plaintext: string; id: string }> | null>`
+- Returns an array of objects, where:
+  - **`plaintext`** is the decrypted value.
+  - **`id`** is the same **id** you passed in, so you can correlate which plaintext matches which original ciphertext.
+- Returns `null` if the provided `encryptedPayloads` is empty or `null`.
+
+### Example Usage
+
+```ts
+// Suppose you've retrieved an array of users where their email fields are ciphertext:
+const users = [
+  { id: '1', name: 'CJ', email: 'ENCRYPTED_VALUE_1' },
+  { id: '2', name: 'Alex', email: 'ENCRYPTED_VALUE_2' },
+]
+
+// 1) Prepare the array for bulk decryption
+const encryptedPayloads = users.map((user) => ({
+  c: user.email,
+  id: user.id,
+}))
+
+// 2) Call bulkDecrypt
+const decryptedResults = await bulkDecrypt(encryptedPayloads)
+
+// decryptedResults might look like:
+// [
+//   { plaintext: 'cj@example.com', id: '1' },
+//   { plaintext: 'alex@example.com', id: '2' },
+// ]
+
+// 3) Reassemble data by matching IDs
+if (decryptedResults) {
+  decryptedResults.forEach((result) => {
+    const user = users.find((u) => u.id === result.id)
+    if (user) {
+      user.email = result.plaintext  // Put the decrypted value back in place
+    }
+  })
+}
+```

--- a/docs/bulk-encryption-decryption.md
+++ b/docs/bulk-encryption-decryption.md
@@ -102,7 +102,7 @@ const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads).with
    - **Description**:
      An array of objects containing the **ciphertext** (`c`) and the **id**. If this array is empty or `null`, the function returns `null`.
 
-### Return value
+**Return value**
 
 - **Type**: `Promise<Array<{ plaintext: string; id: string }> | null>`
 - Returns an array of objects, where:

--- a/docs/bulk-encryption-decryption.md
+++ b/docs/bulk-encryption-decryption.md
@@ -3,7 +3,7 @@
 If you have a large list of items to encrypt or decrypt, you can use the **`bulkEncrypt`** and **`bulkDecrypt`** methods to batch encryption/decryption.
 `bulkEncrypt` and `bulkDecrypt` give your app significantly better throughput than the single-item [`encrypt`](../README.md#encrypting-data) / [`decrypt`](../README.md#decrypting-data) methods.
 
-#### Bulk encrypting data
+### Bulk encrypting data
 
 ```ts
 const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
@@ -26,7 +26,7 @@ const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
    - **Description**:
      An array of objects containing the **plaintext** and an **id**.
      - **plaintext**: The string you want encrypted.
-     - **id**: A unique identifier you can use to map the returned ciphertext back to its source. For example, if you have a `User` with `id: 1`, you might pass `id: '1'`.
+     - **id**: A unique identifier to map the returned ciphertext back to its source. For example, if you have a `User` with `id: 1`, you might pass `id: '1'`.
 
 2. **`column`**
    - **Type**: `string`
@@ -38,7 +38,7 @@ const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
    - **Description**:
      The name of the table you’re encrypting data in (e.g., "Users").
 
-**Return Value**
+**Return value**
 
 - **Type**: `Promise<Array<{ c: string; id: string }> | null>`
 - Returns an array of objects, where:
@@ -46,7 +46,7 @@ const encryptedResults = await protectClient.bulkEncrypt(plaintextsToEncrypt, {
   - **`id`** is the same **id** you passed in, so you can correlate which ciphertext matches which original plaintext.
 - If `plaintexts` is an empty array, it returns `null`.
 
-### Example Usage
+#### Example usage
 
 ```ts
 // 1) Gather your data. For example, a list of users with plaintext fields.
@@ -85,7 +85,7 @@ if (encryptedResults) {
 }
 ```
 
-#### Bulk decrypting data
+### Bulk decrypting data
 
 ```ts
 const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads)
@@ -102,7 +102,7 @@ const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads).with
    - **Description**:
      An array of objects containing the **ciphertext** (`c`) and the **id**. If this array is empty or `null`, the function returns `null`.
 
-### Return Value
+### Return value
 
 - **Type**: `Promise<Array<{ plaintext: string; id: string }> | null>`
 - Returns an array of objects, where:
@@ -110,7 +110,7 @@ const decryptedResults = await protectClient.bulkDecrypt(encryptedPayloads).with
   - **`id`** is the same **id** you passed in, so you can correlate which plaintext matches which original ciphertext.
 - Returns `null` if the provided `encryptedPayloads` is empty or `null`.
 
-### Example Usage
+#### Example usage
 
 ```ts
 // Suppose you've retrieved an array of users where their email fields are ciphertext:

--- a/docs/lock-context.md
+++ b/docs/lock-context.md
@@ -1,7 +1,7 @@
 
-#### Lock context with Next.js and Clerk
+## Lock context with Next.js and Clerk
 
-If you're using [Clerk](https://clerk.com/) as your identity provider, you can use the `protectClerkMiddleware` function to automatically set the CTS token for every user session.
+If you're using [Clerk](https://clerk.com/) as your identity provider, use the `protectClerkMiddleware` function to automatically set the CTS token for every user session.
 
 Install the `@cipherstash/nextjs` package:
 
@@ -24,7 +24,7 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
 })
 ```
 
-##### Retrieving the CTS token in Next.js
+### Retrieving the CTS token in Next.js
 
 You can then use the `getCtsToken` function to retrieve the CTS token for the current user session.
 
@@ -52,7 +52,7 @@ export default async function Page() {
 }
 ```
 
-#### Contructing a LockContext with an existing CTS token
+### Contructing a LockContext with an existing CTS token
 
 Since the CTS token is already available, you can construct a `LockContext` object with the existing CTS token.
 
@@ -80,7 +80,7 @@ export default async function Page() {
 ```
 
 
-### Custom lock contexts
+#### Custom lock contexts
 
 If you want to override the default context, you can pass a custom context to the `LockContext` constructor.
 

--- a/docs/lock-context.md
+++ b/docs/lock-context.md
@@ -1,0 +1,108 @@
+
+#### Lock context with Next.js and Clerk
+
+If you're using [Clerk](https://clerk.com/) as your identity provider, you can use the `protectClerkMiddleware` function to automatically set the CTS token for every user session.
+
+Install the `@cipherstash/nextjs` package:
+
+```bash
+npm install @cipherstash/nextjs
+# or
+yarn add @cipherstash/nextjs
+# or
+pnpm add @cipherstash/nextjs
+```
+
+In your `middleware.ts` file, add the following code:
+
+```typescript
+import { clerkMiddleware } from '@clerk/nextjs/server'
+import { protectClerkMiddleware } from '@cipherstash/nextjs/clerk'
+
+export default clerkMiddleware(async (auth, req: NextRequest) => {
+  return protectClerkMiddleware(auth, req)
+})
+```
+
+##### Retrieving the CTS token in Next.js
+
+You can then use the `getCtsToken` function to retrieve the CTS token for the current user session.
+
+```typescript
+import { getCtsToken } from '@cipherstash/nextjs'
+
+export default async function Page() {
+  const ctsToken = await getCtsToken()
+
+  // getCtsToken returns either
+  // ---
+  // { success: true, ctsToken: CtsToken }
+  // or
+  // { success: false, error: string }
+
+  if (!ctsToken.success) {
+    // handle error
+  }
+
+  return (
+    <div>
+      <h1>Server side rendered page</h1>
+    </div>
+  )
+}
+```
+
+#### Contructing a LockContext with an existing CTS token
+
+Since the CTS token is already available, you can construct a `LockContext` object with the existing CTS token.
+
+```typescript
+import { LockContext } from '@cipherstash/protect/identify'
+import { getCtsToken } from '@cipherstash/nextjs'
+
+export default async function Page() {
+  const ctsToken = await getCtsToken()
+
+  if (!ctsToken.success) {
+    // handle error
+  }
+
+  const lockContext = new LockContext({
+    ctsToken
+  })
+
+  return (
+    <div>
+      <h1>Server side rendered page</h1>
+    </div>
+  )
+}
+```
+
+
+### Custom lock contexts
+
+If you want to override the default context, you can pass a custom context to the `LockContext` constructor.
+
+```typescript
+import { LockContext } from '@cipherstash/protect/identify'
+
+// protectClient from the previous steps
+const lc = new LockContext({
+  context: {
+    identityClaim: ['sub'], // this is the default context
+  },
+})
+```
+
+**Context and identity claim options**
+
+The context object contains an `identityClaim` property.
+The `identityClaim` property must be an array of strings that correspond to the Identity Claim(s) you want to lock the encryption operation to.
+
+Currently supported Identity Claims are:
+
+| Identity Claim | Description |
+| -------------- | ----------- |
+| `sub`          | The user's subject identifier. |
+| `scopes`       | The user's scopes set by your IDP policy. |

--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -1,0 +1,28 @@
+### Next.js
+
+Using `@cipherstash/protect` with Next.js? You need to opt-out from the Server Components bundling and use native Node.js `require` instead.
+
+#### Using version 15 or later
+
+`next.config.ts` [configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages):
+
+```js
+const nextConfig = {
+  ...
+  serverExternalPackages: ['@cipherstash/protect'],
+}
+```
+
+#### Using version 14
+
+`next.config.mjs` [configuration](https://nextjs.org/docs/14/app/api-reference/next-config-js/serverComponentsExternalPackages):
+
+```js
+const nextConfig = {
+  ...
+  experimental: {
+    serverComponentsExternalPackages: ['@cipherstash/protect'],
+  },
+}
+```
+

--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -1,8 +1,8 @@
-### Next.js
+## Next.js
 
-Using `@cipherstash/protect` with Next.js? You need to opt-out from the Server Components bundling and use native Node.js `require` instead.
+Using `@cipherstash/protect` with Next.js? You need to opt-out from the Server Components bundling and use native Node.js `require` instead. 
 
-#### Using version 15 or later
+### Using version 15 or later
 
 `next.config.ts` [configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages):
 
@@ -13,7 +13,7 @@ const nextConfig = {
 }
 ```
 
-#### Using version 14
+### Using version 14
 
 `next.config.mjs` [configuration](https://nextjs.org/docs/14/app/api-reference/next-config-js/serverComponentsExternalPackages):
 


### PR DESCRIPTION
Big picture changes: 

- Center code examples, to demonstrate functionality 
- Split docs on bigger features into separate files, to improve readability of the main README
- Copy edits, for clarity