### PR TITLE
test(cli): add node-pty E2E suite for the stash CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,9 @@ jobs:
       # Run TurboRepo tests
       - name: Run tests
         run: pnpm run test
+
+      # CLI E2E tests drive the built `dist/bin/stash.js` through a real
+      # pseudo-terminal via node-pty. Run via turbo so the `^build` + `build`
+      # deps declared on the `test:e2e` task are honored.
+      - name: Run CLI E2E tests
+        run: pnpm exec turbo run test:e2e --filter @cipherstash/cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,10 @@ pnpm changeset:publish
 - Import `dotenv/config` at the top when tests need environment variables.
 - Prefer testing via the public API. Avoid reaching into private internals.
 - Some tests have larger timeouts (e.g., 30s) to accommodate network calls.
+- `packages/cli` has a second suite — pty-driven E2E tests under
+  `packages/cli/tests/e2e/**` run via `pnpm --filter @cipherstash/cli
+  test:e2e` (requires a build). See `packages/cli/AGENTS.md` for when to
+  add or update them.
 
 ## Bundling and Deployment Notes
 

--- a/docs/plans/cli-pty-integration-tests.md
+++ b/docs/plans/cli-pty-integration-tests.md
@@ -1,0 +1,208 @@
+# Plan: node-pty Integration Tests for `@cipherstash/cli`
+
+## Goal
+
+Add a small, sustainable integration test layer for the `stash` CLI that
+exercises the built binary through a real pseudo‑terminal, so we can catch
+regressions in `@clack/prompts` flows (rendering, key handling, cancellation,
+exit codes) that the existing unit tests can't see.
+
+Non‑goals for v1:
+- Full coverage of every command/flag combination.
+- Spinning up real Postgres / real auth servers.
+- Replacing existing unit tests.
+
+## Why node-pty (vs alternatives)
+
+- `mock-stdin` doesn't drive a real TTY; clack's raw‑mode select/multiselect
+  prompts behave differently or not at all.
+- `cli-testing-library` (crutchcorn) drives stdin without a pty — same
+  fidelity concern; revisit only if we hit `node-pty` build pain.
+- `expect(1)` adds a Tcl runtime and lives outside Vitest — the team has
+  found it clunky in past projects.
+
+`node-pty` (or the prebuilt fork `node-pty-prebuilt-multiarch`) gives us a
+real pty inside Vitest with no second toolchain. The cost is one native
+module on install.
+
+## Scope of v1
+
+Cover the cheap, high‑value surface first. Each test runs the **built**
+`packages/cli/dist/bin/stash.js` so we exercise the same artifact users
+get.
+
+| Test | Command | What it asserts |
+| --- | --- | --- |
+| help | `stash --help` | exit 0, output contains "CipherStash CLI v" and command list |
+| version | `stash --version` | exit 0, output matches `package.json#version` |
+| unknown top-level | `stash bogus` | exit 1, output contains "Unknown command" + help |
+| auth no-subcommand | `stash auth` | exit 0, output contains auth HELP |
+| auth unknown sub | `stash auth bogus` | exit 1, output contains "Unknown auth command" |
+| db unknown sub | `stash db bogus` | exit 1, output contains "Unknown db subcommand" |
+| db migrate stub | `stash db migrate` | exit 0, warns "not yet implemented" |
+| init cancel | `stash init` then ctrl‑c at first prompt | exit 0, output contains "Setup cancelled." |
+
+`init cancel` is the only test that drives a clack prompt; it's enough to
+validate the helper end‑to‑end without standing up auth or a database.
+Deeper flows (full `init`, `db install --dry-run` with fixtures) come in
+a follow‑up once the harness is proven.
+
+## Deliverables
+
+1. `node-pty-prebuilt-multiarch` added as a dev dependency on
+   `packages/cli`. Use the prebuilt fork rather than upstream `node-pty`
+   to skip the C++ toolchain requirement on dev machines and CI.
+2. `packages/cli/vitest.integration.config.ts` — separate config so
+   integration tests don't slow the default `vitest run`. Uses
+   `pool: 'forks'` and a 30s `testTimeout`; matches `**/*.e2e.test.ts`.
+3. `packages/cli/tests/helpers/pty.ts` — small wrapper around
+   `node-pty.spawn` exposing:
+   - `render(args, opts?)` → `{ output, waitFor, write, key, exitCode, kill }`
+   - `output` is the cumulative ANSI‑stripped buffer.
+   - `waitFor(text, timeoutMs?)` polls until text appears or rejects.
+   - `key('Enter' | 'Up' | 'Down' | 'CtrlC' | …)` writes the right escape.
+   - `exitCode` resolves when the pty exits.
+   Target: ~80 lines, no external deps beyond `strip-ansi`.
+4. `packages/cli/tests/e2e/smoke.e2e.test.ts` — covers the help / version /
+   unknown‑command / `auth` / `db migrate` rows from the table above.
+5. `packages/cli/tests/e2e/init-cancel.e2e.test.ts` — runs `stash init`,
+   waits for the first clack prompt, sends ``, asserts the
+   cancellation message and exit code 0.
+6. `packages/cli/package.json` script: `"test:e2e": "vitest run --config
+   vitest.integration.config.ts"`. Default `test` script unchanged.
+7. `turbo.json` task `test:e2e` with `dependsOn: ["^build", "build"]` so
+   the CLI is rebuilt before E2E runs. Keep `cache: false`.
+8. CI: extend the existing test workflow to also run `pnpm --filter
+   @cipherstash/cli test:e2e`. Confirm the prebuilt binary resolves on
+   the GH runners (Linux x64, macOS arm64). If it doesn't, fall back to
+   upstream `node-pty` and add `python3` / build tools to the workflow.
+
+## Test harness shape (sketch)
+
+```ts
+// tests/helpers/pty.ts
+import { spawn, type IPty } from 'node-pty-prebuilt-multiarch'
+import stripAnsi from 'strip-ansi'
+import { resolve } from 'node:path'
+
+const STASH_BIN = resolve(__dirname, '../../dist/bin/stash.js')
+
+export interface RenderOptions {
+  cwd?: string
+  env?: Record<string, string>
+  cols?: number
+  rows?: number
+}
+
+export function render(args: string[], opts: RenderOptions = {}) {
+  const pty = spawn('node', [STASH_BIN, ...args], {
+    cwd: opts.cwd ?? process.cwd(),
+    cols: opts.cols ?? 100,
+    rows: opts.rows ?? 30,
+    env: { ...process.env, NO_COLOR: '1', CI: '1', ...opts.env },
+  })
+
+  let raw = ''
+  pty.onData((d) => { raw += d })
+
+  const exitCode = new Promise<number>((res) => {
+    pty.onExit(({ exitCode }) => res(exitCode))
+  })
+
+  return {
+    pty,
+    get output() { return stripAnsi(raw) },
+    get raw() { return raw },
+    exitCode,
+    write: (s: string) => pty.write(s),
+    key: (k: 'Enter' | 'Up' | 'Down' | 'Space' | 'CtrlC' | 'Esc') =>
+      pty.write(KEYS[k]),
+    waitFor: (text: string | RegExp, timeoutMs = 5000) => /* poll */ undefined,
+    kill: () => pty.kill(),
+  }
+}
+
+const KEYS = {
+  Enter: '\r',
+  Up: '[A',
+  Down: '[B',
+  Space: ' ',
+  CtrlC: '',
+  Esc: '',
+} as const
+```
+
+## Rollout
+
+1. Land harness + smoke tests behind `test:e2e` (not part of default
+   `pnpm test`). One PR.
+2. Wire CI in a follow‑up PR after we've watched the suite locally on
+   both macOS and Linux for a few runs.
+3. Add deeper flows (full `init`, `db install --dry-run` against a
+   throw‑away Postgres) in subsequent PRs once the harness is stable.
+
+## Open questions
+
+- **Native binary on CI**: CI has build tools available, so upstream
+  `node-pty` is fine if `node-pty-prebuilt-multiarch` is missing
+  prebuilts for any of our targets. Decide at install time.
+
+## Resolved
+
+- **Telemetry — not a concern for the CLI.** A grep across
+  `packages/cli/src/` shows zero `posthog` imports; analytics moved to
+  `packages/wizard` when that package was extracted. The CLI's
+  `package.json` still lists `posthog-node` as a dep — stale, worth
+  removing in a follow-up but not blocking. For *future* wizard E2E
+  tests: `posthog-node` has no built-in disable env var, but
+  `wizard/src/lib/analytics.ts` already short-circuits when the API
+  key is empty, so passing an empty `POSTHOG_API_KEY` in test env is
+  enough.
+
+## Phase 2: message handles for assertion stability
+
+Once the harness is landed, introduce a lightweight messages module to
+decouple test assertions from prompt wording. Goal: when product tweaks
+copy, *no test changes are needed*.
+
+**Shape — not an i18n framework.** A single `src/messages.ts` (or
+per-command `messages.ts`) exporting a typed `as const` object:
+
+```ts
+export const messages = {
+  init: {
+    intro: 'CipherStash Stack Setup',
+    cancelled: 'Setup cancelled.',
+    complete: 'Setup complete!',
+  },
+  auth: {
+    unknownSubcommand: (sub: string) => `Unknown auth command: ${sub}`,
+  },
+  db: {
+    migrateNotImplemented:
+      '"npx @cipherstash/cli db migrate" is not yet implemented.',
+  },
+} as const
+```
+
+- Production code substitutes literals with `messages.x.y`.
+- Tests `import { messages }` and assert `output.includes(messages.x.y)`.
+- TypeScript catches every site on rename — including tests.
+- Zero deps, zero runtime cost.
+
+**Hybrid policy:** only extract strings that tests assert on. Inline
+strings that no test depends on stay inline — premature extraction is
+worse than copy-paste here.
+
+**Anti-pattern, do not adopt:** emitting hidden marker tokens (e.g.
+`[init.cancelled]`) in user-facing output and stripping them before
+display. Complicates the renderer, breaks terminal copy/paste, earns
+nothing the messages module doesn't already give us.
+
+**Sequencing:**
+1. Phase 1 PR: harness + smoke tests using literal-string assertions
+   against text that's been stable across many releases (help banner,
+   `"Unknown command"`, the `db migrate` warning, `"Setup cancelled."`).
+2. Phase 2 PR: introduce `messages.ts`, mechanically migrate prod call
+   sites and test assertions in the same change. Small, reviewable.
+3. Defer full i18n until there's an actual localisation requirement.

