### PR TITLE
Chore: bump protect-ffi to v0.13.0

### DIFF
--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -56,7 +56,7 @@
 	},
 	"dependencies": {
 		"@byteslice/result": "^0.2.0",
-		"@cipherstash/protect-ffi": "0.12.0",
+		"@cipherstash/protect-ffi": "0.13.0-0",
 		"zod": "^3.24.2"
 	},
 	"optionalDependencies": {

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -37,7 +37,7 @@
 		"dev": "tsup --watch",
 		"eql:update": "tsx ./generateEqlSchema.ts",
 		"eql:generate": "json2ts ./eql.schema.json --output ./src/eql.schema.ts",
-		"test": "vitest run",
+		"test": "tsc --noEmit && vitest run",
 		"release": "tsup"
 	},
 	"devDependencies": {

--- a/packages/protect/src/ffi/index.ts
+++ b/packages/protect/src/ffi/index.ts
@@ -4,6 +4,7 @@ import {
   encrypt as ffiEncrypt,
   encryptBulk as ffiEncryptBulk,
   newClient,
+  type EncryptPayload as FFIEncryptPayload,
 } from '@cipherstash/protect-ffi'
 import { withResult, type Result } from '@byteslice/result'
 import { type ProtectError, ProtectErrorTypes } from '..'
@@ -119,12 +120,11 @@ class EncryptOperation
           return null
         }
 
-        const val = await ffiEncrypt(
-          this.client,
-          this.plaintext,
-          this.column.getName(),
-          this.table.tableName,
-        )
+        const val = await ffiEncrypt(this.client, {
+          plaintext: this.plaintext,
+          column: this.column.getName(),
+          table: this.table.tableName,
+        })
 
         return JSON.parse(val)
       },
@@ -200,10 +200,12 @@ class EncryptOperationWithLockContext
 
         const val = await ffiEncrypt(
           client,
-          plaintext,
-          column.getName(),
-          table.tableName,
-          context.data.context,
+          {
+            plaintext: plaintext,
+            column: column.getName(),
+            table: table.tableName,
+            lockContext: context.data.context,
+          },
           context.data.ctsToken,
         )
 

--- a/packages/protect/src/ffi/payload-helpers.ts
+++ b/packages/protect/src/ffi/payload-helpers.ts
@@ -2,7 +2,7 @@ import type { Result } from '@byteslice/result'
 import type { ProtectError } from '..'
 import type {
   BulkDecryptPayload as InternalBulkDecryptPayload,
-  BulkEncryptPayload as InternalBulkEncryptPayload,
+  EncryptPayload as InternalBulkEncryptPayload,
 } from '@cipherstash/protect-ffi'
 
 import type { LockContext } from '../identify'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@cipherstash/protect-ffi':
-        specifier: 0.12.0
-        version: 0.12.0
+        specifier: 0.13.0-0
+        version: 0.13.0-0
       typescript:
         specifier: ^5.0.0
         version: 5.7.2
@@ -378,33 +378,33 @@ packages:
   '@changesets/write@0.3.2':
     resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
 
