### PR TITLE
fix(protect): handle undefined and null values in model interfaces

### DIFF
--- a/.changeset/thirty-otters-cough.md
+++ b/.changeset/thirty-otters-cough.md
@@ -2,4 +2,4 @@
 "@cipherstash/protect": minor
 ---
 
-Fixed a bug in the model interface to correclty handle undefined and null values.
+Fixed a bug in the model interface to correctly handle undefined and null values.

--- a/.changeset/thirty-otters-cough.md
+++ b/.changeset/thirty-otters-cough.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/protect": minor
+---
+
+Fixed a bug in the model interface to correclty handle undefined and null values.

--- a/packages/protect/__tests__/protect.test.ts
+++ b/packages/protect/__tests__/protect.test.ts
@@ -141,6 +141,48 @@ describe('encryption and decryption', () => {
       address: null,
     })
   }, 30000)
+
+  it('should handle undefined values in a model', async () => {
+    const protectClient = await protect(users)
+
+    // Create a model with undefined values
+    const decryptedModel = {
+      id: '1',
+      email: undefined,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      number: 1,
+      address: null,
+    }
+
+    // Encrypt the model
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Decrypt the model
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual({
+      id: '1',
+      email: undefined,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      number: 1,
+      address: null,
+    })
+  }, 30000)
 })
 
 describe('bulk encryption', () => {
@@ -244,6 +286,57 @@ describe('bulk encryption edge cases', () => {
         id: '1',
         email: 'test1',
         address: null,
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+        number: 1,
+      },
+      {
+        id: '2',
+        email: null,
+        address: '123 Main St',
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+        number: 2,
+      },
+      {
+        id: '3',
+        email: 'test3',
+        address: '456 Oak St',
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+        number: 3,
+      },
+    ]
+
+    // Encrypt the models
+    const encryptedModels = await protectClient.bulkEncryptModels<User>(
+      decryptedModels,
+      users,
+    )
+
+    if (encryptedModels.failure) {
+      throw new Error(`[protect]: ${encryptedModels.failure.message}`)
+    }
+
+    // Decrypt the models
+    const decryptedResult = await protectClient.bulkDecryptModels<User>(
+      encryptedModels.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModels)
+  }, 30000)
+
+  it('should handle mixed undefined and non-undefined values in bulk operations', async () => {
+    const protectClient = await protect(users)
+    const decryptedModels = [
+      {
+        id: '1',
+        email: 'test1',
+        address: undefined,
         createdAt: new Date('2021-01-01'),
         updatedAt: new Date('2021-01-01'),
         number: 1,

--- a/packages/protect/src/ffi/model-helpers.ts
+++ b/packages/protect/src/ffi/model-helpers.ts
@@ -128,11 +128,11 @@ function prepareFieldsForOperation<T extends Record<string, unknown>>(
   otherFields: Record<string, unknown>
   operationFields: Record<string, unknown>
   keyMap: Record<string, string>
-  nullFields: Record<string, null>
+  nullFields: Record<string, null | undefined>
 } {
   const otherFields = extractOtherFields(model)
   const operationFields: Record<string, unknown> = {}
-  const nullFields: Record<string, null> = {}
+  const nullFields: Record<string, null | undefined> = {}
   const keyMap: Record<string, string> = {}
   let index = 0
 
@@ -143,8 +143,8 @@ function prepareFieldsForOperation<T extends Record<string, unknown>>(
     : Object.entries(extractEncryptedFields(model))
 
   for (const [key, value] of fieldsToProcess) {
-    if (value === null) {
-      nullFields[key] = null
+    if (value === null || value === undefined) {
+      nullFields[key] = value === undefined ? undefined : null
       continue
     }
 
@@ -309,11 +309,11 @@ function prepareBulkModelsForOperation<T extends Record<string, unknown>>(
   otherFields: Record<string, unknown>[]
   operationFields: Record<string, unknown>[]
   keyMap: Record<string, { modelIndex: number; fieldKey: string }>
-  nullFields: Record<string, null>[]
+  nullFields: Record<string, null | undefined>[]
 } {
   const otherFields: Record<string, unknown>[] = []
   const operationFields: Record<string, unknown>[] = []
-  const nullFields: Record<string, null>[] = []
+  const nullFields: Record<string, null | undefined>[] = []
   const keyMap: Record<string, { modelIndex: number; fieldKey: string }> = {}
   let index = 0
 
@@ -321,7 +321,7 @@ function prepareBulkModelsForOperation<T extends Record<string, unknown>>(
     const model = models[modelIndex]
     const modelOtherFields = extractOtherFields(model)
     const modelOperationFields: Record<string, unknown> = {}
-    const modelNullFields: Record<string, null> = {}
+    const modelNullFields: Record<string, null | undefined> = {}
 
     const fieldsToProcess = table
       ? Object.entries(model).filter(([key]) =>
@@ -330,8 +330,8 @@ function prepareBulkModelsForOperation<T extends Record<string, unknown>>(
       : Object.entries(extractEncryptedFields(model))
 
     for (const [key, value] of fieldsToProcess) {
-      if (value === null) {
-        modelNullFields[key] = null
+      if (value === null || value === undefined) {
+        modelNullFields[key] = value === undefined ? undefined : null
         continue
       }
 


### PR DESCRIPTION
Fixes an issue where the model interfaces don't handle `undefined` correctly. Now the model interfaces will handle both `null` and `undefined` values correctly