### PR TITLE
feat(protect): add support for deeply nested protect schemas

### DIFF
--- a/.changeset/smart-worlds-wait.md
+++ b/.changeset/smart-worlds-wait.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/protect": minor
+---
+
+Added support for deeply nested protect schemas to support more complex model objects.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -8,6 +8,7 @@ Protect.js lets you define a schema in TypeScript with properties that map to yo
 - [Understanding schema files](#understanding-schema-files)
 - [Defining your schema](#defining-your-schema)
   - [Searchable encryption](#searchable-encryption)
+  - [Nested objects](#nested-objects)
 - [Available index options](#available-index-options)
 - [Initializing the Protect client](#initializing-the-protect-client)
 
@@ -74,6 +75,34 @@ export const protectedUsers = csTable("users", {
   email: csColumn("email").freeTextSearch().equality().orderAndRange(),
 });
 ```
+
+### Nested objects
+
+Protect.js supports nested objects in your schema, allowing you to encrypt and search on nested properties. You can define nested objects up to 3 levels deep.
+
+```ts
+import { csTable, csColumn } from "@cipherstash/protect";
+
+export const protectedUsers = csTable("users", {
+  email: csColumn("email").freeTextSearch().equality().orderAndRange(),
+  profile: {
+    name: csColumn("name").freeTextSearch(),
+    address: {
+      street: csColumn("street").freeTextSearch(),
+      location: {
+        coordinates: csColumn("coordinates").equality(),
+      },
+    },
+  },
+});
+```
+
+When working with nested objects:
+- Each level can have its own encrypted fields
+- Index options can be applied to any level of nesting
+- The maximum nesting depth is 3 levels
+- Null and undefined values are supported at any level
+- Optional nested objects are supported
 
 ## Available index options
 

--- a/packages/protect/__tests__/nested-models.test.ts
+++ b/packages/protect/__tests__/nested-models.test.ts
@@ -1,0 +1,242 @@
+import 'dotenv/config'
+import { describe, expect, it, vi } from 'vitest'
+
+import { LockContext, protect, csTable, csColumn } from '../src'
+
+const users = csTable('users', {
+  email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+  address: csColumn('address').freeTextSearch(),
+  example: {
+    field: csColumn('field').freeTextSearch(),
+    nested: {
+      deeper: csColumn('deeper').freeTextSearch(),
+    },
+  },
+})
+
+type User = {
+  id: string
+  email?: string | null
+  createdAt?: Date
+  updatedAt?: Date
+  address?: string | null
+  notEncrypted?: string | null
+  example: {
+    field: string | undefined | null
+    nested?: {
+      deeper: string | undefined | null
+    }
+  }
+}
+
+describe('encrypt models with nested fields', () => {
+  it('should encrypt and decrypt a model with nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      address: '123 Main St',
+      notEncrypted: 'not encrypted',
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      example: {
+        field: 'test',
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    console.log('data that is encrypted', encryptedModel.data.example.field)
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle null values in nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '2',
+      email: null,
+      address: null,
+      example: {
+        field: null,
+        nested: {
+          deeper: null,
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle undefined values in nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '3',
+      example: {
+        field: undefined,
+        nested: {
+          deeper: undefined,
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle mixed null and undefined values in nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '4',
+      email: 'test@example.com',
+      address: undefined,
+      notEncrypted: 'not encrypted',
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      example: {
+        field: null,
+        nested: {
+          deeper: undefined,
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    console.log('data that is encrypted', encryptedModel.data)
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    console.log('data that is decrypted', decryptedResult.data)
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle deeply nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '3',
+      example: {
+        field: 'outer',
+        nested: {
+          deeper: 'inner value',
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle missing optional nested fields', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '5',
+      example: {
+        field: 'present',
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+})

--- a/packages/protect/__tests__/schema.test.ts
+++ b/packages/protect/__tests__/schema.test.ts
@@ -1,0 +1,145 @@
+import { csColumn, csTable, buildEncryptConfig } from '../src/schema'
+import { describe, it, expect } from 'vitest'
+
+describe('Schema with nested columns', () => {
+  it('should handle nested column structures in encrypt config', () => {
+    const users = csTable('users', {
+      email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+      address: csColumn('address').freeTextSearch(),
+      example: {
+        field: csColumn('field').freeTextSearch(),
+        nested: {
+          deep: csColumn('deep').equality(),
+        },
+      },
+    } as const)
+
+    const config = buildEncryptConfig(users)
+
+    // Verify basic structure
+    expect(config).toEqual({
+      v: 2,
+      tables: {
+        users: expect.any(Object),
+      },
+    })
+
+    // Verify all columns are present with correct names
+    const columns = config.tables.users
+    expect(Object.keys(columns)).toEqual([
+      'email',
+      'address',
+      'example.field',
+      'example.nested.deep',
+    ])
+
+    // Verify email column configuration
+    expect(columns.email).toEqual({
+      cast_as: 'text',
+      indexes: {
+        match: expect.any(Object),
+        unique: expect.any(Object),
+        ore: {},
+      },
+    })
+
+    // Verify address column configuration
+    expect(columns.address).toEqual({
+      cast_as: 'text',
+      indexes: {
+        match: expect.any(Object),
+      },
+    })
+
+    // Verify nested field configuration
+    expect(columns['example.field']).toEqual({
+      cast_as: 'text',
+      indexes: {
+        match: expect.any(Object),
+      },
+    })
+
+    // Verify deeply nested field configuration
+    expect(columns['example.nested.deep']).toEqual({
+      cast_as: 'text',
+      indexes: {
+        unique: expect.any(Object),
+      },
+    })
+  })
+
+  it('should handle multiple tables with nested columns', () => {
+    const users = csTable('users', {
+      email: csColumn('email').equality(),
+      profile: {
+        name: csColumn('name').freeTextSearch(),
+      },
+    } as const)
+
+    const posts = csTable('posts', {
+      title: csColumn('title').freeTextSearch(),
+      metadata: {
+        tags: csColumn('tags').equality(),
+      },
+    } as const)
+
+    const config = buildEncryptConfig(users, posts)
+
+    // Verify both tables are present
+    expect(Object.keys(config.tables)).toEqual(['users', 'posts'])
+
+    // Verify users table columns
+    expect(Object.keys(config.tables.users)).toEqual(['email', 'profile.name'])
+    expect(config.tables.users.email.indexes).toHaveProperty('unique')
+    expect(config.tables.users['profile.name'].indexes).toHaveProperty('match')
+
+    // Verify posts table columns
+    expect(Object.keys(config.tables.posts)).toEqual(['title', 'metadata.tags'])
+    expect(config.tables.posts.title.indexes).toHaveProperty('match')
+    expect(config.tables.posts['metadata.tags'].indexes).toHaveProperty(
+      'unique',
+    )
+  })
+
+  it('should handle complex nested structures with multiple index types', () => {
+    const complex = csTable('complex', {
+      id: csColumn('id').equality(),
+      content: {
+        text: csColumn('text').freeTextSearch().orderAndRange(),
+        metadata: {
+          tags: csColumn('tags').equality().freeTextSearch(),
+          stats: {
+            views: csColumn('views').orderAndRange(),
+          },
+        },
+      },
+    } as const)
+
+    const config = buildEncryptConfig(complex)
+
+    // Verify all columns are present
+    expect(Object.keys(config.tables.complex)).toEqual([
+      'id',
+      'content.text',
+      'content.metadata.tags',
+      'content.metadata.stats.views',
+    ])
+
+    // Verify complex nested column with multiple indexes
+    expect(config.tables.complex['content.metadata.tags']).toEqual({
+      cast_as: 'text',
+      indexes: {
+        unique: expect.any(Object),
+        match: expect.any(Object),
+      },
+    })
+
+    // Verify deeply nested column with order and range
+    expect(config.tables.complex['content.metadata.stats.views']).toEqual({
+      cast_as: 'text',
+      indexes: {
+        ore: {},
+      },
+    })
+  })
+})


### PR DESCRIPTION
Added support for nested objects in Protect schemas, allowing you to encrypt and search on nested properties through the model interfaces. E.g.

```ts
import { csTable, csColumn } from "@cipherstash/protect";

export const protectedUsers = csTable("users", {
  email: csColumn("email").freeTextSearch().equality().orderAndRange(),
  profile: {
    name: csColumn("name").freeTextSearch(),
    address: {
      street: csColumn("street").freeTextSearch(),
      location: {
        coordinates: csColumn("coordinates").equality(),
      },
    },
  },
});
```

When working with nested objects:
- Each level can have its own encrypted fields
- Index options can be applied to any level of nesting
- The maximum nesting depth is 3 levels
- Null and undefined values are supported at any level
- Optional nested objects are supported