### PR TITLE
fix: evlog bundling

### DIFF
--- a/.changeset/bundle-evlog-cjs.md
+++ b/.changeset/bundle-evlog-cjs.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/stack": patch
+---
+
+Bundle `evlog` into the CJS output. `evlog` is pure ESM (no `require` condition in its `exports` map), so CJS consumers of `@cipherstash/stack` (e.g. webpack bundles) were failing with `ERR_PACKAGE_PATH_NOT_EXPORTED` when the stack's `index.cjs` tried to `require("evlog")`. `evlog` is now inlined at build time and no longer resolved at runtime.

--- a/packages/stack/tsup.config.ts
+++ b/packages/stack/tsup.config.ts
@@ -22,5 +22,6 @@ export default defineConfig([
     target: 'es2022',
     tsconfig: './tsconfig.json',
     external: ['drizzle-orm', '@supabase/supabase-js'],
+    noExternal: ['evlog'],
   },
 ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an export error that prevented CommonJS consumers from importing and using the package properly in their applications. Dependencies lacking native CommonJS export support are now bundled directly into the compiled package output at build time, completely eliminating runtime module resolution errors and ensuring seamless compatibility for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->