### PR TITLE
feat: ✨ add searchable JSON encryption and update FFI to v0.17.0

### DIFF
--- a/packages/protect/__tests__/basic-protect.test.ts
+++ b/packages/protect/__tests__/basic-protect.test.ts
@@ -1,0 +1,44 @@
+import 'dotenv/config'
+import { csColumn, csTable } from '@cipherstash/schema'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { protect } from '../src'
+
+const users = csTable('users', {
+  email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+  address: csColumn('address').freeTextSearch(),
+  json: csColumn('json').dataType('jsonb'),
+})
+
+let protectClient: Awaited<ReturnType<typeof protect>>
+
+beforeAll(async () => {
+  protectClient = await protect({
+    schemas: [users],
+  })
+})
+
+describe('encryption and decryption', () => {
+  it('should encrypt and decrypt a payload', async () => {
+    const email = 'hello@example.com'
+
+    const ciphertext = await protectClient.encrypt(email, {
+      column: users.email,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const a = ciphertext.data
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: email,
+    })
+  }, 30000)
+})

--- a/packages/protect/__tests__/bulk-protect.test.ts
+++ b/packages/protect/__tests__/bulk-protect.test.ts
@@ -326,53 +326,6 @@ describe('bulk encryption and decryption', () => {
 
       expect(decryptedData.data).toHaveLength(0)
     }, 30000)