-  '@cipherstash/protect-ffi-darwin-arm64@0.12.0':
-    resolution: {integrity: sha512-Oh7A9Mbn17QDHLLbugbT5bo/hZRrtgzcJZBTvXNTQpW9FtNmscCz1Wn79CJX+IhpdVrVxIQk7GOnG7JhTxJ/JA==}
+  '@cipherstash/protect-ffi-darwin-arm64@0.13.0-0':
+    resolution: {integrity: sha512-ZvBy/h995AtZsIf6F56oYzut48O5xEuha3xnzetBsEzR5Esh1tFjwmOawFdu+4EpRNXrePQAVnvsw9kR+wsRNA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@cipherstash/protect-ffi-darwin-x64@0.12.0':
-    resolution: {integrity: sha512-1UkwOm5lUukIFPXYaI1KvlBy+WafMGX0qw5lYBq1ybFMOhQgAdCloRxON60yM1aEM6MCWgqw6J6eQbisLms/Ow==}
+  '@cipherstash/protect-ffi-darwin-x64@0.13.0-0':
+    resolution: {integrity: sha512-pmtwGUekzHm/i+diVNyS+NG2+Kjxw3Rvz46LAbwvNk9OM4Qf91Uqigwl4vE48oHN78MCtD7c5ZcdpwjIRqJ0rQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@cipherstash/protect-ffi-linux-arm64-gnu@0.12.0':
-    resolution: {integrity: sha512-zIOQoAgWXqPXE+wXQwiTu0+GNkLvXhN9US49nKezL2P+X97PuzZd0XaL+e5AXuDdrt5wC1WjUDvKvP1cQpNYPg==}
+  '@cipherstash/protect-ffi-linux-arm64-gnu@0.13.0-0':
+    resolution: {integrity: sha512-MeK2ZnTTVboMl45dLHBuY/QaEvINt4rurglbgQLvuO4zXFrPDftinFguIIxFxOOFy/SQ5M8WIU/p60/DMfwK4w==}
     cpu: [arm64]
     os: [linux]
 
-  '@cipherstash/protect-ffi-linux-x64-gnu@0.12.0':
-    resolution: {integrity: sha512-wSJPi+pNR9+7DgcLZz/6V1VZAyejeEByIh+URfuRDaqbv8oxhh957WPfZTrWZXP5paIhXEdzkH62g6rnAxKaiQ==}
+  '@cipherstash/protect-ffi-linux-x64-gnu@0.13.0-0':
+    resolution: {integrity: sha512-1+GDWSdlXLJF6Gxg67cbwV/Q4a956MHR+azhPS0PLrMYRQJJLwKH5pEdyQFAF2u2384KyQ5JmRy7r8XiKHMnYA==}
     cpu: [x64]
     os: [linux]
 
-  '@cipherstash/protect-ffi-win32-x64-msvc@0.12.0':
-    resolution: {integrity: sha512-45icvAH+3QUaZVzCkpz4Xb8+EZ4jcQs0pd9Cvk6CMX4srkzdzGcN61NaEJmcWmYaq4XQqGSHYQi9afznpfvJow==}
+  '@cipherstash/protect-ffi-win32-x64-msvc@0.13.0-0':
+    resolution: {integrity: sha512-eLsnjoichdcmv4YqObbmgFj858UmZXOPqmDTCQmg11xlHqTUMtENFFfoTLE1KeALd47ISLjA64UDfLaT7T7K4g==}
     cpu: [x64]
     os: [win32]
 
-  '@cipherstash/protect-ffi@0.12.0':
-    resolution: {integrity: sha512-h1EdM+erAWBCy37jq4XExTQY4Pheg+wqLRyBGDRkS9vgxOQTt2g4TquqYVaS+aFZsYE1pMw76aSJNdca9sP2jg==}
+  '@cipherstash/protect-ffi@0.13.0-0':
+    resolution: {integrity: sha512-givD3suCpTFUtLkKgc3Enukk9kSJ1FTTgjbRoMjrI7MGk85WDr/K6ExEykBZk3p6QNv4+y/oyHwwVoZ9JowTfA==}
 
   '@clerk/backend@1.21.5':
     resolution: {integrity: sha512-fZ+HuHQkPngYp9vAEqsJ1XJkhWjSWTin90UixeV3jNrbuPY2jd70LKYTAIEvggnnG42pYxdVupaQDUfqj0dy4Q==}
@@ -4015,30 +4015,30 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@cipherstash/protect-ffi-darwin-arm64@0.12.0':
+  '@cipherstash/protect-ffi-darwin-arm64@0.13.0-0':
     optional: true
 
-  '@cipherstash/protect-ffi-darwin-x64@0.12.0':
+  '@cipherstash/protect-ffi-darwin-x64@0.13.0-0':
     optional: true
 
-  '@cipherstash/protect-ffi-linux-arm64-gnu@0.12.0':
+  '@cipherstash/protect-ffi-linux-arm64-gnu@0.13.0-0':
     optional: true
 
-  '@cipherstash/protect-ffi-linux-x64-gnu@0.12.0':
+  '@cipherstash/protect-ffi-linux-x64-gnu@0.13.0-0':
     optional: true
 
-  '@cipherstash/protect-ffi-win32-x64-msvc@0.12.0':
+  '@cipherstash/protect-ffi-win32-x64-msvc@0.13.0-0':
     optional: true
 
-  '@cipherstash/protect-ffi@0.12.0':
+  '@cipherstash/protect-ffi@0.13.0-0':
     dependencies:
       '@neon-rs/load': 0.1.82
     optionalDependencies:
-      '@cipherstash/protect-ffi-darwin-arm64': 0.12.0
-      '@cipherstash/protect-ffi-darwin-x64': 0.12.0
-      '@cipherstash/protect-ffi-linux-arm64-gnu': 0.12.0
-      '@cipherstash/protect-ffi-linux-x64-gnu': 0.12.0
-      '@cipherstash/protect-ffi-win32-x64-msvc': 0.12.0
+      '@cipherstash/protect-ffi-darwin-arm64': 0.13.0-0
+      '@cipherstash/protect-ffi-darwin-x64': 0.13.0-0
+      '@cipherstash/protect-ffi-linux-arm64-gnu': 0.13.0-0
+      '@cipherstash/protect-ffi-linux-x64-gnu': 0.13.0-0
+      '@cipherstash/protect-ffi-win32-x64-msvc': 0.13.0-0
 
   '@clerk/backend@1.21.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:


### PR DESCRIPTION
WIP. Currently just demonstrates that the new types in v0.13.0-0 (from https://github.com/cipherstash/protectjs-ffi/pull/19) work as expected.