--- a/docs/plans/cli-pty-integration-tests.md
+++ b/docs/plans/cli-pty-integration-tests.md
@@ -40,12 +40,14 @@ get.
 | auth unknown sub | `stash auth bogus` | exit 1, output contains "Unknown auth command" |
 | db unknown sub | `stash db bogus` | exit 1, output contains "Unknown db subcommand" |
 | db migrate stub | `stash db migrate` | exit 0, warns "not yet implemented" |
-| init cancel | `stash init` then ctrl‑c at first prompt | exit 0, output contains "Setup cancelled." |
+| auth login cancel | `stash auth login` then ctrl‑c at the region prompt | exit 0, output contains "Cancelled." |
 
-`init cancel` is the only test that drives a clack prompt; it's enough to
-validate the helper end‑to‑end without standing up auth or a database.
-Deeper flows (full `init`, `db install --dry-run` with fixtures) come in
-a follow‑up once the harness is proven.
+The `auth login` cancel test is the only one that drives a clack prompt —
+enough to validate the helper end‑to‑end without standing up auth or a
+database. `selectRegion()` is a synchronous `p.select` that runs before any
+network I/O, so cancelling there is deterministic. Deeper flows (full
+`init`, `db install --dry-run` with fixtures) come in a follow‑up once the
+harness is proven.
 
 ## Deliverables
 
