### PR TITLE
fix(cli): unwrap default export when loading stash.config.ts

### DIFF
--- a/packages/cli/src/__tests__/config-jiti-integration.test.ts
+++ b/packages/cli/src/__tests__/config-jiti-integration.test.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Integration test for `loadStashConfig` against the *real* jiti runtime.
+ *
+ * The companion file `config.test.ts` mocks the `jiti` module entirely,
+ * which is fast but can't catch wrapper/unwrap regressions in how the
+ * default export is returned. This file deliberately does NOT mock jiti —
+ * it writes a real `stash.config.ts` into a temp dir and asserts that
+ * `loadStashConfig` returns the inner config rather than the module
+ * namespace. Regression net for #374: in jiti 2.x the constructor's
+ * `interopDefault: true` does not apply to `.import()`, so the per-call
+ * `{ default: true }` option is required.
+ */
+
+describe('loadStashConfig — real jiti', () => {
+  let tmpDir: string
+  let originalCwd: () => string
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-config-real-jiti-'))
+    originalCwd = process.cwd
+    originalEnv = process.env.STASH_TEST_DATABASE_URL
+  })
+
+  afterEach(() => {
+    process.cwd = originalCwd
+    if (originalEnv === undefined) {
+      // biome-ignore lint/performance/noDelete: process.env.X = undefined coerces to the string "undefined" in Node, not an unset.
+      delete process.env.STASH_TEST_DATABASE_URL
+    } else {
+      process.env.STASH_TEST_DATABASE_URL = originalEnv
+    }
+
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('unwraps `export default {...}` to the inner config (#374 regression)', async () => {
+    process.env.STASH_TEST_DATABASE_URL =
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+    fs.writeFileSync(
+      path.join(tmpDir, 'stash.config.ts'),
+      `export default {
+         databaseUrl: process.env.STASH_TEST_DATABASE_URL,
+         client: './src/encryption/index.ts',
+       }`,
+    )
+    process.cwd = () => tmpDir
+
+    const { loadStashConfig } = await import('@/config/index.ts')
+    const config = await loadStashConfig()
+
+    expect(config).toEqual({
+      databaseUrl: 'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+      client: './src/encryption/index.ts',
+    })
+  })
+
+  it('reports a useful error when databaseUrl is genuinely missing', async () => {
+    // biome-ignore lint/performance/noDelete: see afterEach above; need an actual unset.
+    delete process.env.STASH_TEST_DATABASE_URL
+    fs.writeFileSync(
+      path.join(tmpDir, 'stash.config.ts'),
+      `export default {
+         databaseUrl: process.env.STASH_TEST_DATABASE_URL,
+       }`,
+    )
+    process.cwd = () => tmpDir
+
+    const errSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit')
+    })
+
+    const { loadStashConfig } = await import('@/config/index.ts')
+    await expect(loadStashConfig()).rejects.toThrow('process.exit')
+
+    const allCalls = errSpy.mock.calls.flat().join('\n')
+    expect(allCalls).toContain('Invalid stash.config.ts')
+    expect(allCalls).toContain('databaseUrl')
+  })
+})

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -97,13 +97,19 @@ Create a ${CONFIG_FILENAME} file in your project root:
   }
 
   const { createJiti } = await import('jiti')
-  const jiti = createJiti(configPath, {
-    interopDefault: true,
-  })
+  const jiti = createJiti(configPath)
 
   let rawConfig: unknown
   try {
-    rawConfig = await jiti.import(configPath)
+    // The per-call `{ default: true }` option is the jiti 2.x way to ask
+    // for the default export to be unwrapped. The `interopDefault`
+    // *constructor* option only applies to the deprecated synchronous
+    // `jiti(id)` callable form — `jiti.import()` silently ignores it and
+    // returns the full module namespace (`{ default: { ... } }`). That
+    // wrapper would then fail Zod validation with a misleading
+    // "databaseUrl: received undefined" even when the user's config sets
+    // it (#374).
+    rawConfig = await jiti.import(configPath, { default: true })
   } catch (error) {
     console.error(`Error: Failed to load ${CONFIG_FILENAME} at ${configPath}\n`)
     console.error(error)
@@ -148,12 +154,13 @@ export async function loadEncryptConfig(
   }
 
   const { createJiti } = await import('jiti')
-  const jiti = createJiti(resolvedPath, {
-    interopDefault: true,
-  })
+  const jiti = createJiti(resolvedPath)
 
   let moduleExports: Record<string, unknown>
   try {
+    // No `{ default: true }` here — we want the full module namespace so
+    // `Object.values` can find an EncryptionClient regardless of whether
+    // the user re-exports it as `default` or as a named binding.
     moduleExports = (await jiti.import(resolvedPath)) as Record<string, unknown>
   } catch (error) {
     console.error(


### PR DESCRIPTION
Closes #374.

## Symptom

```
$ npx @cipherstash/cli db install
Error: Invalid stash.config.ts
  - databaseUrl: Invalid input: expected nonoptional, received undefined
```

Even when the user's `stash.config.ts` clearly sets `databaseUrl` from `process.env.DATABASE_URL`, and a `console.log` of the same env var prints the URL just before the error fires.

## Root cause

`loadStashConfig` (`packages/cli/src/config/index.ts`) was constructing jiti with `interopDefault: true` and then calling `jiti.import(...)`:

```ts
const jiti = createJiti(configPath, { interopDefault: true })
const rawConfig = await jiti.import(configPath)   // ← option silently ignored
```

In jiti 2.x, the **constructor's** `interopDefault` only applies to the deprecated synchronous `jiti(id)` callable form. The async `jiti.import()` ignores it and always returns the module namespace. So for `export default defineConfig({...})`, `rawConfig` is `{ default: { databaseUrl, client } }`. Zod then validates the wrapper, finds no top-level `databaseUrl`, and emits the misleading "expected nonoptional, received undefined" error.

Verified empirically against `jiti@2.6.1`:

```
> jiti.import(configPath)                       → {"default":{"databaseUrl":"..."}}
> jiti.import(configPath, { default: true })    → {"databaseUrl":"..."}
```

## Fix

Switch to the per-call `{ default: true }` option (the jiti 2.x async-API way to ask for default-export unwrapping). Drop the now-misleading `interopDefault: true` from both `loadStashConfig` and the symmetric `loadEncryptConfig` call site (which wasn't symptom-bugged because it iterates `Object.values` to find the EncryptionClient — but consistency keeps the next reader from reaching the same wrong conclusion).

## Why the existing test missed it

`packages/cli/src/__tests__/config.test.ts` mocks `jiti.import` to return the *already-unwrapped* shape:

```ts
mockJiti.import = vi.fn().mockResolvedValue({ databaseUrl: '...' })
```

So the test never exercised the real jiti behavior and would pass regardless of which option was set.

## Regression test

New `src/__tests__/config-jiti-integration.test.ts` drives `loadStashConfig` against real jiti and a real `stash.config.ts` file written into a temp dir. Two cases:

1. `export default {...}` is unwrapped to the inner config (the regression we're fixing).
2. A genuinely-missing `databaseUrl` produces a useful error message containing `Invalid stash.config.ts` and `databaseUrl`.

The mocked `config.test.ts` stays in place for fast schema iteration.

## Test plan

- [x] `pnpm --filter @cipherstash/cli build` clean
- [x] `pnpm --filter @cipherstash/cli test` — 78 pass (was 76; +2 from the new integration test)
- [x] `biome check` clean on changed files
- [ ] Confirm the user's reproduction (`npx @cipherstash/cli db install` against a config that reads `databaseUrl` from `process.env.DATABASE_URL`) succeeds with this branch