### PR TITLE
docs: provide a next step for the user after finishing the basic demo

### DIFF
--- a/apps/basic/README.md
+++ b/apps/basic/README.md
@@ -69,3 +69,7 @@ pnpm start
 ```
 
 The application will log the plaintext to the console that has been encrypted using the CipherStash, decrypted, and logged the original plaintext.
+
+## Next steps
+
+Check out the [Protect.js + Next.js + Clerk example app](../nextjs-clerk) to see how to add end-user identity as an extra control when encrypting data.

--- a/apps/basic/README.md
+++ b/apps/basic/README.md
@@ -21,7 +21,7 @@ cd protectjs
 pnpm build
 
 # Install deps for basic example
-cd protectjs/apps/basic
+cd apps/basic
 pnpm install
 ```
 


### PR DESCRIPTION
- fix: change incorrect path
- docs: add a next step for the user to do once they've finished the [basic example](https://github.com/cipherstash/protectjs/tree/fab30407ae89b38e9b9937a0b9154353025840c1/apps/basic)