@@ -65,9 +67,9 @@ a follow‑up once the harness is proven.
    Target: ~80 lines, no external deps beyond `strip-ansi`.
 4. `packages/cli/tests/e2e/smoke.e2e.test.ts` — covers the help / version /
    unknown‑command / `auth` / `db migrate` rows from the table above.
-5. `packages/cli/tests/e2e/init-cancel.e2e.test.ts` — runs `stash init`,
-   waits for the first clack prompt, sends ``, asserts the
-   cancellation message and exit code 0.
+5. `packages/cli/tests/e2e/auth-login-cancel.e2e.test.ts` — runs
+   `stash auth login`, waits for the region prompt ("Select a region"),
+   sends ctrl-c, asserts the cancellation message and exit code 0.
 6. `packages/cli/package.json` script: `"test:e2e": "vitest run --config
    vitest.integration.config.ts"`. Default `test` script unchanged.
 7. `turbo.json` task `test:e2e` with `dependsOn: ["^build", "build"]` so

--- a/package.json
+++ b/package.json
@@ -72,7 +72,10 @@
         "drizzle-orm": "*"
       }
     },
-    "dedupe-peer-dependents": true
+    "dedupe-peer-dependents": true,
+    "onlyBuiltDependencies": [
+      "node-pty"
+    ]
   },
   "overrides": {
     "@babel/runtime": "7.26.10",

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,82 @@
+# `@cipherstash/cli` — agent notes
+
+## Two test suites
+
+This package has **two** Vitest configs. Run the right one for the change.
+
+| Command | Config | Scope | Needs build? |
+| --- | --- | --- | --- |
+| `pnpm --filter @cipherstash/cli test` | `vitest.config.ts` | Unit tests under `src/__tests__/**` and `src/**/__tests__/**` | No |
+| `pnpm --filter @cipherstash/cli test:e2e` | `vitest.integration.config.ts` | E2E tests under `tests/e2e/**.e2e.test.ts` driving the built `dist/bin/stash.js` through a real pty (`node-pty`) | **Yes** — run `pnpm --filter @cipherstash/cli build` first, or use the turbo `test:e2e` task which depends on `build`. |
+
+The unit config explicitly excludes `tests/e2e/**` so the default `pnpm test`
+stays fast and self-contained.
+
+## When to add or update an E2E test
+
+Update `tests/e2e/**` whenever you:
+
+- Add or rename a top-level command, subcommand, or flag (smoke tests assert
+  on help text, command names, and unknown-command behavior).
+- Change the user-facing string for an exit message that an existing E2E
+  asserts on (e.g. "Setup cancelled.", "Unknown auth command:",
+  "not yet implemented"). Either update the assertion or, preferably, route
+  the string through the future `messages.ts` module (see
+  `docs/plans/cli-pty-integration-tests.md`, phase 2).
+- Touch `src/bin/stash.ts` argv parsing, exit codes, or top-level error
+  handling.
+- Add a new clack prompt that changes the *first* prompt rendered for a
+  command currently covered by E2E (the cancel test waits for a specific
+  prompt label).
+
+You do **not** need to add an E2E test for every new flag or branch — keep
+E2E coverage to the highest-value flows. Unit tests still own the bulk of
+behaviour coverage.
+
+## How the harness works
+
+`tests/helpers/pty.ts` exports `render(args, opts?)` which spawns
+`dist/bin/stash.js` inside a real pseudo-terminal and returns:
+
+- `output` — cumulative ANSI-stripped stdout.
+- `raw` — same, with ANSI escapes preserved (handy when debugging).
+- `waitFor(text|regex, timeoutMs?)` — polls until the match appears.
+- `key(name)` — sends keystrokes (`Enter`, `Up`, `Down`, `CtrlC`, etc.).
+- `write(string)` — raw stdin write.
+- `exit` — promise resolving to `{ exitCode, signal? }`.
+- `kill(signal?)` — terminate the pty.
+
+A real pty is required because `@clack/prompts` switches stdin to raw mode
+and renders differently when stdout isn't a TTY; piped-stdin mocks don't
+exercise the same code paths.
+
+## Gotchas
+
+- **Build before E2E.** `dist/bin/stash.js` is the artifact under test. The
+  turbo `test:e2e` task already depends on `build`, but if you invoke the
+  script directly you must build first.
+- **macOS spawn-helper exec bit.** pnpm strips the executable bit when
+  unpacking node-pty's prebuilds. The helper auto-fixes this at module load
+  via `ensureSpawnHelperExecutable`. If you see `posix_spawnp failed` after
+  reinstalling `node_modules`, the chmod logic should handle it on next
+  test run; if not, manually `chmod +x` the helper under
+  `node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/<plat>/spawn-helper`.
+- **Don't broaden the cancel test target.** `auth login` was chosen because
+  `selectRegion()` runs before any network I/O. Don't move the cancel
+  assertion to a command that hits the auth server or DB before the first
+  prompt — flaky.
+- **Don't assert on full prompt strings if avoidable.** Prefer stable
+  substrings. Phase 2 (planned) introduces a `messages.ts` module so test
+  assertions can import handles and survive copy changes; until then,
+  assert on the most stable fragment ("Select a region", not the full
+  rendered prompt frame).
+- **Telemetry.** The CLI source no longer imports `posthog-node` (analytics
+  moved to `packages/wizard`). The dep is still listed in `package.json`
+  and should be removed in a follow-up. If you re-introduce telemetry to
+  the CLI, gate construction on an env var (the wizard's
+  `getClient()` pattern) so E2E tests can no-op it.
+
+## Plan and rationale
+
+Background, alternative approaches considered, and the phase-2 messages
+module are in `docs/plans/cli-pty-integration-tests.md`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
 		"postbuild": "chmod +x ./dist/bin/stash.js",
 		"dev": "tsup --watch",
 		"test": "vitest run",
+		"test:e2e": "vitest run --config vitest.integration.config.ts",
 		"lint": "biome check ."
 	},
 	"dependencies": {
@@ -60,6 +61,8 @@
 	"devDependencies": {
 		"@cipherstash/stack": "workspace:*",
 		"@types/pg": "^8.11.11",
+		"node-pty": "^1.1.0",
+		"strip-ansi": "^7.2.0",
 		"tsup": "catalog:repo",
 		"tsx": "catalog:repo",
 		"typescript": "catalog:repo",

--- a/packages/cli/tests/e2e/auth-login-cancel.e2e.test.ts
+++ b/packages/cli/tests/e2e/auth-login-cancel.e2e.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '../helpers/pty.js'
+
+describe('stash auth login — interactive cancel', () => {
+  it('shows the region prompt, cancels on ctrl-c, and exits 0', async () => {
+    const r = render(['auth', 'login'])
+
+    // First clack prompt — `selectRegion()` runs synchronously before any
+    // network activity, so this is a deterministic assertion target.
+    await r.waitFor('Select a region')
+
+    r.key('CtrlC')
+
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(0)
+    expect(r.output).toContain('Cancelled.')
+  })
+})

--- a/packages/cli/tests/e2e/smoke.e2e.test.ts
+++ b/packages/cli/tests/e2e/smoke.e2e.test.ts
@@ -31,7 +31,10 @@ describe('stash CLI — non-interactive smoke', () => {
     const r = render(['definitely-not-a-command'])
     const { exitCode } = await r.exit
     expect(exitCode).toBe(1)
-    expect(r.output).toContain('Unknown command: definitely-not-a-command')
+    // Assert the stable phrase and the user-supplied token separately so a
+    // copy tweak to the surrounding wording doesn't break the test.
+    expect(r.output).toContain('Unknown command')
+    expect(r.output).toContain('definitely-not-a-command')
     expect(r.output).toContain('Usage: npx @cipherstash/cli')
   })
 
@@ -47,14 +50,16 @@ describe('stash CLI — non-interactive smoke', () => {
     const r = render(['auth', 'bogus-sub'])
     const { exitCode } = await r.exit
     expect(exitCode).toBe(1)
-    expect(r.output).toContain('Unknown auth command: bogus-sub')
+    expect(r.output).toContain('Unknown auth command')
+    expect(r.output).toContain('bogus-sub')
   })
 
   it('db bogus-sub exits 1 with help', async () => {
     const r = render(['db', 'bogus-sub'])
     const { exitCode } = await r.exit
     expect(exitCode).toBe(1)
-    expect(r.output).toContain('Unknown db subcommand: bogus-sub')
+    expect(r.output).toContain('Unknown db subcommand')
+    expect(r.output).toContain('bogus-sub')
   })
 
   it('db migrate is a stub that exits 0 with a "not yet implemented" warning', async () => {

--- a/packages/cli/tests/e2e/smoke.e2e.test.ts
+++ b/packages/cli/tests/e2e/smoke.e2e.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { render } from '../helpers/pty.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'),
+) as { version: string }
+
+describe('stash CLI — non-interactive smoke', () => {
+  it('--help prints the help banner and exits 0', async () => {
+    const r = render(['--help'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(0)
+    expect(r.output).toContain('CipherStash CLI v')
+    expect(r.output).toContain('Usage: npx @cipherstash/cli')
+    expect(r.output).toContain('init')
+    expect(r.output).toContain('db install')
+  })
+
+  it('--version prints the package version', async () => {
+    const r = render(['--version'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(0)
+    expect(r.output.trim()).toContain(pkg.version)
+  })
+
+  it('unknown top-level command exits 1 with help', async () => {
+    const r = render(['definitely-not-a-command'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(1)
+    expect(r.output).toContain('Unknown command: definitely-not-a-command')
+    expect(r.output).toContain('Usage: npx @cipherstash/cli')
+  })
+
+  it('auth with no subcommand prints auth help and exits 0', async () => {
+    const r = render(['auth'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(0)
+    expect(r.output).toContain('Usage: npx @cipherstash/cli auth')
+    expect(r.output).toContain('login')
+  })
+
+  it('auth bogus-sub exits 1 with auth help', async () => {
+    const r = render(['auth', 'bogus-sub'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(1)
+    expect(r.output).toContain('Unknown auth command: bogus-sub')
+  })
+
+  it('db bogus-sub exits 1 with help', async () => {
+    const r = render(['db', 'bogus-sub'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(1)
+    expect(r.output).toContain('Unknown db subcommand: bogus-sub')
+  })
+
+  it('db migrate is a stub that exits 0 with a "not yet implemented" warning', async () => {
+    const r = render(['db', 'migrate'])
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(0)
+    expect(r.output).toContain('not yet implemented')
+  })
+})

--- a/packages/cli/tests/helpers/pty.ts
+++ b/packages/cli/tests/helpers/pty.ts
@@ -1,0 +1,171 @@
+import { chmodSync, existsSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { type IPty, spawn } from 'node-pty'
+import stripAnsi from 'strip-ansi'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Built CLI binary. Tests assume `pnpm --filter @cipherstash/cli build` has run.
+export const STASH_BIN = resolve(__dirname, '../../dist/bin/stash.js')
+
+// pnpm strips the executable bit when unpacking node-pty's macOS prebuilds,
+// causing `posix_spawnp` to fail with EACCES. Re-add it on first import.
+// Linux builds from source and doesn't ship a spawn-helper, so the file is
+// absent there — guard with existsSync.
+function ensureSpawnHelperExecutable() {
+  try {
+    const require = createRequire(import.meta.url)
+    const pkg = require.resolve('node-pty/package.json')
+    const helper = join(dirname(pkg), 'build/Release/spawn-helper')
+    const prebuilt = join(
+      dirname(pkg),
+      `prebuilds/${process.platform}-${process.arch}/spawn-helper`,
+    )
+    for (const path of [helper, prebuilt]) {
+      if (!existsSync(path)) continue
+      const mode = statSync(path).mode
+      // Owner-execute bit (0o100). Skip the chmod call when already set.
+      if ((mode & 0o100) === 0) chmodSync(path, mode | 0o755)
+    }
+  } catch {
+    // Best-effort: if we can't fix it here, the spawn() call will surface
+    // a clear posix_spawnp error and the user can chmod manually.
+  }
+}
+
+ensureSpawnHelperExecutable()
+
+export type Key =
+  | 'Enter'
+  | 'Up'
+  | 'Down'
+  | 'Left'
+  | 'Right'
+  | 'Space'
+  | 'Tab'
+  | 'Backspace'
+  | 'CtrlC'
+  | 'CtrlD'
+  | 'Esc'
+
+const KEYS: Record<Key, string> = {
+  Enter: '\r',
+  Up: '\x1b[A',
+  Down: '\x1b[B',
+  Left: '\x1b[D',
+  Right: '\x1b[C',
+  Space: ' ',
+  Tab: '\t',
+  Backspace: '\x7f',
+  CtrlC: '\x03',
+  CtrlD: '\x04',
+  Esc: '\x1b',
+}
+
+export interface RenderOptions {
+  cwd?: string
+  env?: Record<string, string>
+  cols?: number
+  rows?: number
+}
+
+export interface Rendered {
+  pty: IPty
+  /** ANSI-stripped cumulative stdout. */
+  readonly output: string
+  /** Raw cumulative stdout including ANSI escapes. */
+  readonly raw: string
+  /** Resolves with the process exit code when the pty exits. */
+  exit: Promise<{ exitCode: number; signal?: number }>
+  write(data: string): void
+  key(k: Key): void
+  /**
+   * Polls until `match` appears in the ANSI-stripped output. Rejects on
+   * timeout. Useful for waiting on a clack prompt to render before sending
+   * input.
+   */
+  waitFor(match: string | RegExp, timeoutMs?: number): Promise<void>
+  kill(signal?: string): void
+}
+
+export function render(args: string[], opts: RenderOptions = {}): Rendered {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    // Force-disable color codes from the CLI itself; we still strip ANSI on
+    // assertions, but suppressing where possible keeps `raw` readable when
+    // debugging a failure.
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    // Avoid posthog or anything else thinking it's an interactive dev shell.
+    CI: '1',
+    ...(opts.env ?? {}),
+  }
+
+  // Use the absolute path to the current node binary — node-pty's
+  // `posix_spawnp` doesn't inherit PATH lookup reliably across all macOS /
+  // Linux configurations, especially under Vitest's fork pool.
+  const pty = spawn(process.execPath, [STASH_BIN, ...args], {
+    cwd: opts.cwd ?? process.cwd(),
+    cols: opts.cols ?? 100,
+    rows: opts.rows ?? 30,
+    env,
+  })
+
+  let raw = ''
+  pty.onData((d) => {
+    raw += d
+  })
+
+  const exit = new Promise<{ exitCode: number; signal?: number }>((res) => {
+    pty.onExit((e) => res(e))
+  })
+
+  const waitFor = async (match: string | RegExp, timeoutMs = 5_000) => {
+    const deadline = Date.now() + timeoutMs
+    const matches = (s: string) =>
+      typeof match === 'string' ? s.includes(match) : match.test(s)
+    if (matches(stripAnsi(raw))) return
+    await new Promise<void>((res, rej) => {
+      const timer = setTimeout(
+        () => {
+          cleanup()
+          rej(
+            new Error(
+              `Timed out after ${timeoutMs}ms waiting for ${
+                typeof match === 'string' ? JSON.stringify(match) : match
+              }. Output so far:\n${stripAnsi(raw)}`,
+            ),
+          )
+        },
+        Math.max(0, deadline - Date.now()),
+      )
+      const sub = pty.onData(() => {
+        if (matches(stripAnsi(raw))) {
+          cleanup()
+          res()
+        }
+      })
+      const cleanup = () => {
+        clearTimeout(timer)
+        sub.dispose()
+      }
+    })
+  }
+
+  return {
+    pty,
+    get output() {
+      return stripAnsi(raw)
+    },
+    get raw() {
+      return raw
+    },
+    exit,
+    write: (data: string) => pty.write(data),
+    key: (k: Key) => pty.write(KEYS[k]),
+    waitFor,
+    kill: (signal?: string) => pty.kill(signal),
+  }
+}

--- a/packages/cli/tests/helpers/pty.ts
+++ b/packages/cli/tests/helpers/pty.ts
@@ -98,8 +98,9 @@ export function render(args: string[], opts: RenderOptions = {}): Rendered {
     // debugging a failure.
     NO_COLOR: '1',
     FORCE_COLOR: '0',
-    // Avoid posthog or anything else thinking it's an interactive dev shell.
-    CI: '1',
+    // Match the convention the CLI itself uses (e.g. install.ts checks
+    // `process.env.CI !== 'true'`) so test runs hit the same code paths.
+    CI: 'true',
     ...(opts.env ?? {}),
   }
 
@@ -124,8 +125,13 @@ export function render(args: string[], opts: RenderOptions = {}): Rendered {
 
   const waitFor = async (match: string | RegExp, timeoutMs = 5_000) => {
     const deadline = Date.now() + timeoutMs
-    const matches = (s: string) =>
-      typeof match === 'string' ? s.includes(match) : match.test(s)
+    const matches = (s: string) => {
+      if (typeof match === 'string') return s.includes(match)
+      // Reset stateful regex (`/g`/`/y`) state so successive .test() calls
+      // don't drift through the buffer.
+      match.lastIndex = 0
+      return match.test(s)
+    }
     if (matches(stripAnsi(raw))) return
     await new Promise<void>((res, rej) => {
       const timer = setTimeout(

--- a/packages/cli/vitest.integration.config.ts
+++ b/packages/cli/vitest.integration.config.ts
@@ -4,7 +4,10 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     globals: true,
-    exclude: ['**/node_modules/**', '**/dist/**', 'tests/e2e/**'],
+    include: ['tests/**/*.e2e.test.ts'],
+    pool: 'forks',
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       '@types/pg':
         specifier: ^8.11.11
         version: 8.16.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       tsup:
         specifier: catalog:repo
         version: 8.4.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.3)(typescript@5.6.3)
@@ -162,6 +168,10 @@ importers:
       next:
         specifier: ^14 || ^15
         version: 15.5.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu':
+        specifier: 4.24.0
+        version: 4.24.0
     devDependencies:
       '@clerk/nextjs':
         specifier: catalog:security
@@ -178,10 +188,6 @@ importers:
       vitest:
         specifier: catalog:repo
         version: 3.1.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.3)
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu':
-        specifier: 4.24.0
-        version: 4.24.0
 
   packages/protect:
     dependencies:
@@ -203,6 +209,10 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.25.76
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu':
+        specifier: 4.24.0
+        version: 4.24.0
     devDependencies:
       '@supabase/supabase-js':
         specifier: ^2.47.10
@@ -228,10 +238,6 @@ importers:
       vitest:
         specifier: catalog:repo
         version: 3.1.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.19.3)
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu':
-        specifier: 4.24.0
-        version: 4.24.0
 
   packages/protect-dynamodb:
     dependencies:
@@ -1577,6 +1583,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -2417,6 +2427,12 @@ packages:
       sass:
         optional: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
@@ -2843,6 +2859,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4166,6 +4186,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   any-promise@1.3.0: {}
 
   argparse@1.0.10:
@@ -4931,6 +4953,12 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
@@ -5359,6 +5387,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,11 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "cache": false
+    },
+    "test:e2e": {
+      "dependsOn": ["^build", "build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a pty-driven integration test suite for `@cipherstash/cli` so we can cover `@clack/prompts` flows (raw mode, escape sequences, cancellation) that piped-stdin mocks can't reach. Drives the built `dist/bin/stash.js` through a real pseudo-terminal via `node-pty`.

- New `vitest.integration.config.ts` (forks pool, 30s timeout) and `test:e2e` script + turbo task that depend on `build`.
- Default `vitest.config.ts` now excludes `tests/e2e/**` so the existing `pnpm test` stays fast and build-free.
- `tests/helpers/pty.ts` — small `render` / `waitFor` / `key` / `exit` wrapper. Auto-fixes the exec bit pnpm strips from node-pty's macOS spawn-helper prebuild.
- 8 new tests: 7 non-interactive smoke (help, version, unknown commands, `db migrate` stub) + 1 interactive cancel test (`auth login` → ctrl-c at the region prompt).
- `packages/cli/AGENTS.md` documents when to add/update E2E tests, the harness API, and the gotchas. Root `AGENTS.md` gets a one-line pointer.
- `docs/plans/cli-pty-integration-tests.md` captures the rationale, alternatives considered, and a planned phase-2 messages-handle refactor.

## Why node-pty and not a mock

`@clack/prompts` switches stdin to raw mode and renders differently when stdout isn't a TTY. `mock-stdin` and `cli-testing-library` don't drive a real pty so the high-fidelity prompt flows (select/multiselect, ctrl-c) aren't exercised. `expect(1)` adds a Tcl runtime and lives outside Vitest. `node-pty` keeps tests inside Vitest with no second toolchain.

## Test plan

- [x] `pnpm --filter @cipherstash/cli test` — 76 unit tests pass, ~400ms, no e2e bleed-through
- [x] `pnpm --filter @cipherstash/cli test:e2e` — 8 e2e tests pass, ~1s, all spawning the built binary through a real pty
- [ ] CI confirms node-pty's prebuilt binaries resolve on the runner matrix (Linux x64 / darwin arm64 on Node 22)
- [ ] Reviewer sanity check: `pnpm --filter @cipherstash/cli build && pnpm --filter @cipherstash/cli test:e2e` locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added end-to-end testing infrastructure for the CLI with interactive terminal support, enabling comprehensive testing of user interactions and command behavior.

* **Tests**
  * Added smoke tests validating help, version, error handling, and command stubs.
  * Added interactive test for auth flow cancellation.

* **Documentation**
  * Added comprehensive guides for running and maintaining CLI test suites with platform-specific considerations.
  * Added specification document outlining E2E testing strategy and rollout plan.

* **Chores**
  * Updated build and test configurations to support E2E test execution.
  * Added necessary test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->