-
-    it('should handle encrypted payloads with only "c" key', async () => {
-      // First encrypt some data
-      const plaintexts = [
-        { id: 'user1', plaintext: 'alice@example.com' },
-        { id: 'user2', plaintext: 'bob@example.com' },
-        { id: 'user3', plaintext: 'charlie@example.com' },
-      ]
-
-      const encryptedData = await protectClient.bulkEncrypt(plaintexts, {
-        column: users.email,
-        table: users,
-      })
-
-      if (encryptedData.failure) {
-        throw new Error(`[protect]: ${encryptedData.failure.message}`)
-      }
-
-      // Remove all keys except "c" from each encrypted payload
-      const modifiedEncryptedData = encryptedData.data.map((item) => ({
-        id: item.id,
-        data: {
-          c: item.data?.c,
-        } as EncryptedPayload,
-      }))
-
-      // Now decrypt the modified data
-      const decryptedData = await protectClient.bulkDecrypt(
-        modifiedEncryptedData,
-      )
-
-      if (decryptedData.failure) {
-        throw new Error(`[protect]: ${decryptedData.failure.message}`)
-      }
-
-      // Verify structure
-      expect(decryptedData.data).toHaveLength(3)
-      expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
-      expect(decryptedData.data[0]).toHaveProperty('data', 'alice@example.com')
-      expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
-      expect(decryptedData.data[1]).toHaveProperty('data', 'bob@example.com')
-      expect(decryptedData.data[2]).toHaveProperty('id', 'user3')
-      expect(decryptedData.data[2]).toHaveProperty(
-        'data',
-        'charlie@example.com',
-      )
-    }, 30000)
   })
 
   describe('bulk operations with lock context', () => {

--- a/packages/protect/__tests__/debug.test.ts
+++ b/packages/protect/__tests__/debug.test.ts
@@ -1,0 +1,39 @@
+import 'dotenv/config'
+import { csColumn, csTable, csValue } from '@cipherstash/schema'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { protect } from '../src'
+
+const users = csTable('users', {
+  email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+  json: csColumn('json').dataType('jsonb'),
+  jsonSearchable: csColumn('jsonSearchable')
+    .dataType('jsonb')
+    .searchableJson('users/jsonSearchable'),
+})
+
+type User = {
+  id: string
+  email?: string | null
+  createdAt?: Date
+  updatedAt?: Date
+  address?: string | null
+  json?: Record<string, unknown> | null
+  metadata?: {
+    profile?: Record<string, unknown> | null
+    settings?: {
+      preferences?: Record<string, unknown> | null
+    }
+  }
+}
+
+let protectClient: Awaited<ReturnType<typeof protect>>
+
+const test = false
+
+beforeAll(async () => {
+  protectClient = await protect({
+    schemas: [users],
+  })
+})
+
+describe('debugging', () => {})

--- a/packages/protect/__tests__/int-protect.test.ts
+++ b/packages/protect/__tests__/int-protect.test.ts
@@ -1,0 +1,1050 @@
+import 'dotenv/config'
+import { csColumn, csTable, csValue } from '@cipherstash/schema'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { LockContext, protect } from '../src'
+
+const users = csTable('users', {
+  email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+  address: csColumn('address').freeTextSearch(),
+  age: csColumn('age').dataType('int').equality().orderAndRange(),
+  score: csColumn('score').dataType('int').equality().orderAndRange(),
+  metadata: {
+    count: csValue('metadata.count').dataType('int'),
+    level: csValue('metadata.level').dataType('int'),
+  },
+})
+
+type User = {
+  id: string
+  email?: string | null
+  createdAt?: Date
+  updatedAt?: Date
+  address?: string | null
+  age?: number | null
+  score?: number | null
+  metadata?: {
+    count?: number | null
+    level?: number | null
+  }
+}
+
+let protectClient: Awaited<ReturnType<typeof protect>>
+
+beforeAll(async () => {
+  protectClient = await protect({
+    schemas: [users],
+  })
+})
+
+describe('Integer encryption and decryption', () => {
+  it('should encrypt and decrypt a simple integer', async () => {
+    const age = 25
+
+    const ciphertext = await protectClient.encrypt(age, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: age,
+    })
+  }, 30000)
+
+  it('should encrypt and decrypt zero', async () => {
+    const score = 0
+
+    const ciphertext = await protectClient.encrypt(score, {
+      column: users.score,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: score,
+    })
+  }, 30000)
+
+  it('should encrypt and decrypt negative integers', async () => {
+    const temperature = -42
+
+    const ciphertext = await protectClient.encrypt(temperature, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: temperature,
+    })
+  }, 30000)
+
+  it('should encrypt and decrypt large integers', async () => {
+    const largeNumber = 2147483647 // Max 32-bit signed integer
+
+    const ciphertext = await protectClient.encrypt(largeNumber, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: largeNumber,
+    })
+  }, 30000)
+
+  it('should encrypt and decrypt very large integers', async () => {
+    const veryLargeNumber = 9007199254740991 // Max safe integer in JavaScript
+
+    const ciphertext = await protectClient.encrypt(veryLargeNumber, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: veryLargeNumber,
+    })
+  }, 30000)
+
+  it('should handle null integer', async () => {
+    const ciphertext = await protectClient.encrypt(null, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify null is preserved
+    expect(ciphertext.data).toBeNull()
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: null,
+    })
+  }, 30000)
+})
+
+describe('Integer model encryption and decryption', () => {
+  it('should encrypt and decrypt a model with integer fields', async () => {
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      address: '123 Main St',
+      age: 30,
+      score: 95,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.address).toHaveProperty('c')
+    expect(encryptedModel.data.age).toHaveProperty('c')
+    expect(encryptedModel.data.score).toHaveProperty('c')
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModel.data.id).toBe('1')
+    expect(encryptedModel.data.createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModel.data.updatedAt).toEqual(new Date('2021-01-01'))
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle null integers in model', async () => {
+    const decryptedModel = {
+      id: '2',
+      email: 'test2@example.com',
+      address: '456 Oak St',
+      age: null,
+      score: null,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.address).toHaveProperty('c')
+    expect(encryptedModel.data.age).toBeNull()
+    expect(encryptedModel.data.score).toBeNull()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle undefined integers in model', async () => {
+    const decryptedModel = {
+      id: '3',
+      email: 'test3@example.com',
+      address: '789 Pine St',
+      age: undefined,
+      score: undefined,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.address).toHaveProperty('c')
+    expect(encryptedModel.data.age).toBeUndefined()
+    expect(encryptedModel.data.score).toBeUndefined()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+})
+
+describe('Integer bulk encryption and decryption', () => {
+  it('should bulk encrypt and decrypt integer payloads', async () => {
+    const intPayloads = [
+      { id: 'user1', plaintext: 25 },
+      { id: 'user2', plaintext: 30 },
+      { id: 'user3', plaintext: 35 },
+    ]
+
+    const encryptedData = await protectClient.bulkEncrypt(intPayloads, {
+      column: users.age,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(3)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('c')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toHaveProperty('c')
+    expect(encryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(encryptedData.data[2]).toHaveProperty('data')
+    expect(encryptedData.data[2].data).toHaveProperty('c')
+
+    // Verify all encrypted values are different
+    expect(encryptedData.data[0].data?.c).not.toBe(
+      encryptedData.data[1].data?.c,
+    )
+    expect(encryptedData.data[1].data?.c).not.toBe(
+      encryptedData.data[2].data?.c,
+    )
+    expect(encryptedData.data[0].data?.c).not.toBe(
+      encryptedData.data[2].data?.c,
+    )
+
+    // Now decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(3)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', 25)
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', 30)
+    expect(decryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(decryptedData.data[2]).toHaveProperty('data', 35)
+  }, 30000)
+
+  it('should handle mixed null and non-null integers in bulk operations', async () => {
+    const intPayloads = [
+      { id: 'user1', plaintext: 25 },
+      { id: 'user2', plaintext: null },
+      { id: 'user3', plaintext: 35 },
+    ]
+
+    const encryptedData = await protectClient.bulkEncrypt(intPayloads, {
+      column: users.age,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(3)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('c')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toBeNull()
+    expect(encryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(encryptedData.data[2]).toHaveProperty('data')
+    expect(encryptedData.data[2].data).toHaveProperty('c')
+
+    // Now decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(3)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', 25)
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', null)
+    expect(decryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(decryptedData.data[2]).toHaveProperty('data', 35)
+  }, 30000)
+
+  it('should bulk encrypt and decrypt models with integer fields', async () => {
+    const decryptedModels = [
+      {
+        id: '1',
+        email: 'test1@example.com',
+        address: '123 Main St',
+        age: 25,
+        score: 85,
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+      },
+      {
+        id: '2',
+        email: 'test2@example.com',
+        address: '456 Oak St',
+        age: 30,
+        score: 90,
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+      },
+    ]
+
+    const encryptedModels = await protectClient.bulkEncryptModels<User>(
+      decryptedModels,
+      users,
+    )
+
+    if (encryptedModels.failure) {
+      throw new Error(`[protect]: ${encryptedModels.failure.message}`)
+    }
+
+    // Verify encrypted fields for each model
+    expect(encryptedModels.data[0].email).toHaveProperty('c')
+    expect(encryptedModels.data[0].address).toHaveProperty('c')
+    expect(encryptedModels.data[0].age).toHaveProperty('c')
+    expect(encryptedModels.data[0].score).toHaveProperty('c')
+    expect(encryptedModels.data[1].email).toHaveProperty('c')
+    expect(encryptedModels.data[1].address).toHaveProperty('c')
+    expect(encryptedModels.data[1].age).toHaveProperty('c')
+    expect(encryptedModels.data[1].score).toHaveProperty('c')
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModels.data[0].id).toBe('1')
+    expect(encryptedModels.data[0].createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[0].updatedAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[1].id).toBe('2')
+    expect(encryptedModels.data[1].createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[1].updatedAt).toEqual(new Date('2021-01-01'))
+
+    const decryptedResult = await protectClient.bulkDecryptModels<User>(
+      encryptedModels.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModels)
+  }, 30000)
+})
+
+describe('Integer encryption with lock context', () => {
+  it('should encrypt and decrypt integer with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const age = 42
+
+    const ciphertext = await protectClient
+      .encrypt(age, {
+        column: users.age,
+        table: users,
+      })
+      .withLockContext(lockContext.data)
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient
+      .decrypt(ciphertext.data)
+      .withLockContext(lockContext.data)
+
+    if (plaintext.failure) {
+      throw new Error(`[protect]: ${plaintext.failure.message}`)
+    }
+
+    expect(plaintext.data).toEqual(age)
+  }, 30000)
+
+  it('should encrypt integer model with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      age: 30,
+      score: 95,
+    }
+
+    const encryptedModel = await protectClient
+      .encryptModel(decryptedModel, users)
+      .withLockContext(lockContext.data)
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.age).toHaveProperty('c')
+    expect(encryptedModel.data.score).toHaveProperty('c')
+
+    const decryptedResult = await protectClient
+      .decryptModel(encryptedModel.data)
+      .withLockContext(lockContext.data)
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should bulk encrypt integers with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const intPayloads = [
+      { id: 'user1', plaintext: 25 },
+      { id: 'user2', plaintext: 30 },
+    ]
+
+    const encryptedData = await protectClient
+      .bulkEncrypt(intPayloads, {
+        column: users.age,
+        table: users,
+      })
+      .withLockContext(lockContext.data)
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(2)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('c')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toHaveProperty('c')
+
+    // Decrypt with lock context
+    const decryptedData = await protectClient
+      .bulkDecrypt(encryptedData.data)
+      .withLockContext(lockContext.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(2)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', 25)
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', 30)
+  }, 30000)
+})
+
+describe('Integer nested object encryption', () => {
+  it('should encrypt and decrypt nested integer objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      metadata: {
+        count: 100,
+        level: 5,
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.metadata?.count).toHaveProperty('c')
+    expect(encryptedModel.data.metadata?.level).toHaveProperty('c')
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModel.data.id).toBe('1')
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle null values in nested integer objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '2',
+      email: 'test2@example.com',
+      metadata: {
+        count: null,
+        level: null,
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify null fields are preserved
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.metadata?.count).toBeNull()
+    expect(encryptedModel.data.metadata?.level).toBeNull()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle undefined values in nested integer objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '3',
+      email: 'test3@example.com',
+      metadata: {
+        count: undefined,
+        level: undefined,
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify undefined fields are preserved
+    expect(encryptedModel.data.email).toHaveProperty('c')
+    expect(encryptedModel.data.metadata?.count).toBeUndefined()
+    expect(encryptedModel.data.metadata?.level).toBeUndefined()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+})
+
+describe('Integer search terms', () => {
+  it('should create search terms for integer fields', async () => {
+    const searchTerms = [
+      {
+        value: '25',
+        column: users.age,
+        table: users,
+      },
+      {
+        value: '100',
+        column: users.score,
+        table: users,
+      },
+    ]
+
+    const searchTermsResult = await protectClient.createSearchTerms(searchTerms)
+
+    if (searchTermsResult.failure) {
+      throw new Error(`[protect]: ${searchTermsResult.failure.message}`)
+    }
+
+    expect(searchTermsResult.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          c: expect.any(String),
+        }),
+      ]),
+    )
+  }, 30000)
+
+  it('should create search terms with composite-literal return type for integers', async () => {
+    const searchTerms = [
+      {
+        value: '42',
+        column: users.age,
+        table: users,
+        returnType: 'composite-literal' as const,
+      },
+    ]
+
+    const searchTermsResult = await protectClient.createSearchTerms(searchTerms)
+
+    if (searchTermsResult.failure) {
+      throw new Error(`[protect]: ${searchTermsResult.failure.message}`)
+    }
+
+    const result = searchTermsResult.data[0] as string
+    expect(result).toMatch(/^\(.*\)$/)
+    expect(() => JSON.parse(result.slice(1, -1))).not.toThrow()
+  }, 30000)
+
+  it('should create search terms with escaped-composite-literal return type for integers', async () => {
+    const searchTerms = [
+      {
+        value: '99',
+        column: users.score,
+        table: users,
+        returnType: 'escaped-composite-literal' as const,
+      },
+    ]
+
+    const searchTermsResult = await protectClient.createSearchTerms(searchTerms)
+
+    if (searchTermsResult.failure) {
+      throw new Error(`[protect]: ${searchTermsResult.failure.message}`)
+    }
+
+    const result = searchTermsResult.data[0] as string
+    expect(result).toMatch(/^".*"$/)
+    const unescaped = JSON.parse(result)
+    expect(unescaped).toMatch(/^\(.*\)$/)
+    expect(() => JSON.parse(unescaped.slice(1, -1))).not.toThrow()
+  }, 30000)
+})
+
+describe('Integer performance tests', () => {
+  it('should handle large numbers of integers efficiently', async () => {
+    const largeIntArray = Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      data: {
+        age: i + 18, // Ages 18-117
+        score: (i % 100) + 1, // Scores 1-100
+      },
+    }))
+
+    const intPayloads = largeIntArray.map((item, index) => ({
+      id: `user${index}`,
+      plaintext: item.data.age,
+    }))
+
+    const encryptedData = await protectClient.bulkEncrypt(intPayloads, {
+      column: users.age,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(100)
+
+    // Decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify all data is preserved
+    expect(decryptedData.data).toHaveLength(100)
+
+    for (let i = 0; i < 100; i++) {
+      expect(decryptedData.data[i].id).toBe(`user${i}`)
+      expect(decryptedData.data[i].data).toEqual(largeIntArray[i].data.age)
+    }
+  }, 60000)
+})
+
+describe('Integer advanced scenarios', () => {
+  it('should handle boundary values', async () => {
+    const boundaryValues = [
+      Number.MIN_SAFE_INTEGER,
+      -2147483648, // Min 32-bit signed integer
+      -1,
+      0,
+      1,
+      2147483647, // Max 32-bit signed integer
+      Number.MAX_SAFE_INTEGER,
+    ]
+
+    for (const value of boundaryValues) {
+      const ciphertext = await protectClient.encrypt(value, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      expect(plaintext).toEqual({
+        data: value,
+      })
+    }
+  }, 30000)
+
+  it('should handle consecutive integers', async () => {
+    const consecutiveInts = Array.from({ length: 10 }, (_, i) => i + 1)
+
+    for (const value of consecutiveInts) {
+      const ciphertext = await protectClient.encrypt(value, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      expect(plaintext).toEqual({
+        data: value,
+      })
+    }
+  }, 30000)
+
+  it('should handle random integers', async () => {
+    const randomInts = Array.from(
+      { length: 20 },
+      () => Math.floor(Math.random() * 10000) - 5000,
+    )
+
+    for (const value of randomInts) {
+      const ciphertext = await protectClient.encrypt(value, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      expect(plaintext).toEqual({
+        data: value,
+      })
+    }
+  }, 30000)
+
+  it('should handle mixed positive and negative integers', async () => {
+    const mixedInts = [-100, -50, -1, 0, 1, 50, 100]
+
+    for (const value of mixedInts) {
+      const ciphertext = await protectClient.encrypt(value, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      expect(plaintext).toEqual({
+        data: value,
+      })
+    }
+  }, 30000)
+})
+
+describe('Integer error handling and edge cases', () => {
+  it('should handle floating point numbers (should be truncated)', async () => {
+    const floatValue = 42.7
+
+    const ciphertext = await protectClient.encrypt(floatValue, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    // Floating point numbers are preserved as-is (not truncated)
+    expect(plaintext).toEqual({
+      data: floatValue,
+    })
+  }, 30000)
+
+  it('should handle very large numbers (should be handled appropriately)', async () => {
+    const veryLargeNumber = 1e15
+
+    const ciphertext = await protectClient.encrypt(veryLargeNumber, {
+      column: users.age,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('c')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: veryLargeNumber,
+    })
+  }, 30000)
+
+  it('should handle string numbers (should be converted)', async () => {
+    // Note: This test might fail if the library doesn't handle string conversion
+    // Remove this test if string conversion is not supported
+    const stringNumber = '42'
+
+    try {
+      const ciphertext = await protectClient.encrypt(stringNumber, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      // String should be converted to number
+      expect(plaintext).toEqual({
+        data: Number(stringNumber),
+      })
+    } catch (error) {
+      // If string conversion is not supported, that's also acceptable
+      expect(error).toBeDefined()
+    }
+  }, 30000)
+
+  it('should handle all integer edge cases', async () => {
+    const edgeCases = [
+      Number.MIN_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER,
+      0,
+      1,
+      -1,
+      Number.MAX_VALUE,
+      Number.MIN_VALUE,
+    ]
+
+    for (const value of edgeCases) {
+      const ciphertext = await protectClient.encrypt(value, {
+        column: users.age,
+        table: users,
+      })
+
+      if (ciphertext.failure) {
+        throw new Error(`[protect]: ${ciphertext.failure.message}`)
+      }
+
+      // Verify encrypted field
+      expect(ciphertext.data).toHaveProperty('c')
+
+      const plaintext = await protectClient.decrypt(ciphertext.data)
+
+      expect(plaintext).toEqual({
+        data: value,
+      })
+    }
+  }, 30000)
+})

--- a/packages/protect/__tests__/json-protect.test.ts
+++ b/packages/protect/__tests__/json-protect.test.ts
@@ -1,0 +1,1217 @@
+import 'dotenv/config'
+import { csColumn, csTable, csValue } from '@cipherstash/schema'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { LockContext, protect } from '../src'
+
+const users = csTable('users', {
+  email: csColumn('email').freeTextSearch().equality().orderAndRange(),
+  address: csColumn('address').freeTextSearch(),
+  json: csColumn('json').dataType('jsonb').searchableJson('users/json'),
+  metadata: {
+    profile: csValue('metadata.profile'),
+    settings: {
+      preferences: csValue('metadata.settings.preferences'),
+    },
+  },
+})
+
+type User = {
+  id: string
+  email?: string | null
+  createdAt?: Date
+  updatedAt?: Date
+  address?: string | null
+  json?: Record<string, unknown> | null
+  metadata?: {
+    profile?: Record<string, unknown> | null
+    settings?: {
+      preferences?: Record<string, unknown> | null
+    }
+  }
+}
+
+let protectClient: Awaited<ReturnType<typeof protect>>
+
+beforeAll(async () => {
+  protectClient = await protect({
+    schemas: [users],
+  })
+})
+
+describe('JSON encryption and decryption', () => {
+  it('should encrypt and decrypt a simple JSON payload', async () => {
+    const json = {
+      name: 'John Doe',
+      age: 30,
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should encrypt and decrypt a complex JSON payload', async () => {
+    const json = {
+      user: {
+        id: 123,
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        preferences: {
+          theme: 'dark',
+          notifications: true,
+          language: 'en-US',
+        },
+        tags: ['premium', 'verified'],
+        metadata: {
+          created: '2023-01-01T00:00:00Z',
+          lastLogin: '2023-12-01T10:30:00Z',
+        },
+      },
+      settings: {
+        privacy: {
+          public: false,
+          shareData: true,
+        },
+        features: {
+          beta: true,
+          experimental: false,
+        },
+      },
+      array: [1, 2, 3, { nested: 'value' }],
+      nullValue: null,
+      booleanValue: true,
+      numberValue: 42.5,
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle null JSON payload', async () => {
+    const ciphertext = await protectClient.encrypt(null, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify null is preserved
+    expect(ciphertext.data).toBeNull()
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: null,
+    })
+  }, 30000)
+
+  it('should handle empty JSON object', async () => {
+    const json = {}
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with special characters', async () => {
+    const json = {
+      message: 'Hello "world" with \'quotes\' and \\backslashes\\',
+      unicode: '🚀 emoji and ñ special chars',
+      symbols: '!@#$%^&*()_+-=[]{}|;:,.<>?/~`',
+      multiline: 'Line 1\nLine 2\tTabbed',
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+})
+
+describe('JSON model encryption and decryption', () => {
+  it('should encrypt and decrypt a model with JSON field', async () => {
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      address: '123 Main St',
+      json: {
+        name: 'John Doe',
+        age: 30,
+        preferences: {
+          theme: 'dark',
+          notifications: true,
+        },
+      },
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.address).toHaveProperty('k')
+    expect(encryptedModel.data.json).toHaveProperty('k')
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModel.data.id).toBe('1')
+    expect(encryptedModel.data.createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModel.data.updatedAt).toEqual(new Date('2021-01-01'))
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle null JSON in model', async () => {
+    const decryptedModel = {
+      id: '2',
+      email: 'test2@example.com',
+      address: '456 Oak St',
+      json: null,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.address).toHaveProperty('k')
+    expect(encryptedModel.data.json).toBeNull()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle undefined JSON in model', async () => {
+    const decryptedModel = {
+      id: '3',
+      email: 'test3@example.com',
+      address: '789 Pine St',
+      json: undefined,
+      createdAt: new Date('2021-01-01'),
+      updatedAt: new Date('2021-01-01'),
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.address).toHaveProperty('k')
+    expect(encryptedModel.data.json).toBeUndefined()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+})
+
+describe('JSON bulk encryption and decryption', () => {
+  it('should bulk encrypt and decrypt JSON payloads', async () => {
+    const jsonPayloads = [
+      { id: 'user1', plaintext: { name: 'Alice', age: 25 } },
+      { id: 'user2', plaintext: { name: 'Bob', age: 30 } },
+      { id: 'user3', plaintext: { name: 'Charlie', age: 35 } },
+    ]
+
+    const encryptedData = await protectClient.bulkEncrypt(jsonPayloads, {
+      column: users.json,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(3)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('k')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toHaveProperty('k')
+    expect(encryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(encryptedData.data[2]).toHaveProperty('data')
+    expect(encryptedData.data[2].data).toHaveProperty('k')
+
+    // Now decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(3)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', {
+      name: 'Alice',
+      age: 25,
+    })
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', {
+      name: 'Bob',
+      age: 30,
+    })
+    expect(decryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(decryptedData.data[2]).toHaveProperty('data', {
+      name: 'Charlie',
+      age: 35,
+    })
+  }, 30000)
+
+  it('should handle mixed null and non-null JSON in bulk operations', async () => {
+    const jsonPayloads = [
+      { id: 'user1', plaintext: { name: 'Alice', age: 25 } },
+      { id: 'user2', plaintext: null },
+      { id: 'user3', plaintext: { name: 'Charlie', age: 35 } },
+    ]
+
+    const encryptedData = await protectClient.bulkEncrypt(jsonPayloads, {
+      column: users.json,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(3)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('k')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toBeNull()
+    expect(encryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(encryptedData.data[2]).toHaveProperty('data')
+    expect(encryptedData.data[2].data).toHaveProperty('k')
+
+    // Now decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(3)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', {
+      name: 'Alice',
+      age: 25,
+    })
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', null)
+    expect(decryptedData.data[2]).toHaveProperty('id', 'user3')
+    expect(decryptedData.data[2]).toHaveProperty('data', {
+      name: 'Charlie',
+      age: 35,
+    })
+  }, 30000)
+
+  it('should bulk encrypt and decrypt models with JSON fields', async () => {
+    const decryptedModels = [
+      {
+        id: '1',
+        email: 'test1@example.com',
+        address: '123 Main St',
+        json: {
+          name: 'Alice',
+          preferences: { theme: 'dark' },
+        },
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+      },
+      {
+        id: '2',
+        email: 'test2@example.com',
+        address: '456 Oak St',
+        json: {
+          name: 'Bob',
+          preferences: { theme: 'light' },
+        },
+        createdAt: new Date('2021-01-01'),
+        updatedAt: new Date('2021-01-01'),
+      },
+    ]
+
+    const encryptedModels = await protectClient.bulkEncryptModels<User>(
+      decryptedModels,
+      users,
+    )
+
+    if (encryptedModels.failure) {
+      throw new Error(`[protect]: ${encryptedModels.failure.message}`)
+    }
+
+    // Verify encrypted fields for each model
+    expect(encryptedModels.data[0].email).toHaveProperty('k')
+    expect(encryptedModels.data[0].address).toHaveProperty('k')
+    expect(encryptedModels.data[0].json).toHaveProperty('k')
+    expect(encryptedModels.data[1].email).toHaveProperty('k')
+    expect(encryptedModels.data[1].address).toHaveProperty('k')
+    expect(encryptedModels.data[1].json).toHaveProperty('k')
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModels.data[0].id).toBe('1')
+    expect(encryptedModels.data[0].createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[0].updatedAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[1].id).toBe('2')
+    expect(encryptedModels.data[1].createdAt).toEqual(new Date('2021-01-01'))
+    expect(encryptedModels.data[1].updatedAt).toEqual(new Date('2021-01-01'))
+
+    const decryptedResult = await protectClient.bulkDecryptModels<User>(
+      encryptedModels.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModels)
+  }, 30000)
+})
+
+describe('JSON encryption with lock context', () => {
+  it('should encrypt and decrypt JSON with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const json = {
+      name: 'John Doe',
+      age: 30,
+      preferences: {
+        theme: 'dark',
+        notifications: true,
+      },
+    }
+
+    const ciphertext = await protectClient
+      .encrypt(json, {
+        column: users.json,
+        table: users,
+      })
+      .withLockContext(lockContext.data)
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient
+      .decrypt(ciphertext.data)
+      .withLockContext(lockContext.data)
+
+    if (plaintext.failure) {
+      throw new Error(`[protect]: ${plaintext.failure.message}`)
+    }
+
+    expect(plaintext.data).toEqual(json)
+  }, 30000)
+
+  it('should encrypt JSON model with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      json: {
+        name: 'John Doe',
+        preferences: { theme: 'dark' },
+      },
+    }
+
+    const encryptedModel = await protectClient
+      .encryptModel(decryptedModel, users)
+      .withLockContext(lockContext.data)
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.json).toHaveProperty('k')
+
+    const decryptedResult = await protectClient
+      .decryptModel(encryptedModel.data)
+      .withLockContext(lockContext.data)
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should bulk encrypt JSON with lock context', async () => {
+    const userJwt = process.env.USER_JWT
+
+    if (!userJwt) {
+      console.log('Skipping lock context test - no USER_JWT provided')
+      return
+    }
+
+    const lc = new LockContext()
+    const lockContext = await lc.identify(userJwt)
+
+    if (lockContext.failure) {
+      throw new Error(`[protect]: ${lockContext.failure.message}`)
+    }
+
+    const jsonPayloads = [
+      { id: 'user1', plaintext: { name: 'Alice', age: 25 } },
+      { id: 'user2', plaintext: { name: 'Bob', age: 30 } },
+    ]
+
+    const encryptedData = await protectClient
+      .bulkEncrypt(jsonPayloads, {
+        column: users.json,
+        table: users,
+      })
+      .withLockContext(lockContext.data)
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(2)
+    expect(encryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(encryptedData.data[0]).toHaveProperty('data')
+    expect(encryptedData.data[0].data).toHaveProperty('k')
+    expect(encryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(encryptedData.data[1]).toHaveProperty('data')
+    expect(encryptedData.data[1].data).toHaveProperty('k')
+
+    // Decrypt with lock context
+    const decryptedData = await protectClient
+      .bulkDecrypt(encryptedData.data)
+      .withLockContext(lockContext.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify decrypted data
+    expect(decryptedData.data).toHaveLength(2)
+    expect(decryptedData.data[0]).toHaveProperty('id', 'user1')
+    expect(decryptedData.data[0]).toHaveProperty('data', {
+      name: 'Alice',
+      age: 25,
+    })
+    expect(decryptedData.data[1]).toHaveProperty('id', 'user2')
+    expect(decryptedData.data[1]).toHaveProperty('data', {
+      name: 'Bob',
+      age: 30,
+    })
+  }, 30000)
+})
+
+describe('JSON nested object encryption', () => {
+  it('should encrypt and decrypt nested JSON objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '1',
+      email: 'test@example.com',
+      metadata: {
+        profile: {
+          name: 'John Doe',
+          age: 30,
+          preferences: {
+            theme: 'dark',
+            notifications: true,
+          },
+        },
+        settings: {
+          preferences: {
+            language: 'en-US',
+            timezone: 'UTC',
+          },
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify encrypted fields
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.metadata?.profile).toHaveProperty('k')
+    expect(encryptedModel.data.metadata?.settings?.preferences).toHaveProperty(
+      'c',
+    )
+
+    // Verify non-encrypted fields remain unchanged
+    expect(encryptedModel.data.id).toBe('1')
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle null values in nested JSON objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '2',
+      email: 'test2@example.com',
+      metadata: {
+        profile: null,
+        settings: {
+          preferences: null,
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify null fields are preserved
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.metadata?.profile).toBeNull()
+    expect(encryptedModel.data.metadata?.settings?.preferences).toBeNull()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+
+  it('should handle undefined values in nested JSON objects', async () => {
+    const protectClient = await protect({ schemas: [users] })
+
+    const decryptedModel = {
+      id: '3',
+      email: 'test3@example.com',
+      metadata: {
+        profile: undefined,
+        settings: {
+          preferences: undefined,
+        },
+      },
+    }
+
+    const encryptedModel = await protectClient.encryptModel<User>(
+      decryptedModel,
+      users,
+    )
+
+    if (encryptedModel.failure) {
+      throw new Error(`[protect]: ${encryptedModel.failure.message}`)
+    }
+
+    // Verify undefined fields are preserved
+    expect(encryptedModel.data.email).toHaveProperty('k')
+    expect(encryptedModel.data.metadata?.profile).toBeUndefined()
+    expect(encryptedModel.data.metadata?.settings?.preferences).toBeUndefined()
+
+    const decryptedResult = await protectClient.decryptModel<User>(
+      encryptedModel.data,
+    )
+
+    if (decryptedResult.failure) {
+      throw new Error(`[protect]: ${decryptedResult.failure.message}`)
+    }
+
+    expect(decryptedResult.data).toEqual(decryptedModel)
+  }, 30000)
+})
+
+describe('JSON edge cases and error handling', () => {
+  it('should handle very large JSON objects', async () => {
+    const largeJson = {
+      data: Array.from({ length: 1000 }, (_, i) => ({
+        id: i,
+        name: `User ${i}`,
+        email: `user${i}@example.com`,
+        metadata: {
+          preferences: {
+            theme: i % 2 === 0 ? 'dark' : 'light',
+            notifications: i % 3 === 0,
+          },
+        },
+      })),
+      metadata: {
+        total: 1000,
+        created: new Date().toISOString(),
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(largeJson, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: largeJson,
+    })
+  }, 30000)
+
+  it('should handle JSON with circular references (should fail gracefully)', async () => {
+    const circularObj: Record<string, unknown> = { name: 'test' }
+    circularObj.self = circularObj
+
+    try {
+      await protectClient.encrypt(circularObj, {
+        column: users.json,
+        table: users,
+      })
+      // This should not reach here as JSON.stringify should fail
+      expect(true).toBe(false)
+    } catch (error) {
+      // Expected to fail due to circular reference
+      expect(error).toBeDefined()
+    }
+  }, 30000)
+
+  it('should handle JSON with special data types', async () => {
+    const json = {
+      string: 'hello',
+      number: 42,
+      boolean: true,
+      null: null,
+      array: [1, 2, 3],
+      object: { nested: 'value' },
+      date: new Date('2023-01-01T00:00:00Z'),
+      // Note: Functions and undefined are not JSON serializable
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    // Date objects get serialized to strings in JSON
+    const expectedJson = {
+      ...json,
+      date: '2023-01-01T00:00:00.000Z',
+    }
+
+    expect(plaintext).toEqual({
+      data: expectedJson,
+    })
+  }, 30000)
+})
+
+describe('JSON performance tests', () => {
+  it('should handle large numbers of JSON objects efficiently', async () => {
+    const largeJsonArray = Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      data: {
+        name: `User ${i}`,
+        preferences: {
+          theme: i % 2 === 0 ? 'dark' : 'light',
+          notifications: i % 3 === 0,
+        },
+        metadata: {
+          created: new Date().toISOString(),
+          version: i,
+        },
+      },
+    }))
+
+    const jsonPayloads = largeJsonArray.map((item, index) => ({
+      id: `user${index}`,
+      plaintext: item,
+    }))
+
+    const encryptedData = await protectClient.bulkEncrypt(jsonPayloads, {
+      column: users.json,
+      table: users,
+    })
+
+    if (encryptedData.failure) {
+      throw new Error(`[protect]: ${encryptedData.failure.message}`)
+    }
+
+    // Verify structure
+    expect(encryptedData.data).toHaveLength(100)
+
+    // Decrypt the data
+    const decryptedData = await protectClient.bulkDecrypt(encryptedData.data)
+
+    if (decryptedData.failure) {
+      throw new Error(`[protect]: ${decryptedData.failure.message}`)
+    }
+
+    // Verify all data is preserved
+    expect(decryptedData.data).toHaveLength(100)
+
+    for (let i = 0; i < 100; i++) {
+      expect(decryptedData.data[i].id).toBe(`user${i}`)
+      expect(decryptedData.data[i].data).toEqual(largeJsonArray[i])
+    }
+  }, 60000)
+})
+
+describe('JSON advanced scenarios', () => {
+  it('should handle JSON with deeply nested arrays', async () => {
+    const json = {
+      users: [
+        {
+          id: 1,
+          name: 'Alice',
+          roles: [
+            { name: 'admin', permissions: ['read', 'write', 'delete'] },
+            { name: 'user', permissions: ['read'] },
+          ],
+        },
+        {
+          id: 2,
+          name: 'Bob',
+          roles: [{ name: 'user', permissions: ['read'] }],
+        },
+      ],
+      metadata: {
+        total: 2,
+        lastUpdated: new Date().toISOString(),
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with mixed data types in arrays', async () => {
+    const json = {
+      mixedArray: ['string', 42, true, null, { nested: 'object' }, [1, 2, 3]],
+      metadata: {
+        types: ['string', 'number', 'boolean', 'null', 'object', 'array'],
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with Unicode and international characters', async () => {
+    const json = {
+      international: {
+        chinese: '你好世界',
+        japanese: 'こんにちは世界',
+        korean: '안녕하세요 세계',
+        arabic: 'مرحبا بالعالم',
+        russian: 'Привет мир',
+        emoji: '🚀 🌍 💻 🎉',
+      },
+      metadata: {
+        languages: ['Chinese', 'Japanese', 'Korean', 'Arabic', 'Russian'],
+        encoding: 'UTF-8',
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with scientific notation and large numbers', async () => {
+    const json = {
+      numbers: {
+        integer: 1234567890,
+        float: Math.PI,
+        scientific: 1.23e10,
+        negative: -9876543210,
+        zero: 0,
+        verySmall: 1.23e-10,
+      },
+      metadata: {
+        precision: 'high',
+        format: 'scientific',
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with boolean edge cases', async () => {
+    const json = {
+      booleans: {
+        true: true,
+        false: false,
+        stringTrue: 'true',
+        stringFalse: 'false',
+        numberOne: 1,
+        numberZero: 0,
+        emptyString: '',
+        nullValue: null,
+      },
+      metadata: {
+        type: 'boolean_edge_cases',
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+})
+
+describe('JSON error handling and edge cases', () => {
+  it('should handle malformed JSON gracefully', async () => {
+    // This test ensures the library handles JSON serialization errors
+    const invalidJson = {
+      valid: 'data',
+      // This will cause JSON.stringify to fail
+      circular: null as unknown,
+    }
+
+    // Create a circular reference
+    invalidJson.circular = invalidJson
+
+    try {
+      await protectClient.encrypt(invalidJson, {
+        column: users.json,
+        table: users,
+      })
+      expect(true).toBe(false) // Should not reach here
+    } catch (error) {
+      expect(error).toBeDefined()
+      expect(error).toBeInstanceOf(Error)
+    }
+  }, 30000)
+
+  it('should handle empty arrays and objects', async () => {
+    const json = {
+      emptyArray: [],
+      emptyObject: {},
+      nestedEmpty: {
+        array: [],
+        object: {},
+      },
+      mixedEmpty: {
+        data: 'present',
+        empty: [],
+        null: null,
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with very long strings', async () => {
+    const longString = 'A'.repeat(10000) // 10KB string
+    const json = {
+      longString,
+      metadata: {
+        length: longString.length,
+        type: 'long_string',
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+
+  it('should handle JSON with all primitive types', async () => {
+    const json = {
+      string: 'hello world',
+      number: 42,
+      float: 3.14,
+      boolean: true,
+      null: null,
+      array: [1, 2, 3],
+      object: { key: 'value' },
+      nested: {
+        level1: {
+          level2: {
+            level3: 'deep value',
+          },
+        },
+      },
+    }
+
+    const ciphertext = await protectClient.encrypt(json, {
+      column: users.json,
+      table: users,
+    })
+
+    if (ciphertext.failure) {
+      throw new Error(`[protect]: ${ciphertext.failure.message}`)
+    }
+
+    // Verify encrypted field
+    expect(ciphertext.data).toHaveProperty('k')
+
+    const plaintext = await protectClient.decrypt(ciphertext.data)
+
+    expect(plaintext).toEqual({
+      data: json,
+    })
+  }, 30000)
+})

--- a/packages/protect/__tests__/protect-ops.test.ts
+++ b/packages/protect/__tests__/protect-ops.test.ts
@@ -25,29 +25,7 @@ beforeAll(async () => {
   })
 })
 
-describe('encryption and decryption', () => {
-  it('should encrypt and decrypt a payload', async () => {
-    const email = 'hello@example.com'
-
-    const ciphertext = await protectClient.encrypt(email, {
-      column: users.email,
-      table: users,
-    })
-
-    if (ciphertext.failure) {
-      throw new Error(`[protect]: ${ciphertext.failure.message}`)
-    }
-
-    // Verify encrypted field
-    expect(ciphertext.data).toHaveProperty('c')
-
-    const plaintext = await protectClient.decrypt(ciphertext.data)
-
-    expect(plaintext).toEqual({
-      data: email,
-    })
-  }, 30000)
-
+describe('encryption and decryption edge cases', () => {
   it('should return null if plaintext is null', async () => {
     const ciphertext = await protectClient.encrypt(null, {
       column: users.email,

--- a/packages/protect/__tests__/supabase.test.ts
+++ b/packages/protect/__tests__/supabase.test.ts
@@ -2,7 +2,7 @@ import 'dotenv/config'
 import { csColumn, csTable } from '@cipherstash/schema'
 import { describe, expect, it } from 'vitest'
 import {
-  type EncryptedPayload,
+  type Encrypted,
   bulkModelsToEncryptedPgComposites,
   encryptedToPgComposite,
   isEncryptedPayload,
@@ -61,7 +61,7 @@ describe('supabase', () => {
       throw new Error(`[protect]: ${error.message}`)
     }
 
-    const dataToDecrypt = data[0].encrypted as EncryptedPayload
+    const dataToDecrypt = data[0].encrypted as Encrypted
     const plaintext = await protectClient.decrypt(dataToDecrypt)
 
     await supabase.from('protect-ci').delete().eq('id', insertedData[0].id)

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -55,7 +55,7 @@
 	},
 	"dependencies": {
 		"@byteslice/result": "^0.2.0",
-		"@cipherstash/protect-ffi": "0.16.0",
+		"@cipherstash/protect-ffi": "0.17.0",
 		"@cipherstash/schema": "workspace:*",
 		"zod": "^3.24.2"
 	},

--- a/packages/protect/src/ffi/index.ts
+++ b/packages/protect/src/ffi/index.ts
@@ -1,5 +1,5 @@
 import { type Result, withResult } from '@byteslice/result'
-import { newClient } from '@cipherstash/protect-ffi'
+import { type JsPlaintext, newClient } from '@cipherstash/protect-ffi'
 import {
   type EncryptConfig,
   type ProtectTable,
@@ -15,8 +15,7 @@ import type {
   Client,
   Decrypted,
   EncryptOptions,
-  EncryptPayload,
-  EncryptedPayload,
+  Encrypted,
   SearchTerm,
 } from '../types'
 import { BulkDecryptOperation } from './operations/bulk-decrypt'
@@ -92,7 +91,10 @@ export class ProtectClient {
    *    await eqlClient.encrypt(plaintext, { column, table })
    *    await eqlClient.encrypt(plaintext, { column, table }).withLockContext(lockContext)
    */
-  encrypt(plaintext: EncryptPayload, opts: EncryptOptions): EncryptOperation {
+  encrypt(
+    plaintext: JsPlaintext | null,
+    opts: EncryptOptions,
+  ): EncryptOperation {
     return new EncryptOperation(this.client, plaintext, opts)
   }
 
@@ -102,7 +104,7 @@ export class ProtectClient {
    *    await eqlClient.decrypt(encryptedData)
    *    await eqlClient.decrypt(encryptedData).withLockContext(lockContext)
    */
-  decrypt(encryptedData: EncryptedPayload): DecryptOperation {
+  decrypt(encryptedData: Encrypted): DecryptOperation {
     return new DecryptOperation(this.client, encryptedData)
   }
 

--- a/packages/protect/src/ffi/operations/bulk-decrypt.ts
+++ b/packages/protect/src/ffi/operations/bulk-decrypt.ts
@@ -1,5 +1,6 @@
 import { type Result, withResult } from '@byteslice/result'
 import {
+  type Encrypted as CipherStashEncrypted,
   type DecryptResult,
   decryptBulkFallible,
 } from '@cipherstash/protect-ffi'
@@ -20,9 +21,7 @@ const createDecryptPayloads = (
     .filter(({ data }) => data !== null)
     .map(({ id, data, originalIndex }) => ({
       id,
-      ciphertext: (typeof data === 'object' && data !== null
-        ? data.c
-        : data) as string,
+      ciphertext: data as CipherStashEncrypted,
       originalIndex,
       ...(lockContext && { lockContext }),
     }))

--- a/packages/protect/src/ffi/operations/bulk-encrypt.ts
+++ b/packages/protect/src/ffi/operations/bulk-encrypt.ts
@@ -1,5 +1,5 @@
 import { type Result, withResult } from '@byteslice/result'
-import { encryptBulk } from '@cipherstash/protect-ffi'
+import { type JsPlaintext, encryptBulk } from '@cipherstash/protect-ffi'
 import type {
   ProtectColumn,
   ProtectTable,
@@ -14,7 +14,7 @@ import type {
   BulkEncryptedData,
   Client,
   EncryptOptions,
-  EncryptedPayload,
+  Encrypted,
 } from '../../types'
 import { noClientError } from '../index'
 import { ProtectOperation } from './base-operation'
@@ -31,7 +31,7 @@ const createEncryptPayloads = (
     .filter(({ plaintext }) => plaintext !== null)
     .map(({ id, plaintext, originalIndex }) => ({
       id,
-      plaintext: plaintext as string,
+      plaintext: plaintext as JsPlaintext,
       column: column.getName(),
       table: table.tableName,
       originalIndex,
@@ -47,7 +47,7 @@ const createNullResult = (
 
 const mapEncryptedDataToResult = (
   plaintexts: BulkEncryptPayload,
-  encryptedData: EncryptedPayload[],
+  encryptedData: Encrypted[],
 ): BulkEncryptedData => {
   const result: BulkEncryptedData = new Array(plaintexts.length)
   let encryptedIndex = 0

--- a/packages/protect/src/ffi/operations/encrypt.ts
+++ b/packages/protect/src/ffi/operations/encrypt.ts
@@ -1,5 +1,8 @@
 import { type Result, withResult } from '@byteslice/result'
-import { encrypt as ffiEncrypt } from '@cipherstash/protect-ffi'
+import {
+  type JsPlaintext,
+  encrypt as ffiEncrypt,
+} from '@cipherstash/protect-ffi'
 import type {
   ProtectColumn,
   ProtectTable,
@@ -9,22 +12,21 @@ import type {
 import { type ProtectError, ProtectErrorTypes } from '../..'
 import { logger } from '../../../../utils/logger'
 import type { LockContext } from '../../identify'
-import type {
-  Client,
-  EncryptOptions,
-  EncryptPayload,
-  EncryptedPayload,
-} from '../../types'
+import type { Client, EncryptOptions, Encrypted } from '../../types'
 import { noClientError } from '../index'
 import { ProtectOperation } from './base-operation'
 
-export class EncryptOperation extends ProtectOperation<EncryptedPayload> {
+export class EncryptOperation extends ProtectOperation<Encrypted> {
   private client: Client
-  private plaintext: EncryptPayload
+  private plaintext: JsPlaintext | null
   private column: ProtectColumn | ProtectValue
   private table: ProtectTable<ProtectTableColumn>
 
-  constructor(client: Client, plaintext: EncryptPayload, opts: EncryptOptions) {
+  constructor(
+    client: Client,
+    plaintext: JsPlaintext | null,
+    opts: EncryptOptions,
+  ) {
     super()
     this.client = client
     this.plaintext = plaintext
@@ -38,7 +40,7 @@ export class EncryptOperation extends ProtectOperation<EncryptedPayload> {
     return new EncryptOperationWithLockContext(this, lockContext)
   }
 
-  public async execute(): Promise<Result<EncryptedPayload, ProtectError>> {
+  public async execute(): Promise<Result<Encrypted, ProtectError>> {
     logger.debug('Encrypting data WITHOUT a lock context', {
       column: this.column.getName(),
       table: this.table.tableName,
@@ -72,7 +74,7 @@ export class EncryptOperation extends ProtectOperation<EncryptedPayload> {
 
   public getOperation(): {
     client: Client
-    plaintext: EncryptPayload
+    plaintext: JsPlaintext | null
     column: ProtectColumn | ProtectValue
     table: ProtectTable<ProtectTableColumn>
   } {
@@ -85,7 +87,7 @@ export class EncryptOperation extends ProtectOperation<EncryptedPayload> {
   }
 }
 
-export class EncryptOperationWithLockContext extends ProtectOperation<EncryptedPayload> {
+export class EncryptOperationWithLockContext extends ProtectOperation<Encrypted> {
   private operation: EncryptOperation
   private lockContext: LockContext
 
@@ -95,7 +97,7 @@ export class EncryptOperationWithLockContext extends ProtectOperation<EncryptedP
     this.lockContext = lockContext
   }
 
-  public async execute(): Promise<Result<EncryptedPayload, ProtectError>> {
+  public async execute(): Promise<Result<Encrypted, ProtectError>> {
     return await withResult(
       async () => {
         const { client, plaintext, column, table } =

--- a/packages/protect/src/helpers/index.ts
+++ b/packages/protect/src/helpers/index.ts
@@ -1,16 +1,13 @@
-import type { Encrypted } from '@cipherstash/protect-ffi'
-import type { EncryptedPayload } from '../types'
+import type { Encrypted } from '../types'
 
 export type EncryptedPgComposite = {
-  data: EncryptedPayload
+  data: Encrypted
 }
 
 /**
  * Helper function to transform an encrypted payload into a PostgreSQL composite type
  */
-export function encryptedToPgComposite(
-  obj: EncryptedPayload,
-): EncryptedPgComposite {
+export function encryptedToPgComposite(obj: Encrypted): EncryptedPgComposite {
   return {
     data: obj,
   }
@@ -47,13 +44,15 @@ export function bulkModelsToEncryptedPgComposites<
 /**
  * Helper function to check if a value is an encrypted payload
  */
-export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
+export function isEncryptedPayload(value: unknown): value is Encrypted {
   if (value === null) return false
 
   // TODO: this can definitely be improved
   if (typeof value === 'object') {
     const obj = value as Encrypted
-    return 'v' in obj && 'c' in obj && 'i' in obj
+    return (
+      obj !== null && 'v' in obj && ('c' in obj || 'sv' in obj) && 'i' in obj
+    )
   }
 
   return false

--- a/packages/protect/src/types.ts
+++ b/packages/protect/src/types.ts
@@ -1,4 +1,8 @@
-import type { Encrypted, newClient } from '@cipherstash/protect-ffi'
+import type {
+  Encrypted as CipherStashEncrypted,
+  JsPlaintext,
+  newClient,
+} from '@cipherstash/protect-ffi'
 import type {
   ProtectColumn,
   ProtectTable,
@@ -12,13 +16,19 @@ import type {
 export type Client = Awaited<ReturnType<typeof newClient>> | undefined
 
 /**
+ * Type to represent an encrypted payload
+ */
+export type Encrypted = CipherStashEncrypted | null
+
+/**
  * Represents an encrypted payload in the database
+ * @deprecated Use `Encrypted` instead
  */
 export type EncryptedPayload = Encrypted | null
 
 /**
  * Represents an encrypted data object in the database
- * @deprecated Use `EncryptedPayload` instead
+ * @deprecated Use `Encrypted` instead
  */
 export type EncryptedData = Encrypted | null
 
@@ -26,7 +36,7 @@ export type EncryptedData = Encrypted | null
  * Represents a value that will be encrypted and used in a search
  */
 export type SearchTerm = {
-  value: string
+  value: JsPlaintext
   column: ProtectColumn
   table: ProtectTable<ProtectTableColumn>
   returnType?: 'eql' | 'composite-literal' | 'escaped-composite-literal'
@@ -34,17 +44,16 @@ export type SearchTerm = {
 
 /**
  * The return type of the search term based on the return type specified in the `SearchTerm` type
- * If the return type is `eql`, the return type is `EncryptedPayload`
+ * If the return type is `eql`, the return type is `Encrypted`
  * If the return type is `composite-literal`, the return type is `string` where the value is a composite literal
  * If the return type is `escaped-composite-literal`, the return type is `string` where the value is an escaped composite literal
  */
-export type EncryptedSearchTerm = EncryptedPayload | string
+export type EncryptedSearchTerm = Encrypted | string
 
 /**
  * Represents a payload to be encrypted using the `encrypt` function
- * We currently only support the encryption of strings
  */
-export type EncryptPayload = string | null
+export type EncryptPayload = JsPlaintext | null
 
 /**
  * Represents the options for encrypting a payload using the `encrypt` function
@@ -58,21 +67,21 @@ export type EncryptOptions = {
  * Type to identify encrypted fields in a model
  */
 export type EncryptedFields<T> = {
-  [K in keyof T as T[K] extends EncryptedPayload ? K : never]: T[K]
+  [K in keyof T as T[K] extends Encrypted ? K : never]: T[K]
 }
 
 /**
  * Type to identify non-encrypted fields in a model
  */
 export type OtherFields<T> = {
-  [K in keyof T as T[K] extends EncryptedPayload | null ? never : K]: T[K]
+  [K in keyof T as T[K] extends Encrypted ? never : K]: T[K]
 }
 
 /**
  * Type to represent decrypted fields in a model
  */
 export type DecryptedFields<T> = {
-  [K in keyof T as T[K] extends EncryptedPayload | null ? K : never]: string
+  [K in keyof T as T[K] extends Encrypted ? K : never]: string
 }
 
 /**
@@ -85,12 +94,12 @@ export type Decrypted<T> = OtherFields<T> & DecryptedFields<T>
  */
 export type BulkEncryptPayload = Array<{
   id?: string
-  plaintext: string | null
+  plaintext: JsPlaintext | null
 }>
 
-export type BulkEncryptedData = Array<{ id?: string; data: EncryptedPayload }>
-export type BulkDecryptPayload = Array<{ id?: string; data: EncryptedPayload }>
-export type BulkDecryptedData = Array<DecryptionResult<string | null>>
+export type BulkEncryptedData = Array<{ id?: string; data: Encrypted }>
+export type BulkDecryptPayload = Array<{ id?: string; data: Encrypted }>
+export type BulkDecryptedData = Array<DecryptionResult<JsPlaintext | null>>
 
 type DecryptionSuccess<T> = {
   error?: never

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,19 +3,7 @@ import { z } from 'zod'
 // ------------------------
 // Zod schemas
 // ------------------------
-const castAsEnum = z
-  .enum([
-    'big_int',
-    'boolean',
-    'date',
-    'real',
-    'double',
-    'int',
-    'small_int',
-    'text',
-    'jsonb',
-  ])
-  .default('text')
+const castAsEnum = z.enum(['text', 'int', 'jsonb']).default('text')
 
 const tokenFilterSchema = z.object({
   kind: z.literal('downcase'),
@@ -200,7 +188,7 @@ export class ProtectColumn {
   /**
    * Enable a STE Vec index, requires a prefix.
    */
-  josn(prefix: string) {
+  searchableJson(prefix: string) {
     this.indexesValue.ste_vec = { prefix }
     return this
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@cipherstash/protect-ffi':
-        specifier: 0.16.0
-        version: 0.16.0
+        specifier: 0.17.0
+        version: 0.17.0
       '@cipherstash/schema':
         specifier: workspace:*
         version: link:../schema
@@ -975,33 +975,33 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@cipherstash/protect-ffi-darwin-arm64@0.16.0':
-    resolution: {integrity: sha512-RXxhgGemIbFMPH9NcpIncI9uICwEwJxsYekIaZ/DEsT9wUTGmPVkAyscGlellHx5xUkDtrvxIQY086GlcNON8w==}
+  '@cipherstash/protect-ffi-darwin-arm64@0.17.0':
+    resolution: {integrity: sha512-/QsbCzpDs9orsBWf7RhPosyspsES7WjD2xr98NeJeN5IR/KbVmr+KuEchl18eqeVH1EzXNT5FZLZ+AUfEjO9rw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@cipherstash/protect-ffi-darwin-x64@0.16.0':
-    resolution: {integrity: sha512-H5LG2mzeQ6Fy3sPqBw1D/IZ5QVe+pZNYRR1u2wiSc6UR7fdlRZPzYNPWcTuHDJvI4vEY3DZjYCUaNNeeGtX0IA==}
+  '@cipherstash/protect-ffi-darwin-x64@0.17.0':
+    resolution: {integrity: sha512-EOq6ZNAPlWU0SJTCmfQQkLPX7UDUv7O/fuTzVGksPjM6vC1iYAGRXa37TdxGHXzZDmOl9En70KblPtHI0opT7g==}
     cpu: [x64]
     os: [darwin]
 
-  '@cipherstash/protect-ffi-linux-arm64-gnu@0.16.0':
-    resolution: {integrity: sha512-iHsdJKX6IAe8EoPMdH/zQycH8WXNC7IKoYVI6CdvelJjhScIMfKxeuQolDgEYSQe5ujLfCA6Ujk0bqyKPwiS7Q==}
+  '@cipherstash/protect-ffi-linux-arm64-gnu@0.17.0':
+    resolution: {integrity: sha512-jLA+tNKNE4sluH6Clnn2TUoOPcvyuSaAj6h4FluswQahiHdILPDaM5WbePnbwOIi0eumff3zo9HuAWRJqhB7Pw==}
     cpu: [arm64]
     os: [linux]
 
-  '@cipherstash/protect-ffi-linux-x64-gnu@0.16.0':
-    resolution: {integrity: sha512-desQSbnHAB8i8GfQ/kYMojX92McVsejnCf2uCfW9ilkJ+HVtFVfrYp1R2Y2zCtQtvdfuYel07UiFpogIWGp/2Q==}
+  '@cipherstash/protect-ffi-linux-x64-gnu@0.17.0':
+    resolution: {integrity: sha512-QjAyb7K2X/ccnIsKByTLG3iD5qQy4GQ23EWWJcTUkz6u1smE6C1lXjs9y43jlFcQc9WaGlIFn4SeC4q4fnuMDA==}
     cpu: [x64]
     os: [linux]
 
-  '@cipherstash/protect-ffi-win32-x64-msvc@0.16.0':
-    resolution: {integrity: sha512-9aZAepWdPUnBeNM8tWL7D0VCqrylwySZbw0qChVDzEfDMrxOnIjrTht54kI14FVKfRHWugm7FFbzjjfLwS4M5A==}
+  '@cipherstash/protect-ffi-win32-x64-msvc@0.17.0':
+    resolution: {integrity: sha512-bXU2Tv516qJEp47Yc7lizNdRCrXehubc87CdzU1Jl/bReWtmRK2Nu6lH9FsLtPSPdo8SClb81ZqtryxBW19n+w==}
     cpu: [x64]
     os: [win32]
 
-  '@cipherstash/protect-ffi@0.16.0':
-    resolution: {integrity: sha512-sG5yo0Q277oQGXHd4T4hA9Jdf19AI+0sLzEOvcjjvb/T9AZplsUZJd1ZU0oQUzSrJ4JGzOahyQ6CeMrYvdmdeg==}
+  '@cipherstash/protect-ffi@0.17.0':
+    resolution: {integrity: sha512-TJv/qhuSzid42XXgdmeExf8G/XLZ51VB0wHsg0hJoR9t6yNjWOuOY3NZ37X5+7rWJnnIjjVFsQIr3sQ+aam7sw==}
 
   '@clerk/backend@1.25.5':
     resolution: {integrity: sha512-nnBpr7oSq5iATWRExuljEfp7xa90KE1OUgaGCSmtZYF0T9TWHGkZHYqkQhD4XjiqlR2XsrsQ/UzPfmHM1Km7+Q==}
@@ -7813,30 +7813,30 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@cipherstash/protect-ffi-darwin-arm64@0.16.0':
+  '@cipherstash/protect-ffi-darwin-arm64@0.17.0':
     optional: true
 
-  '@cipherstash/protect-ffi-darwin-x64@0.16.0':
+  '@cipherstash/protect-ffi-darwin-x64@0.17.0':
     optional: true
 
-  '@cipherstash/protect-ffi-linux-arm64-gnu@0.16.0':
+  '@cipherstash/protect-ffi-linux-arm64-gnu@0.17.0':
     optional: true
 
-  '@cipherstash/protect-ffi-linux-x64-gnu@0.16.0':
+  '@cipherstash/protect-ffi-linux-x64-gnu@0.17.0':
     optional: true
 
-  '@cipherstash/protect-ffi-win32-x64-msvc@0.16.0':
+  '@cipherstash/protect-ffi-win32-x64-msvc@0.17.0':
     optional: true
 
-  '@cipherstash/protect-ffi@0.16.0':
+  '@cipherstash/protect-ffi@0.17.0':
     dependencies:
       '@neon-rs/load': 0.1.82
     optionalDependencies:
-      '@cipherstash/protect-ffi-darwin-arm64': 0.16.0
-      '@cipherstash/protect-ffi-darwin-x64': 0.16.0
-      '@cipherstash/protect-ffi-linux-arm64-gnu': 0.16.0
-      '@cipherstash/protect-ffi-linux-x64-gnu': 0.16.0
-      '@cipherstash/protect-ffi-win32-x64-msvc': 0.16.0
+      '@cipherstash/protect-ffi-darwin-arm64': 0.17.0
+      '@cipherstash/protect-ffi-darwin-x64': 0.17.0
+      '@cipherstash/protect-ffi-linux-arm64-gnu': 0.17.0
+      '@cipherstash/protect-ffi-linux-x64-gnu': 0.17.0
+      '@cipherstash/protect-ffi-win32-x64-msvc': 0.17.0
 
   '@clerk/backend@1.25.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:


### PR DESCRIPTION
- Add searchableJson() method to schema for JSON field indexing
- Update @cipherstash/protect-ffi from 0.16.0 to 0.17.0
- Refactor type system: EncryptedPayload → Encrypted, add JsPlaintext
- Add comprehensive test suites for JSON, integer, and basic encryption
- Update encryption format to use 'k' property for searchable JSON
- Remove deprecated search terms tests for JSON fields
- Simplify schema data types to text, int, jsonb only
- Update model helpers to handle new encryption format
- Fix type safety issues in bulk operations and model encryption