### PR TITLE
feat(cli): layered DATABASE_URL resolution for db / schema commands

### DIFF
--- a/.changeset/cli-database-url-resolution.md
+++ b/.changeset/cli-database-url-resolution.md
@@ -1,0 +1,37 @@
+---
+'@cipherstash/cli': minor
+---
+
+Layered `DATABASE_URL` resolution for DB / schema commands.
+
+Previously, any DB-touching command (`db install`, `db push`, `db upgrade`, `db status`, `db validate`, `db test-connection`, `schema build`) failed with the cryptic Zod error:
+
+```
+Error: Invalid stash.config.ts
+  - databaseUrl: Invalid input: expected nonoptional, received undefined
+```
+
+if `DATABASE_URL` wasn't already in the environment. The CLI auto-loaded `.env.local` / `.env.development.local` / `.env.development` / `.env`, but had no story for `--database-url` flags, local Supabase, or pasted-once values.
+
+The scaffolded `stash.config.ts` now calls a resolver directly:
+
+```ts
+import { defineConfig, resolveDatabaseUrl } from '@cipherstash/cli'
+
+export default defineConfig({
+  databaseUrl: await resolveDatabaseUrl(),
+  client: './src/encryption/index.ts',
+})
+```
+
+`resolveDatabaseUrl()` walks sources in order; first hit wins:
+
+1. `--database-url <url>` flag — new, accepted on all seven DB / schema commands. Used for this run only; never written to disk.
+2. `process.env.DATABASE_URL` — covers shell exports, mise, direnv, dotenv-cli, the existing dotenv loads.
+3. `supabase status --output env` → `DB_URL` — auto-engaged when `--supabase` is set or a `supabase/config.toml` is detected. Useful for local Supabase users who haven't exported the URL yet.
+4. Interactive prompt — opens with a tip listing the alternatives (flag, env, the user's actual dotenv file). Skipped under `CI=true` or non-TTY stdin.
+5. Hard fail with a source-naming error message.
+
+The connection string is **never persisted to disk** — `stash.config.ts` only contains the `await resolveDatabaseUrl()` call, never a literal URL. The resolver also doesn't mutate `process.env`; CLI flag context is threaded into the config evaluation via `AsyncLocalStorage` so concurrent loads stay isolated. Source labels are logged on non-env paths (`Using DATABASE_URL from --database-url flag` / `from supabase status` / `from prompt`) but the URL itself is never echoed.
+
+`db test-connection`'s connection-failure hint is now source-aware: it points users at `--database-url`, the env var, and the actual dotenv file in their project (`.env.local` if present, `.env` otherwise) — not the misleading `stash.config.ts` it used to suggest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,27 @@ pnpm changeset:publish
    - `pnpm --filter <changed-pkg> build`
    - `pnpm --filter <changed-pkg> test`
 6. Update docs in `docs/*` and usage examples if APIs change.
+7. **Add a changeset before opening or finalising the PR** when the
+   change affects a published package's public behaviour or surface
+   (new feature, bug fix, breaking change, UX-visible tweak). Run
+   `pnpm changeset` (interactive) or hand-write a markdown file under
+   `.changeset/` matching the existing format:
+
+   ```
+   ---
+   '@cipherstash/<pkg>': minor   # or patch / major
+   ---
+
+   <user-facing description of what changed and why>
+   ```
+
+   The repo's `changeset-bot` GitHub app posts a "🦋 No Changeset
+   found" warning on PRs missing one. Skip changesets only for
+   internal-only changes (test-only PRs, internal refactors with no
+   observable behaviour change, repo tooling). When in doubt, add
+   one — releases use Changesets to drive version bumps and
+   `CHANGELOG.md` entries, so a missing changeset means the change
+   ships invisibly.
 
 ## Useful Links in this repo
 

--- a/packages/cli/src/__tests__/database-url.test.ts
+++ b/packages/cli/src/__tests__/database-url.test.ts
@@ -1,0 +1,255 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { messages } from '../messages.js'
+
+// Mock seams. We hoist them so the in-test reconfiguration touches the same
+// fn instances the resolver imports.
+const supabase = vi.hoisted(() => ({ execSync: vi.fn() }))
+vi.mock('node:child_process', () => ({ execSync: supabase.execSync }))
+
+const detect = vi.hoisted(() => ({ detectSupabaseProject: vi.fn() }))
+vi.mock('../commands/db/detect.js', () => ({
+  detectSupabaseProject: detect.detectSupabaseProject,
+}))
+
+const clack = vi.hoisted(() => ({
+  text: vi.fn(),
+  isCancel: vi.fn(),
+  cancel: vi.fn(),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn() },
+  note: vi.fn(),
+}))
+vi.mock('@clack/prompts', () => ({
+  text: clack.text,
+  isCancel: clack.isCancel,
+  cancel: clack.cancel,
+  log: clack.log,
+  note: clack.note,
+}))
+
+const { resolveDatabaseUrl } = await import('../config/database-url.js')
+
+const VALID_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+
+let originalEnv: string | undefined
+let originalCi: string | undefined
+let originalIsTty: boolean | undefined
+let tmpDir: string
+
+function noProject() {
+  detect.detectSupabaseProject.mockReturnValue({
+    hasMigrationsDir: false,
+    hasConfigToml: false,
+    migrationsDir: '/tmp/x',
+  })
+}
+
+beforeEach(() => {
+  originalEnv = process.env.DATABASE_URL
+  originalCi = process.env.CI
+  originalIsTty = process.stdin.isTTY
+  // biome-ignore lint/performance/noDelete: see config-jiti-integration.test.ts; need an actual unset.
+  delete process.env.DATABASE_URL
+  // biome-ignore lint/performance/noDelete: ditto.
+  delete process.env.CI
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'database-url-test-'))
+  noProject()
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    // biome-ignore lint/performance/noDelete: unset, not assignment.
+    delete process.env.DATABASE_URL
+  } else {
+    process.env.DATABASE_URL = originalEnv
+  }
+  if (originalCi === undefined) {
+    // biome-ignore lint/performance/noDelete: unset, not assignment.
+    delete process.env.CI
+  } else {
+    process.env.CI = originalCi
+  }
+  Object.defineProperty(process.stdin, 'isTTY', {
+    value: originalIsTty,
+    configurable: true,
+  })
+  vi.clearAllMocks()
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+describe('resolveDatabaseUrl — flag source', () => {
+  it('uses the flag value and overwrites env, even when env was already set', async () => {
+    process.env.DATABASE_URL = 'postgresql://existing@h/d'
+    const result = await resolveDatabaseUrl({ databaseUrlFlag: VALID_URL })
+    expect(result).toEqual({ url: VALID_URL, source: 'flag' })
+    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(clack.log.info).toHaveBeenCalledWith(messages.db.urlResolvedFromFlag)
+  })
+
+  it('exits 1 when the flag is malformed', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(
+      resolveDatabaseUrl({ databaseUrlFlag: 'not-a-url' }),
+    ).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(clack.log.error).toHaveBeenCalledWith(messages.db.urlFlagMalformed)
+  })
+})
+
+describe('resolveDatabaseUrl — env source', () => {
+  it('returns the existing env value without mutating', async () => {
+    process.env.DATABASE_URL = VALID_URL
+    const result = await resolveDatabaseUrl()
+    expect(result).toEqual({ url: VALID_URL, source: 'env' })
+    // env was already set; we don't reassign.
+    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(clack.log.info).not.toHaveBeenCalled()
+  })
+
+  it('treats empty-string env as unset and falls through', async () => {
+    process.env.DATABASE_URL = ''
+    process.env.CI = 'true'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(clack.log.error).toHaveBeenCalledWith(messages.db.urlMissingCi)
+  })
+})
+
+describe('resolveDatabaseUrl — supabase source', () => {
+  it('parses DB_URL from `supabase status --output env`', async () => {
+    detect.detectSupabaseProject.mockReturnValue({
+      hasMigrationsDir: true,
+      hasConfigToml: true,
+      migrationsDir: '/tmp/x',
+    })
+    supabase.execSync.mockReturnValueOnce(`API_URL=http://127.0.0.1:54321
+DB_URL=${VALID_URL}
+GRAPHQL_URL=http://127.0.0.1:54321/graphql/v1
+`)
+    const result = await resolveDatabaseUrl()
+    expect(result).toEqual({ url: VALID_URL, source: 'supabase-status' })
+    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(clack.log.info).toHaveBeenCalledWith(
+      messages.db.urlResolvedFromSupabase,
+    )
+  })
+
+  it('falls through when supabase binary not found', async () => {
+    detect.detectSupabaseProject.mockReturnValue({
+      hasMigrationsDir: false,
+      hasConfigToml: true,
+      migrationsDir: '/tmp/x',
+    })
+    supabase.execSync.mockImplementation(() => {
+      const err = new Error('command not found')
+      throw err
+    })
+    process.env.CI = 'true'
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('falls through when JSON/env output has no DB_URL', async () => {
+    detect.detectSupabaseProject.mockReturnValue({
+      hasMigrationsDir: false,
+      hasConfigToml: true,
+      migrationsDir: '/tmp/x',
+    })
+    supabase.execSync.mockReturnValue('API_URL=http://127.0.0.1:54321\n')
+    process.env.CI = 'true'
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+  })
+
+  it('does NOT call supabase when no project is detected and no --supabase flag', async () => {
+    process.env.CI = 'true'
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+    expect(supabase.execSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveDatabaseUrl — prompt source', () => {
+  beforeEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+  })
+
+  it('prompts and uses the entered URL, then suggests a hint file', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env.local'), '')
+    clack.text.mockResolvedValueOnce(VALID_URL)
+    clack.isCancel.mockReturnValueOnce(false)
+    const result = await resolveDatabaseUrl({ cwd: tmpDir })
+    expect(result).toEqual({ url: VALID_URL, source: 'prompt' })
+    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(clack.note).toHaveBeenCalledWith(messages.db.urlHint('.env.local'))
+  })
+
+  it('defaults the hint file to .env when no dotenv files exist', async () => {
+    clack.text.mockResolvedValueOnce(VALID_URL)
+    clack.isCancel.mockReturnValueOnce(false)
+    await resolveDatabaseUrl({ cwd: tmpDir })
+    expect(clack.note).toHaveBeenCalledWith(messages.db.urlHint('.env'))
+  })
+
+  it('exits 0 when the user cancels the prompt', async () => {
+    const cancelSym = Symbol('clack:cancel')
+    clack.text.mockResolvedValueOnce(cancelSym)
+    clack.isCancel.mockReturnValueOnce(true)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl({ cwd: tmpDir })).rejects.toThrow(
+      'process.exit',
+    )
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+})
+
+describe('resolveDatabaseUrl — CI guard', () => {
+  it('does not prompt and exits 1 when CI=true with no flag and no env', async () => {
+    process.env.CI = 'true'
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(clack.text).not.toHaveBeenCalled()
+    expect(clack.log.error).toHaveBeenCalledWith(messages.db.urlMissingCi)
+  })
+
+  it('does not prompt when stdin is not a TTY (e.g. piped)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(clack.text).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/__tests__/database-url.test.ts
+++ b/packages/cli/src/__tests__/database-url.test.ts
@@ -77,7 +77,10 @@ afterEach(() => {
     value: originalIsTty,
     configurable: true,
   })
-  vi.clearAllMocks()
+  // restoreAllMocks (not clearAllMocks) is what fully reverts spies on
+  // global objects like `process.exit`. Without restoration the spy stays
+  // attached and bleeds into later tests.
+  vi.restoreAllMocks()
   if (tmpDir && fs.existsSync(tmpDir)) {
     fs.rmSync(tmpDir, { recursive: true, force: true })
   }
@@ -256,20 +259,23 @@ describe('resolveDatabaseUrl — prompt source', () => {
 })
 
 describe('resolveDatabaseUrl — CI guard', () => {
-  it('does not prompt and exits 1 when CI=true with no flag and no env', async () => {
-    process.env.CI = 'true'
-    Object.defineProperty(process.stdin, 'isTTY', {
-      value: true,
-      configurable: true,
-    })
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
-      throw new Error('process.exit')
-    }) as never)
-    await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
-    expect(exitSpy).toHaveBeenCalledWith(1)
-    expect(clack.text).not.toHaveBeenCalled()
-    expect(clack.log.error).toHaveBeenCalledWith(messages.db.urlMissingCi)
-  })
+  it.each(['true', 'TRUE', '1', ' true '])(
+    'does not prompt and exits 1 when CI=%j (truthy)',
+    async (ciValue) => {
+      process.env.CI = ciValue
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      })
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit')
+      }) as never)
+      await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(clack.text).not.toHaveBeenCalled()
+      expect(clack.log.error).toHaveBeenCalledWith(messages.db.urlMissingCi)
+    },
+  )
 
   it('does not prompt when stdin is not a TTY (e.g. piped)', async () => {
     Object.defineProperty(process.stdin, 'isTTY', {

--- a/packages/cli/src/__tests__/database-url.test.ts
+++ b/packages/cli/src/__tests__/database-url.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { messages } from '../messages.js'
 
-// Mock seams. We hoist them so the in-test reconfiguration touches the same
-// fn instances the resolver imports.
+// Mock seams. Hoisted so the in-test reconfiguration touches the same fn
+// instances the resolver imports.
 const supabase = vi.hoisted(() => ({ execSync: vi.fn() }))
 vi.mock('node:child_process', () => ({ execSync: supabase.execSync }))
 
@@ -29,7 +29,9 @@ vi.mock('@clack/prompts', () => ({
   note: clack.note,
 }))
 
-const { resolveDatabaseUrl } = await import('../config/database-url.js')
+const { resolveDatabaseUrl, withResolverContext } = await import(
+  '../config/database-url.js'
+)
 
 const VALID_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
 
@@ -50,7 +52,7 @@ beforeEach(() => {
   originalEnv = process.env.DATABASE_URL
   originalCi = process.env.CI
   originalIsTty = process.stdin.isTTY
-  // biome-ignore lint/performance/noDelete: see config-jiti-integration.test.ts; need an actual unset.
+  // biome-ignore lint/performance/noDelete: process.env.X = undefined assigns the string "undefined" in Node, not unset.
   delete process.env.DATABASE_URL
   // biome-ignore lint/performance/noDelete: ditto.
   delete process.env.CI
@@ -60,13 +62,13 @@ beforeEach(() => {
 
 afterEach(() => {
   if (originalEnv === undefined) {
-    // biome-ignore lint/performance/noDelete: unset, not assignment.
+    // biome-ignore lint/performance/noDelete: see above.
     delete process.env.DATABASE_URL
   } else {
     process.env.DATABASE_URL = originalEnv
   }
   if (originalCi === undefined) {
-    // biome-ignore lint/performance/noDelete: unset, not assignment.
+    // biome-ignore lint/performance/noDelete: see above.
     delete process.env.CI
   } else {
     process.env.CI = originalCi
@@ -82,11 +84,21 @@ afterEach(() => {
 })
 
 describe('resolveDatabaseUrl — flag source', () => {
-  it('uses the flag value and overwrites env, even when env was already set', async () => {
+  it('returns the flag value and does NOT mutate process.env', async () => {
     process.env.DATABASE_URL = 'postgresql://existing@h/d'
     const result = await resolveDatabaseUrl({ databaseUrlFlag: VALID_URL })
-    expect(result).toEqual({ url: VALID_URL, source: 'flag' })
-    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(result).toBe(VALID_URL)
+    // The whole point of the ALS refactor: env stays untouched.
+    expect(process.env.DATABASE_URL).toBe('postgresql://existing@h/d')
+    expect(clack.log.info).toHaveBeenCalledWith(messages.db.urlResolvedFromFlag)
+  })
+
+  it('reads the flag from withResolverContext when no explicit opts are passed', async () => {
+    const result = await withResolverContext(
+      { databaseUrlFlag: VALID_URL },
+      () => resolveDatabaseUrl(),
+    )
+    expect(result).toBe(VALID_URL)
     expect(clack.log.info).toHaveBeenCalledWith(messages.db.urlResolvedFromFlag)
   })
 
@@ -103,12 +115,12 @@ describe('resolveDatabaseUrl — flag source', () => {
 })
 
 describe('resolveDatabaseUrl — env source', () => {
-  it('returns the existing env value without mutating', async () => {
+  it('returns the existing env value without mutating it', async () => {
     process.env.DATABASE_URL = VALID_URL
     const result = await resolveDatabaseUrl()
-    expect(result).toEqual({ url: VALID_URL, source: 'env' })
-    // env was already set; we don't reassign.
+    expect(result).toBe(VALID_URL)
     expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    // The env source is silent — no source label.
     expect(clack.log.info).not.toHaveBeenCalled()
   })
 
@@ -125,7 +137,7 @@ describe('resolveDatabaseUrl — env source', () => {
 })
 
 describe('resolveDatabaseUrl — supabase source', () => {
-  it('parses DB_URL from `supabase status --output env`', async () => {
+  it('parses DB_URL from `supabase status --output env` and does NOT mutate process.env', async () => {
     detect.detectSupabaseProject.mockReturnValue({
       hasMigrationsDir: true,
       hasConfigToml: true,
@@ -136,8 +148,9 @@ DB_URL=${VALID_URL}
 GRAPHQL_URL=http://127.0.0.1:54321/graphql/v1
 `)
     const result = await resolveDatabaseUrl()
-    expect(result).toEqual({ url: VALID_URL, source: 'supabase-status' })
-    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(result).toBe(VALID_URL)
+    // No env mutation under the new design.
+    expect(process.env.DATABASE_URL).toBeUndefined()
     expect(clack.log.info).toHaveBeenCalledWith(
       messages.db.urlResolvedFromSupabase,
     )
@@ -150,8 +163,7 @@ GRAPHQL_URL=http://127.0.0.1:54321/graphql/v1
       migrationsDir: '/tmp/x',
     })
     supabase.execSync.mockImplementation(() => {
-      const err = new Error('command not found')
-      throw err
+      throw new Error('command not found')
     })
     process.env.CI = 'true'
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -161,7 +173,7 @@ GRAPHQL_URL=http://127.0.0.1:54321/graphql/v1
     expect(exitSpy).toHaveBeenCalledWith(1)
   })
 
-  it('falls through when JSON/env output has no DB_URL', async () => {
+  it('falls through when supabase env output has no DB_URL', async () => {
     detect.detectSupabaseProject.mockReturnValue({
       hasMigrationsDir: false,
       hasConfigToml: true,
@@ -193,13 +205,22 @@ describe('resolveDatabaseUrl — prompt source', () => {
     })
   })
 
-  it('prompts and uses the entered URL, then suggests a hint file', async () => {
+  it('shows the alternatives tip before prompting', async () => {
+    clack.text.mockResolvedValueOnce(VALID_URL)
+    clack.isCancel.mockReturnValueOnce(false)
+    await resolveDatabaseUrl({ cwd: tmpDir })
+    expect(clack.note).toHaveBeenCalledWith(messages.db.urlPromptTip)
+    expect(clack.text).toHaveBeenCalled()
+  })
+
+  it('returns the entered URL and suggests an existing dotenv file', async () => {
     fs.writeFileSync(path.join(tmpDir, '.env.local'), '')
     clack.text.mockResolvedValueOnce(VALID_URL)
     clack.isCancel.mockReturnValueOnce(false)
     const result = await resolveDatabaseUrl({ cwd: tmpDir })
-    expect(result).toEqual({ url: VALID_URL, source: 'prompt' })
-    expect(process.env.DATABASE_URL).toBe(VALID_URL)
+    expect(result).toBe(VALID_URL)
+    // No env mutation.
+    expect(process.env.DATABASE_URL).toBeUndefined()
     expect(clack.note).toHaveBeenCalledWith(messages.db.urlHint('.env.local'))
   })
 
@@ -251,5 +272,30 @@ describe('resolveDatabaseUrl — CI guard', () => {
     await expect(resolveDatabaseUrl()).rejects.toThrow('process.exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(clack.text).not.toHaveBeenCalled()
+  })
+})
+
+describe('withResolverContext — concurrent isolation', () => {
+  // The whole reason we use AsyncLocalStorage instead of module-level
+  // state: two concurrent calls must each see their own options without
+  // stepping on each other.
+  it('isolates contexts across concurrent withResolverContext scopes', async () => {
+    const URL_A = 'postgresql://a:a@h/a'
+    const URL_B = 'postgresql://b:b@h/b'
+
+    const [a, b] = await Promise.all([
+      withResolverContext({ databaseUrlFlag: URL_A }, async () => {
+        // Yield to let the other branch start its scope before we read.
+        await new Promise((res) => setTimeout(res, 5))
+        return resolveDatabaseUrl()
+      }),
+      withResolverContext({ databaseUrlFlag: URL_B }, async () => {
+        await new Promise((res) => setTimeout(res, 5))
+        return resolveDatabaseUrl()
+      }),
+    ])
+
+    expect(a).toBe(URL_A)
+    expect(b).toBe(URL_B)
   })
 })

--- a/packages/cli/src/__tests__/database-url.test.ts
+++ b/packages/cli/src/__tests__/database-url.test.ts
@@ -205,12 +205,22 @@ describe('resolveDatabaseUrl — prompt source', () => {
     })
   })
 
-  it('shows the alternatives tip before prompting', async () => {
+  it('shows the alternatives tip with the detected dotenv file before prompting', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.env.local'), '')
     clack.text.mockResolvedValueOnce(VALID_URL)
     clack.isCancel.mockReturnValueOnce(false)
     await resolveDatabaseUrl({ cwd: tmpDir })
-    expect(clack.note).toHaveBeenCalledWith(messages.db.urlPromptTip)
+    expect(clack.note).toHaveBeenCalledWith(
+      messages.db.urlPromptTip('.env.local'),
+    )
     expect(clack.text).toHaveBeenCalled()
+  })
+
+  it('defaults the prompt tip to .env when no dotenv files exist', async () => {
+    clack.text.mockResolvedValueOnce(VALID_URL)
+    clack.isCancel.mockReturnValueOnce(false)
+    await resolveDatabaseUrl({ cwd: tmpDir })
+    expect(clack.note).toHaveBeenCalledWith(messages.db.urlPromptTip('.env'))
   })
 
   it('returns the entered URL and suggests an existing dotenv file', async () => {

--- a/packages/cli/src/bin/stash.ts
+++ b/packages/cli/src/bin/stash.ts
@@ -93,6 +93,7 @@ DB Flags:
   --migrations-dir <path>    (install, requires --supabase) Override the Supabase migrations directory (default: supabase/migrations)
   --exclude-operator-family  (install, upgrade, validate) Skip operator family creation
   --latest                   (install, upgrade) Fetch the latest EQL from GitHub
+  --database-url <url>       (all db / schema commands) Override DATABASE_URL for this run only — never written to disk
 
 Examples:
   npx @cipherstash/cli init
@@ -145,6 +146,10 @@ async function runDbCommand(
   flags: Record<string, boolean>,
   values: Record<string, string>,
 ) {
+  // Plumbed through every db subcommand so the URL resolver can use it as
+  // an explicit override. See packages/cli/src/config/database-url.ts.
+  const databaseUrl = values['database-url']
+
   switch (sub) {
     case 'install':
       await installCommand({
@@ -159,6 +164,7 @@ async function runDbCommand(
         migration: flags.migration,
         direct: flags.direct,
         migrationsDir: values['migrations-dir'],
+        databaseUrl,
       })
       break
     case 'upgrade':
@@ -167,13 +173,14 @@ async function runDbCommand(
         supabase: flags.supabase,
         excludeOperatorFamily: flags['exclude-operator-family'],
         latest: flags.latest,
+        databaseUrl,
       })
       break
     case 'push': {
       const { pushCommand } = await requireStack(
         () => import('../commands/db/push.js'),
       )
-      await pushCommand({ dryRun: flags['dry-run'] })
+      await pushCommand({ dryRun: flags['dry-run'], databaseUrl })
       break
     }
     case 'validate': {
@@ -183,14 +190,15 @@ async function runDbCommand(
       await validateCommand({
         supabase: flags.supabase,
         excludeOperatorFamily: flags['exclude-operator-family'],
+        databaseUrl,
       })
       break
     }
     case 'status':
-      await statusCommand()
+      await statusCommand({ databaseUrl })
       break
     case 'test-connection':
-      await testConnectionCommand()
+      await testConnectionCommand({ databaseUrl })
       break
     case 'migrate':
       p.log.warn(messages.db.migrateNotImplemented)
@@ -206,13 +214,17 @@ async function runDbCommand(
 async function runSchemaCommand(
   sub: string | undefined,
   flags: Record<string, boolean>,
+  values: Record<string, string>,
 ) {
   switch (sub) {
     case 'build': {
       const { builderCommand } = await requireStack(
         () => import('../commands/schema/build.js'),
       )
-      await builderCommand({ supabase: flags.supabase })
+      await builderCommand({
+        supabase: flags.supabase,
+        databaseUrl: values['database-url'],
+      })
       break
     }
     default:
@@ -251,7 +263,7 @@ async function main() {
       await runDbCommand(subcommand, flags, values)
       break
     case 'schema':
-      await runSchemaCommand(subcommand, flags)
+      await runSchemaCommand(subcommand, flags, values)
       break
     case 'env':
       await envCommand({ write: flags.write })

--- a/packages/cli/src/commands/db/config-scaffold.ts
+++ b/packages/cli/src/commands/db/config-scaffold.ts
@@ -69,10 +69,14 @@ export async function resolveClientPath(
 }
 
 function generateConfig(clientPath: string): string {
-  return `import { defineConfig } from '@cipherstash/cli'
+  // The config calls resolveDatabaseUrl() at evaluation time. The CLI
+  // walks a layered chain (--database-url flag → env → supabase status
+  // → interactive prompt) and returns a usable URL. The connection
+  // string is never persisted — only this declarative call is.
+  return `import { defineConfig, resolveDatabaseUrl } from '@cipherstash/cli'
 
 export default defineConfig({
-  databaseUrl: process.env.DATABASE_URL!,
+  databaseUrl: await resolveDatabaseUrl(),
   client: '${clientPath}',
 })
 `

--- a/packages/cli/src/commands/db/install.ts
+++ b/packages/cli/src/commands/db/install.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { loadStashConfig } from '@/config/index.js'
 import {
   EQLInstaller,
@@ -65,7 +66,7 @@ export interface InstallOptions {
 export type SupabaseInstallMode = 'migration' | 'direct'
 
 export async function installCommand(options: InstallOptions) {
-  p.intro('npx @cipherstash/cli db install')
+  p.intro(runnerCommand(detectPackageManager(), '@cipherstash/cli db install'))
 
   // Validate mutually-exclusive / supabase-required flags BEFORE doing any
   // I/O. `--migration` and `--direct` only make sense in the Supabase flow;

--- a/packages/cli/src/commands/db/install.ts
+++ b/packages/cli/src/commands/db/install.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import {
   EQLInstaller,
@@ -54,6 +55,11 @@ export interface InstallOptions {
    * Defaults to `<cwd>/supabase/migrations`.
    */
   migrationsDir?: string
+  /**
+   * Connection string passed via `--database-url`. Used for this run only —
+   * never persisted. See `src/config/database-url.ts`.
+   */
+  databaseUrl?: string
 }
 
 /** Resolved install mode for the Supabase non-Drizzle branch. */
@@ -72,6 +78,14 @@ export async function installCommand(options: InstallOptions) {
     p.outro('Installation aborted.')
     process.exit(1)
   }
+
+  // Resolve DATABASE_URL through the layered chain (flag → env → supabase
+  // status → prompt) and populate process.env so the scaffolded config's
+  // `process.env.DATABASE_URL!` reference resolves on the upcoming load.
+  await resolveDatabaseUrl({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
 
   // Scaffold stash.config.ts if missing. `db install` is the single command
   // that gets a project from zero to installed EQL — no separate setup step

--- a/packages/cli/src/commands/db/install.ts
+++ b/packages/cli/src/commands/db/install.ts
@@ -2,7 +2,6 @@ import { execSync } from 'node:child_process'
 import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import {
   EQLInstaller,
@@ -79,14 +78,6 @@ export async function installCommand(options: InstallOptions) {
     process.exit(1)
   }
 
-  // Resolve DATABASE_URL through the layered chain (flag → env → supabase
-  // status → prompt) and populate process.env so the scaffolded config's
-  // `process.env.DATABASE_URL!` reference resolves on the upcoming load.
-  await resolveDatabaseUrl({
-    databaseUrlFlag: options.databaseUrl,
-    supabase: options.supabase,
-  })
-
   // Scaffold stash.config.ts if missing. `db install` is the single command
   // that gets a project from zero to installed EQL — no separate setup step
   // (CIP-2986).
@@ -98,7 +89,10 @@ export async function installCommand(options: InstallOptions) {
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
   s.stop('Configuration loaded.')
 
   // Safety net: if the user ran `db install` without first running `init`,

--- a/packages/cli/src/commands/db/push.ts
+++ b/packages/cli/src/commands/db/push.ts
@@ -36,12 +36,10 @@ export async function pushCommand(options: {
     'This command pushes the encryption schema to the database for use with CipherStash Proxy.\nIf you are using the SDK directly (Drizzle, Supabase, or plain PostgreSQL), this step is not required.',
   )
 
-  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
-
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({ databaseUrlFlag: options.databaseUrl })
   s.stop('Configuration loaded.')
 
   s.start(`Loading encrypt client from ${config.client}...`)

--- a/packages/cli/src/commands/db/push.ts
+++ b/packages/cli/src/commands/db/push.ts
@@ -27,11 +27,16 @@ function toEqlConfig(config: EncryptConfig): Record<string, unknown> {
   return { v: config.v, tables }
 }
 
-export async function pushCommand(options: { dryRun?: boolean }) {
+export async function pushCommand(options: {
+  dryRun?: boolean
+  databaseUrl?: string
+}) {
   p.intro('npx @cipherstash/cli db push')
   p.log.info(
     'This command pushes the encryption schema to the database for use with CipherStash Proxy.\nIf you are using the SDK directly (Drizzle, Supabase, or plain PostgreSQL), this step is not required.',
   )
+
+  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/db/push.ts
+++ b/packages/cli/src/commands/db/push.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { loadEncryptConfig, loadStashConfig } from '@/config/index.js'
 import type { EncryptConfig } from '@cipherstash/stack/schema'
 import { toEqlCastAs } from '@cipherstash/stack/schema'
@@ -31,7 +32,7 @@ export async function pushCommand(options: {
   dryRun?: boolean
   databaseUrl?: string
 }) {
-  p.intro('npx @cipherstash/cli db push')
+  p.intro(runnerCommand(detectPackageManager(), '@cipherstash/cli db push'))
   p.log.info(
     'This command pushes the encryption schema to the database for use with CipherStash Proxy.\nIf you are using the SDK directly (Drizzle, Supabase, or plain PostgreSQL), this step is not required.',
   )

--- a/packages/cli/src/commands/db/status.ts
+++ b/packages/cli/src/commands/db/status.ts
@@ -1,10 +1,12 @@
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
 import pg from 'pg'
 
 export async function statusCommand(options: { databaseUrl?: string } = {}) {
-  p.intro('npx @cipherstash/cli db status')
+  const pm = detectPackageManager()
+  p.intro(runnerCommand(pm, '@cipherstash/cli db status'))
 
   const s = p.spinner()
 
@@ -42,7 +44,7 @@ export async function statusCommand(options: { databaseUrl?: string } = {}) {
   } else {
     s.stop('EQL is not installed.')
     p.log.warn(
-      'EQL is not installed. Run `npx @cipherstash/cli db install` to install it.',
+      `EQL is not installed. Run \`${runnerCommand(pm, '@cipherstash/cli db install')}\` to install it.`,
     )
     p.outro('Status check complete.')
     return
@@ -102,7 +104,7 @@ export async function statusCommand(options: { databaseUrl?: string } = {}) {
     const message = error instanceof Error ? error.message : String(error)
     if (message.includes('does not exist')) {
       p.log.info(
-        'Active encrypt config: table not found (run `npx @cipherstash/cli db push` to create it)',
+        `Active encrypt config: table not found (run \`${runnerCommand(pm, '@cipherstash/cli db push')}\` to create it)`,
       )
     } else {
       p.log.error(`Failed to check encrypt configuration: ${message}`)

--- a/packages/cli/src/commands/db/status.ts
+++ b/packages/cli/src/commands/db/status.ts
@@ -1,4 +1,3 @@
-import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
@@ -7,12 +6,10 @@ import pg from 'pg'
 export async function statusCommand(options: { databaseUrl?: string } = {}) {
   p.intro('npx @cipherstash/cli db status')
 
-  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
-
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({ databaseUrlFlag: options.databaseUrl })
   s.stop('Configuration loaded.')
 
   const installer = new EQLInstaller({

--- a/packages/cli/src/commands/db/status.ts
+++ b/packages/cli/src/commands/db/status.ts
@@ -1,10 +1,13 @@
+import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
 import pg from 'pg'
 
-export async function statusCommand() {
+export async function statusCommand(options: { databaseUrl?: string } = {}) {
   p.intro('npx @cipherstash/cli db status')
+
+  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
 
   const s = p.spinner()
 
@@ -41,7 +44,9 @@ export async function statusCommand() {
     p.log.success(`EQL installed: yes (version: ${version ?? 'unknown'})`)
   } else {
     s.stop('EQL is not installed.')
-    p.log.warn('EQL is not installed. Run `npx @cipherstash/cli db install` to install it.')
+    p.log.warn(
+      'EQL is not installed. Run `npx @cipherstash/cli db install` to install it.',
+    )
     p.outro('Status check complete.')
     return
   }

--- a/packages/cli/src/commands/db/test-connection.ts
+++ b/packages/cli/src/commands/db/test-connection.ts
@@ -1,9 +1,14 @@
+import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import * as p from '@clack/prompts'
 import pg from 'pg'
 
-export async function testConnectionCommand() {
+export async function testConnectionCommand(
+  options: { databaseUrl?: string } = {},
+) {
   p.intro('npx @cipherstash/cli db test-connection')
+
+  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/db/test-connection.ts
+++ b/packages/cli/src/commands/db/test-connection.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { detectDotenvFile } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import { messages } from '@/messages.js'
@@ -7,7 +8,12 @@ import pg from 'pg'
 export async function testConnectionCommand(
   options: { databaseUrl?: string } = {},
 ) {
-  p.intro('npx @cipherstash/cli db test-connection')
+  p.intro(
+    runnerCommand(
+      detectPackageManager(),
+      '@cipherstash/cli db test-connection',
+    ),
+  )
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/db/test-connection.ts
+++ b/packages/cli/src/commands/db/test-connection.ts
@@ -1,4 +1,3 @@
-import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import * as p from '@clack/prompts'
 import pg from 'pg'
@@ -8,12 +7,10 @@ export async function testConnectionCommand(
 ) {
   p.intro('npx @cipherstash/cli db test-connection')
 
-  await resolveDatabaseUrl({ databaseUrlFlag: options.databaseUrl })
-
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({ databaseUrlFlag: options.databaseUrl })
   s.stop('Configuration loaded.')
 
   const client = new pg.Client({ connectionString: config.databaseUrl })

--- a/packages/cli/src/commands/db/test-connection.ts
+++ b/packages/cli/src/commands/db/test-connection.ts
@@ -1,4 +1,6 @@
+import { detectDotenvFile } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
+import { messages } from '@/messages.js'
 import * as p from '@clack/prompts'
 import pg from 'pg'
 
@@ -47,7 +49,7 @@ export async function testConnectionCommand(
 
     p.log.error(`Failed to connect to database: ${message}`)
     console.log()
-    p.log.info('Check your databaseUrl in stash.config.ts or .env file.')
+    p.log.info(messages.db.urlConnectionFailedHint(detectDotenvFile()))
     process.exit(1)
   } finally {
     await client.end()

--- a/packages/cli/src/commands/db/upgrade.ts
+++ b/packages/cli/src/commands/db/upgrade.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
@@ -9,7 +10,8 @@ export async function upgradeCommand(options: {
   latest?: boolean
   databaseUrl?: string
 }) {
-  p.intro('npx @cipherstash/cli db upgrade')
+  const pm = detectPackageManager()
+  p.intro(runnerCommand(pm, '@cipherstash/cli db upgrade'))
 
   const s = p.spinner()
 
@@ -30,7 +32,7 @@ export async function upgradeCommand(options: {
   if (!installed) {
     s.stop('EQL is not installed.')
     p.log.warn(
-      'EQL is not currently installed. Run "npx @cipherstash/cli db install" first.',
+      `EQL is not currently installed. Run "${runnerCommand(pm, '@cipherstash/cli db install')}" first.`,
     )
     p.outro('Upgrade aborted.')
     process.exit(1)

--- a/packages/cli/src/commands/db/upgrade.ts
+++ b/packages/cli/src/commands/db/upgrade.ts
@@ -1,3 +1,4 @@
+import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
@@ -7,8 +8,14 @@ export async function upgradeCommand(options: {
   supabase?: boolean
   excludeOperatorFamily?: boolean
   latest?: boolean
+  databaseUrl?: string
 }) {
   p.intro('npx @cipherstash/cli db upgrade')
+
+  await resolveDatabaseUrl({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/db/upgrade.ts
+++ b/packages/cli/src/commands/db/upgrade.ts
@@ -1,4 +1,3 @@
-import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadStashConfig } from '@/config/index.js'
 import { EQLInstaller } from '@/installer/index.js'
 import * as p from '@clack/prompts'
@@ -12,15 +11,13 @@ export async function upgradeCommand(options: {
 }) {
   p.intro('npx @cipherstash/cli db upgrade')
 
-  await resolveDatabaseUrl({
-    databaseUrlFlag: options.databaseUrl,
-    supabase: options.supabase,
-  })
-
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
   s.stop('Configuration loaded.')
 
   const installer = new EQLInstaller({

--- a/packages/cli/src/commands/db/validate.ts
+++ b/packages/cli/src/commands/db/validate.ts
@@ -1,3 +1,4 @@
+import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadEncryptConfig, loadStashConfig } from '@/config/index.js'
 import type { EncryptConfig } from '@cipherstash/stack/schema'
 import * as p from '@clack/prompts'
@@ -12,7 +13,17 @@ interface ValidationIssue {
 }
 
 /** Cast-as types that are not string-like — free-text search is meaningless for these. */
-const NON_STRING_CAST_TYPES = new Set(['int', 'small_int', 'big_int', 'real', 'double', 'boolean', 'date', 'number', 'bigint'])
+const NON_STRING_CAST_TYPES = new Set([
+  'int',
+  'small_int',
+  'big_int',
+  'real',
+  'double',
+  'boolean',
+  'date',
+  'number',
+  'bigint',
+])
 
 /**
  * Validate an EncryptConfig against common misconfiguration rules.
@@ -137,8 +148,14 @@ export function reportIssues(issues: ValidationIssue[]): boolean {
 export async function validateCommand(options: {
   supabase?: boolean
   excludeOperatorFamily?: boolean
+  databaseUrl?: string
 }) {
   p.intro('npx @cipherstash/cli db validate')
+
+  await resolveDatabaseUrl({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/db/validate.ts
+++ b/packages/cli/src/commands/db/validate.ts
@@ -1,4 +1,3 @@
-import { resolveDatabaseUrl } from '@/config/database-url.js'
 import { loadEncryptConfig, loadStashConfig } from '@/config/index.js'
 import type { EncryptConfig } from '@cipherstash/stack/schema'
 import * as p from '@clack/prompts'
@@ -152,15 +151,13 @@ export async function validateCommand(options: {
 }) {
   p.intro('npx @cipherstash/cli db validate')
 
-  await resolveDatabaseUrl({
-    databaseUrlFlag: options.databaseUrl,
-    supabase: options.supabase,
-  })
-
   const s = p.spinner()
 
   s.start('Loading stash.config.ts...')
-  const config = await loadStashConfig()
+  const config = await loadStashConfig({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
   s.stop('Configuration loaded.')
 
   s.start(`Loading encrypt client from ${config.client}...`)

--- a/packages/cli/src/commands/db/validate.ts
+++ b/packages/cli/src/commands/db/validate.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager, runnerCommand } from '@/commands/init/utils.js'
 import { loadEncryptConfig, loadStashConfig } from '@/config/index.js'
 import type { EncryptConfig } from '@cipherstash/stack/schema'
 import * as p from '@clack/prompts'
@@ -149,7 +150,7 @@ export async function validateCommand(options: {
   excludeOperatorFamily?: boolean
   databaseUrl?: string
 }) {
-  p.intro('npx @cipherstash/cli db validate')
+  p.intro(runnerCommand(detectPackageManager(), '@cipherstash/cli db validate'))
 
   const s = p.spinner()
 

--- a/packages/cli/src/commands/schema/build.ts
+++ b/packages/cli/src/commands/schema/build.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import * as p from '@clack/prompts'
 import pg from 'pg'
+import { resolveDatabaseUrl } from '../../config/database-url.js'
 import { loadStashConfig } from '../../config/index.js'
 
 type Integration = 'drizzle' | 'supabase' | 'postgresql'
@@ -118,7 +119,6 @@ function drizzleTsType(dataType: string): string {
   }
 }
 
-
 function generateClientFromSchemas(
   integration: Integration,
   schemas: SchemaDef[],
@@ -167,9 +167,7 @@ ${columnDefs.join('\n')}
 const ${schemaVarName} = extractEncryptionSchema(${varName})`
   })
 
-  const schemaVarNames = schemas.map(
-    (s) => `${toCamelCase(s.tableName)}Schema`,
-  )
+  const schemaVarNames = schemas.map((s) => `${toCamelCase(s.tableName)}Schema`)
 
   return `import { pgTable, integer, timestamp } from 'drizzle-orm/pg-core'
 import { encryptedType, extractEncryptionSchema } from '@cipherstash/stack/drizzle'
@@ -206,9 +204,7 @@ ${columnDefs.join('\n')}
 })`
   })
 
-  const tableVarNames = schemas.map(
-    (s) => `${toCamelCase(s.tableName)}Table`,
-  )
+  const tableVarNames = schemas.map((s) => `${toCamelCase(s.tableName)}Table`)
 
   return `import { encryptedTable, encryptedColumn } from '@cipherstash/stack/schema'
 import { Encryption } from '@cipherstash/stack'
@@ -340,7 +336,13 @@ async function buildSchemasFromDatabase(
 
 // --- Command ---
 
-export async function builderCommand(options: { supabase?: boolean } = {}) {
+export async function builderCommand(
+  options: { supabase?: boolean; databaseUrl?: string } = {},
+) {
+  await resolveDatabaseUrl({
+    databaseUrlFlag: options.databaseUrl,
+    supabase: options.supabase,
+  })
   const config = await loadStashConfig()
 
   p.intro('CipherStash Schema Builder')

--- a/packages/cli/src/commands/schema/build.ts
+++ b/packages/cli/src/commands/schema/build.ts
@@ -2,7 +2,6 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import * as p from '@clack/prompts'
 import pg from 'pg'
-import { resolveDatabaseUrl } from '../../config/database-url.js'
 import { loadStashConfig } from '../../config/index.js'
 
 type Integration = 'drizzle' | 'supabase' | 'postgresql'
@@ -339,11 +338,10 @@ async function buildSchemasFromDatabase(
 export async function builderCommand(
   options: { supabase?: boolean; databaseUrl?: string } = {},
 ) {
-  await resolveDatabaseUrl({
+  const config = await loadStashConfig({
     databaseUrlFlag: options.databaseUrl,
     supabase: options.supabase,
   })
-  const config = await loadStashConfig()
 
   p.intro('CipherStash Schema Builder')
 

--- a/packages/cli/src/config/database-url.ts
+++ b/packages/cli/src/config/database-url.ts
@@ -197,7 +197,10 @@ export async function resolveDatabaseUrl(
   }
 
   // 4. Interactive prompt — skipped in CI / non-TTY.
-  const isCi = process.env.CI === 'true'
+  // Accept the common CI-truthy spellings (`true`, `1`, case-insensitive)
+  // since not every CI provider sets `CI=true` exactly.
+  const ciVar = process.env.CI?.trim()
+  const isCi = ciVar !== undefined && /^(1|true)$/i.test(ciVar)
   const isInteractive = Boolean(process.stdin.isTTY) && !isCi
   if (isInteractive) {
     const fromPrompt = await promptForUrl(cwd)

--- a/packages/cli/src/config/database-url.ts
+++ b/packages/cli/src/config/database-url.ts
@@ -1,33 +1,45 @@
 /**
- * Layered DATABASE_URL resolution for DB-touching CLI commands.
+ * Layered DATABASE_URL resolution. Called from inside the user's
+ * `stash.config.ts` via:
  *
- * The scaffolded `stash.config.ts` always references `process.env.DATABASE_URL`
- * (see `commands/db/config-scaffold.ts`). When users haven't already exported
- * the var (or written it to one of the dotenv files we auto-load in
- * `bin/stash.ts`), we walk a chain of fallback sources and populate
- * `process.env.DATABASE_URL` in-process so the existing `loadStashConfig`
- * path Just Works. The connection string is never written to disk by this
- * resolver — `stash.config.ts` keeps its declarative env reference.
+ *   import { defineConfig, resolveDatabaseUrl } from '@cipherstash/cli'
+ *   export default defineConfig({
+ *     databaseUrl: await resolveDatabaseUrl(),
+ *   })
  *
- * Source order (first hit wins; later sources fall through silently if a
- * prior source errors transiently):
+ * The CLI's `loadStashConfig` wraps the jiti-import in
+ * `withResolverContext({ databaseUrlFlag, supabase })` (an
+ * `AsyncLocalStorage` scope) before evaluating the config file. Any
+ * `resolveDatabaseUrl()` call inside the file then sees those options
+ * via `als.getStore()` and walks:
+ *
  *   1. `--database-url <url>` flag (explicit override).
- *   2. `process.env.DATABASE_URL` (shell, mise, direnv, dotenv files).
- *   3. `supabase status --output env` → `DB_URL`, when `--supabase` is set
- *      OR a `supabase/config.toml` is detected.
- *   4. Interactive `p.text` prompt (skipped under `CI=true` or non-TTY stdin).
+ *   2. `process.env.DATABASE_URL` (shell, mise, direnv, dotenv files
+ *      loaded by `bin/stash.ts`).
+ *   3. `supabase status --output env` → `DB_URL`, when `--supabase` is
+ *      set OR a `supabase/config.toml` is detected.
+ *   4. Interactive `p.text` prompt (skipped under `CI=true` or non-TTY
+ *      stdin).
+ *   5. Hard-fail with a source-naming error.
  *
- * If all sources fail, exits 1 with a message naming each source tried.
+ * Returns the resolved URL string. The CLI never mutates
+ * `process.env.DATABASE_URL` — the URL is only carried in the value
+ * `defineConfig` returns. The connection string is never persisted to
+ * disk; `stash.config.ts` references this function, not a literal.
+ *
+ * Concurrency: the ALS context is per-async-flow, so multiple
+ * concurrent `loadStashConfig` calls (e.g. parallel test cases or a
+ * programmatic batch invocation) each get isolated options without
+ * stepping on each other.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import * as p from '@clack/prompts'
 import { detectSupabaseProject } from '../commands/db/detect.js'
 import { messages } from '../messages.js'
-
-export type DatabaseUrlSource = 'flag' | 'env' | 'supabase-status' | 'prompt'
 
 export interface ResolveDatabaseUrlOptions {
   /** Value of `--database-url` if the user passed one. */
@@ -38,9 +50,40 @@ export interface ResolveDatabaseUrlOptions {
   cwd?: string
 }
 
-export interface ResolveDatabaseUrlResult {
-  url: string
-  source: DatabaseUrlSource
+// The CLI ships as two tsup bundles (`dist/index.js` for the library and
+// `dist/bin/stash.js` for the binary), each of which contains its own copy
+// of this file. A bare `new AsyncLocalStorage()` would therefore produce
+// two independent stores: the CLI sets context on the binary's instance,
+// the user's config (loaded via jiti from inside the binary process)
+// imports from the library bundle and reads from a different instance, so
+// nothing propagates. Rendezvous via a `Symbol.for`-keyed slot on
+// `globalThis` so both bundles share a single ALS for the lifetime of the
+// process. Behaviour is identical to a plain module-level `als` — the
+// concurrency guarantees come from `AsyncLocalStorage`, not from where
+// the instance is parked.
+const ALS_KEY = Symbol.for('cipherstash.cli.database-url-als')
+type AlsHolder = {
+  [ALS_KEY]?: AsyncLocalStorage<ResolveDatabaseUrlOptions>
+}
+const alsHolder = globalThis as AlsHolder
+if (!alsHolder[ALS_KEY]) {
+  alsHolder[ALS_KEY] = new AsyncLocalStorage<ResolveDatabaseUrlOptions>()
+}
+const als = alsHolder[ALS_KEY]
+
+/**
+ * Run `fn` inside an ALS scope that exposes `opts` to any
+ * `resolveDatabaseUrl()` call descendant from this async-flow.
+ *
+ * Used by `loadStashConfig` to thread CLI flag values into the user's
+ * config evaluation without mutating `process.env` or any other shared
+ * state.
+ */
+export function withResolverContext<T>(
+  opts: ResolveDatabaseUrlOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return als.run(opts, fn)
 }
 
 /** Walk dotenv precedence and pick the first existing file. Defaults to `.env`. */
@@ -68,7 +111,6 @@ function isUrlParseable(value: string): boolean {
 
 /** Try to extract a `DB_URL=...` value from `supabase status --output env`. */
 function trySupabaseStatus(): string | undefined {
-  // Two invocation forms in case the user has supabase locally vs. only via npx.
   const candidates = [
     ['supabase', ['status', '--output', 'env']],
     ['npx', ['--no-install', 'supabase', 'status', '--output', 'env']],
@@ -81,9 +123,6 @@ function trySupabaseStatus(): string | undefined {
         stdio: ['ignore', 'pipe', 'ignore'],
         timeout: 5_000,
       })
-      // `supabase status --output env` emits shell-style KEY=value lines.
-      // The variable name has historically been `DB_URL` but defensive parse
-      // is cheap.
       const match = out.match(/^(?:DB_URL|db_url)=(?:"([^"]+)"|(\S+))/m)
       const value = match?.[1] ?? match?.[2]
       if (value && isUrlParseable(value)) return value
@@ -95,6 +134,11 @@ function trySupabaseStatus(): string | undefined {
 }
 
 async function promptForUrl(): Promise<string | undefined> {
+  // Surface the alternative paths before prompting so users don't feel
+  // like they're stuck in an interactive flow when a flag or env var
+  // would do.
+  p.note(messages.db.urlPromptTip)
+
   const value = await p.text({
     message: messages.db.urlPromptMessage,
     validate: (v) => {
@@ -111,48 +155,43 @@ async function promptForUrl(): Promise<string | undefined> {
 }
 
 /**
- * Resolve a usable DATABASE_URL through the layered chain. On success,
- * mutates `process.env.DATABASE_URL` (only when previously unset/empty, or
- * when the source was an explicit `--database-url` flag) so downstream
- * config loading sees a populated env. Returns the resolved URL plus its
- * source for logging.
+ * Walk the resolution chain and return a usable DATABASE_URL. Reads
+ * options from the surrounding `withResolverContext` scope (set by the
+ * CLI before evaluating the config file); any explicit `opts` passed
+ * here override the scoped values.
  *
  * Exits 1 when no source resolves a URL.
  */
 export async function resolveDatabaseUrl(
-  options: ResolveDatabaseUrlOptions = {},
-): Promise<ResolveDatabaseUrlResult> {
-  const cwd = options.cwd ?? process.cwd()
+  opts: ResolveDatabaseUrlOptions = {},
+): Promise<string> {
+  const ctx: ResolveDatabaseUrlOptions = { ...als.getStore(), ...opts }
+  const cwd = ctx.cwd ?? process.cwd()
 
   // 1. Flag.
-  if (options.databaseUrlFlag !== undefined) {
-    const trimmed = options.databaseUrlFlag.trim()
+  if (ctx.databaseUrlFlag !== undefined) {
+    const trimmed = ctx.databaseUrlFlag.trim()
     if (!trimmed || !isUrlParseable(trimmed)) {
       p.log.error(messages.db.urlFlagMalformed)
       process.exit(1)
     }
-    // Explicit override always wins — overwrite env so the rest of this
-    // process sees the user's intended URL.
-    process.env.DATABASE_URL = trimmed
     p.log.info(messages.db.urlResolvedFromFlag)
-    return { url: trimmed, source: 'flag' }
+    return trimmed
   }
 
-  // 2. Existing env (covers shell, mise, direnv, dotenv loads in bin/stash.ts).
+  // 2. Existing env (shell, mise, direnv, dotenv files).
   const fromEnv = process.env.DATABASE_URL?.trim()
   if (fromEnv && fromEnv.length > 0) {
-    return { url: fromEnv, source: 'env' }
+    return fromEnv
   }
 
-  // 3. Supabase fallback — only if the user opted in or the project clearly is one.
+  // 3. Supabase fallback — opted-in, or the project clearly is one.
   const supabaseProject = detectSupabaseProject(cwd)
-  if (options.supabase || supabaseProject.hasConfigToml) {
+  if (ctx.supabase || supabaseProject.hasConfigToml) {
     const fromSupabase = trySupabaseStatus()
     if (fromSupabase) {
-      // Mutate env only when previously unset (this branch implies it was).
-      process.env.DATABASE_URL = fromSupabase
       p.log.info(messages.db.urlResolvedFromSupabase)
-      return { url: fromSupabase, source: 'supabase-status' }
+      return fromSupabase
     }
   }
 
@@ -162,12 +201,10 @@ export async function resolveDatabaseUrl(
   if (isInteractive) {
     const fromPrompt = await promptForUrl()
     if (fromPrompt) {
-      process.env.DATABASE_URL = fromPrompt
       p.log.info(messages.db.urlResolvedFromPrompt)
-      // Nudge the user toward making this stick. detectDotenvFile picks the
-      // first file already present, defaulting to `.env`.
+      // Hint the user toward making it stick so they don't get re-prompted.
       p.note(messages.db.urlHint(detectDotenvFile(cwd)))
-      return { url: fromPrompt, source: 'prompt' }
+      return fromPrompt
     }
   }
 

--- a/packages/cli/src/config/database-url.ts
+++ b/packages/cli/src/config/database-url.ts
@@ -1,0 +1,179 @@
+/**
+ * Layered DATABASE_URL resolution for DB-touching CLI commands.
+ *
+ * The scaffolded `stash.config.ts` always references `process.env.DATABASE_URL`
+ * (see `commands/db/config-scaffold.ts`). When users haven't already exported
+ * the var (or written it to one of the dotenv files we auto-load in
+ * `bin/stash.ts`), we walk a chain of fallback sources and populate
+ * `process.env.DATABASE_URL` in-process so the existing `loadStashConfig`
+ * path Just Works. The connection string is never written to disk by this
+ * resolver — `stash.config.ts` keeps its declarative env reference.
+ *
+ * Source order (first hit wins; later sources fall through silently if a
+ * prior source errors transiently):
+ *   1. `--database-url <url>` flag (explicit override).
+ *   2. `process.env.DATABASE_URL` (shell, mise, direnv, dotenv files).
+ *   3. `supabase status --output env` → `DB_URL`, when `--supabase` is set
+ *      OR a `supabase/config.toml` is detected.
+ *   4. Interactive `p.text` prompt (skipped under `CI=true` or non-TTY stdin).
+ *
+ * If all sources fail, exits 1 with a message naming each source tried.
+ */
+
+import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import * as p from '@clack/prompts'
+import { detectSupabaseProject } from '../commands/db/detect.js'
+import { messages } from '../messages.js'
+
+export type DatabaseUrlSource = 'flag' | 'env' | 'supabase-status' | 'prompt'
+
+export interface ResolveDatabaseUrlOptions {
+  /** Value of `--database-url` if the user passed one. */
+  databaseUrlFlag?: string
+  /** Value of `--supabase` flag. Triggers the supabase-status fallback. */
+  supabase?: boolean
+  /** Override cwd for project detection (mainly for tests). */
+  cwd?: string
+}
+
+export interface ResolveDatabaseUrlResult {
+  url: string
+  source: DatabaseUrlSource
+}
+
+/** Walk dotenv precedence and pick the first existing file. Defaults to `.env`. */
+function detectDotenvFile(cwd: string): string {
+  const candidates = [
+    '.env.local',
+    '.env.development.local',
+    '.env.development',
+    '.env',
+  ]
+  for (const file of candidates) {
+    if (existsSync(join(cwd, file))) return file
+  }
+  return '.env'
+}
+
+function isUrlParseable(value: string): boolean {
+  try {
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Try to extract a `DB_URL=...` value from `supabase status --output env`. */
+function trySupabaseStatus(): string | undefined {
+  // Two invocation forms in case the user has supabase locally vs. only via npx.
+  const candidates = [
+    ['supabase', ['status', '--output', 'env']],
+    ['npx', ['--no-install', 'supabase', 'status', '--output', 'env']],
+  ] as const
+
+  for (const [cmd, args] of candidates) {
+    try {
+      const out = execSync(`${cmd} ${args.join(' ')}`, {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5_000,
+      })
+      // `supabase status --output env` emits shell-style KEY=value lines.
+      // The variable name has historically been `DB_URL` but defensive parse
+      // is cheap.
+      const match = out.match(/^(?:DB_URL|db_url)=(?:"([^"]+)"|(\S+))/m)
+      const value = match?.[1] ?? match?.[2]
+      if (value && isUrlParseable(value)) return value
+    } catch {
+      // binary missing, project not started, parse error — fall through.
+    }
+  }
+  return undefined
+}
+
+async function promptForUrl(): Promise<string | undefined> {
+  const value = await p.text({
+    message: messages.db.urlPromptMessage,
+    validate: (v) => {
+      if (!v || v.trim().length === 0) return messages.db.urlInvalid
+      if (!isUrlParseable(v.trim())) return messages.db.urlInvalid
+      return undefined
+    },
+  })
+  if (p.isCancel(value)) {
+    p.cancel(messages.auth.cancelled)
+    process.exit(0)
+  }
+  return value.trim()
+}
+
+/**
+ * Resolve a usable DATABASE_URL through the layered chain. On success,
+ * mutates `process.env.DATABASE_URL` (only when previously unset/empty, or
+ * when the source was an explicit `--database-url` flag) so downstream
+ * config loading sees a populated env. Returns the resolved URL plus its
+ * source for logging.
+ *
+ * Exits 1 when no source resolves a URL.
+ */
+export async function resolveDatabaseUrl(
+  options: ResolveDatabaseUrlOptions = {},
+): Promise<ResolveDatabaseUrlResult> {
+  const cwd = options.cwd ?? process.cwd()
+
+  // 1. Flag.
+  if (options.databaseUrlFlag !== undefined) {
+    const trimmed = options.databaseUrlFlag.trim()
+    if (!trimmed || !isUrlParseable(trimmed)) {
+      p.log.error(messages.db.urlFlagMalformed)
+      process.exit(1)
+    }
+    // Explicit override always wins — overwrite env so the rest of this
+    // process sees the user's intended URL.
+    process.env.DATABASE_URL = trimmed
+    p.log.info(messages.db.urlResolvedFromFlag)
+    return { url: trimmed, source: 'flag' }
+  }
+
+  // 2. Existing env (covers shell, mise, direnv, dotenv loads in bin/stash.ts).
+  const fromEnv = process.env.DATABASE_URL?.trim()
+  if (fromEnv && fromEnv.length > 0) {
+    return { url: fromEnv, source: 'env' }
+  }
+
+  // 3. Supabase fallback — only if the user opted in or the project clearly is one.
+  const supabaseProject = detectSupabaseProject(cwd)
+  if (options.supabase || supabaseProject.hasConfigToml) {
+    const fromSupabase = trySupabaseStatus()
+    if (fromSupabase) {
+      // Mutate env only when previously unset (this branch implies it was).
+      process.env.DATABASE_URL = fromSupabase
+      p.log.info(messages.db.urlResolvedFromSupabase)
+      return { url: fromSupabase, source: 'supabase-status' }
+    }
+  }
+
+  // 4. Interactive prompt — skipped in CI / non-TTY.
+  const isCi = process.env.CI === 'true'
+  const isInteractive = Boolean(process.stdin.isTTY) && !isCi
+  if (isInteractive) {
+    const fromPrompt = await promptForUrl()
+    if (fromPrompt) {
+      process.env.DATABASE_URL = fromPrompt
+      p.log.info(messages.db.urlResolvedFromPrompt)
+      // Nudge the user toward making this stick. detectDotenvFile picks the
+      // first file already present, defaulting to `.env`.
+      p.note(messages.db.urlHint(detectDotenvFile(cwd)))
+      return { url: fromPrompt, source: 'prompt' }
+    }
+  }
+
+  // 5. Hard fail.
+  p.log.error(
+    isCi ? messages.db.urlMissingCi : messages.db.urlMissingInteractive,
+  )
+  process.exit(1)
+}

--- a/packages/cli/src/config/database-url.ts
+++ b/packages/cli/src/config/database-url.ts
@@ -87,7 +87,7 @@ export function withResolverContext<T>(
 }
 
 /** Walk dotenv precedence and pick the first existing file. Defaults to `.env`. */
-function detectDotenvFile(cwd: string): string {
+export function detectDotenvFile(cwd: string = process.cwd()): string {
   const candidates = [
     '.env.local',
     '.env.development.local',
@@ -133,11 +133,12 @@ function trySupabaseStatus(): string | undefined {
   return undefined
 }
 
-async function promptForUrl(): Promise<string | undefined> {
+async function promptForUrl(cwd: string): Promise<string | undefined> {
   // Surface the alternative paths before prompting so users don't feel
   // like they're stuck in an interactive flow when a flag or env var
-  // would do.
-  p.note(messages.db.urlPromptTip)
+  // would do. The dotenv file in the tip is detected from cwd so it
+  // matches what the user actually has (`.env.local` vs `.env` etc.).
+  p.note(messages.db.urlPromptTip(detectDotenvFile(cwd)))
 
   const value = await p.text({
     message: messages.db.urlPromptMessage,
@@ -199,7 +200,7 @@ export async function resolveDatabaseUrl(
   const isCi = process.env.CI === 'true'
   const isInteractive = Boolean(process.stdin.isTTY) && !isCi
   if (isInteractive) {
-    const fromPrompt = await promptForUrl()
+    const fromPrompt = await promptForUrl(cwd)
     if (fromPrompt) {
       p.log.info(messages.db.urlResolvedFromPrompt)
       // Hint the user toward making it stick so they don't get re-prompted.

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -3,6 +3,10 @@ import path from 'node:path'
 import type { EncryptionClient } from '@cipherstash/stack/encryption'
 import type { EncryptConfig } from '@cipherstash/stack/schema'
 import { z } from 'zod'
+import {
+  type ResolveDatabaseUrlOptions,
+  withResolverContext,
+} from './database-url.js'
 
 export interface StashConfig {
   /** PostgreSQL connection string */
@@ -77,9 +81,18 @@ function findConfigFile(startDir: string): string | undefined {
  * Searches from `process.cwd()` upward. Uses `jiti` to evaluate the
  * TypeScript config file at runtime without a separate compile step.
  *
+ * The optional `resolverOptions` argument is threaded into an
+ * `AsyncLocalStorage` scope around the jiti-import call, so that any
+ * `await resolveDatabaseUrl()` inside the user's config file picks up
+ * `--database-url` / `--supabase` flag values from the surrounding CLI
+ * command. This is how the CLI passes flag context into config
+ * evaluation without mutating `process.env` or relying on globals.
+ *
  * Exits with code 1 if the config file is not found or fails validation.
  */
-export async function loadStashConfig(): Promise<ResolvedStashConfig> {
+export async function loadStashConfig(
+  resolverOptions: ResolveDatabaseUrlOptions = {},
+): Promise<ResolvedStashConfig> {
   const configPath = findConfigFile(process.cwd())
 
   if (!configPath) {
@@ -87,10 +100,10 @@ export async function loadStashConfig(): Promise<ResolvedStashConfig> {
 
 Create a ${CONFIG_FILENAME} file in your project root:
 
-  import { defineConfig } from '@cipherstash/cli'
+  import { defineConfig, resolveDatabaseUrl } from '@cipherstash/cli'
 
   export default defineConfig({
-    databaseUrl: process.env.DATABASE_URL!,
+    databaseUrl: await resolveDatabaseUrl(),
   })
 `)
     process.exit(1)
@@ -109,7 +122,9 @@ Create a ${CONFIG_FILENAME} file in your project root:
     // wrapper would then fail Zod validation with a misleading
     // "databaseUrl: received undefined" even when the user's config sets
     // it (#374).
-    rawConfig = await jiti.import(configPath, { default: true })
+    rawConfig = await withResolverContext(resolverOptions, () =>
+      jiti.import(configPath, { default: true }),
+    )
   } catch (error) {
     console.error(`Error: Failed to load ${CONFIG_FILENAME} at ${configPath}\n`)
     console.error(error)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,8 @@
 
 export { defineConfig, loadStashConfig } from './config/index.ts'
 export type { StashConfig } from './config/index.ts'
+export { resolveDatabaseUrl } from './config/database-url.ts'
+export type { ResolveDatabaseUrlOptions } from './config/database-url.ts'
 export {
   EQLInstaller,
   loadBundledEqlSql,

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -25,5 +25,20 @@ export const messages = {
     unknownSubcommand: 'Unknown db subcommand',
     migrateNotImplemented:
       '"npx @cipherstash/cli db migrate" is not yet implemented.',
+    /** Source labels surfaced after DATABASE_URL resolution. */
+    urlResolvedFromFlag: 'Using DATABASE_URL from --database-url flag',
+    urlResolvedFromSupabase: 'Using DATABASE_URL from supabase status',
+    urlResolvedFromPrompt: 'Using DATABASE_URL from prompt',
+    urlPromptMessage: 'Paste your DATABASE_URL',
+    urlInvalid: 'Not a valid URL',
+    urlFlagMalformed:
+      'Invalid --database-url: not a parseable connection string',
+    urlMissingCi:
+      'Cannot resolve DATABASE_URL in CI. Pass --database-url or set DATABASE_URL.',
+    urlMissingInteractive:
+      'Cannot resolve DATABASE_URL. Pass --database-url, set DATABASE_URL in your environment, or run `supabase start` if this is a Supabase project.',
+    /** Nudge shown after a prompt-sourced run completes. */
+    urlHint: (file: string) =>
+      `Set DATABASE_URL in ${file} to skip this prompt next time.`,
   },
 } as const

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -30,9 +30,20 @@ export const messages = {
     urlResolvedFromSupabase: 'Using DATABASE_URL from supabase status',
     urlResolvedFromPrompt: 'Using DATABASE_URL from prompt',
     urlPromptMessage: 'Paste your DATABASE_URL',
-    /** Shown immediately before the URL prompt to surface alternatives. */
-    urlPromptTip:
-      'Tip: you can also pass --database-url <url> on the command line, or set DATABASE_URL in your environment / .env file.',
+    /**
+     * Shown immediately before the URL prompt to surface alternatives.
+     * `dotenvFile` is the first existing dotenv file in the project (or
+     * `.env` as the default) so the suggestion matches the user's setup.
+     */
+    urlPromptTip: (dotenvFile: string) =>
+      `Tip: you can also pass --database-url <url> on the command line, or set DATABASE_URL in your environment / ${dotenvFile} file.`,
+    /**
+     * Shown when a connection attempt fails — points the user at where
+     * to fix the URL. Same dotenv detection as `urlPromptTip` so the
+     * suggestion matches their setup.
+     */
+    urlConnectionFailedHint: (dotenvFile: string) =>
+      `Check that DATABASE_URL is correct. You can pass --database-url <url> on the command line, set DATABASE_URL in your environment, or write it to ${dotenvFile}.`,
     urlInvalid: 'Not a valid URL',
     urlFlagMalformed:
       'Invalid --database-url: not a parseable connection string',

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -30,6 +30,9 @@ export const messages = {
     urlResolvedFromSupabase: 'Using DATABASE_URL from supabase status',
     urlResolvedFromPrompt: 'Using DATABASE_URL from prompt',
     urlPromptMessage: 'Paste your DATABASE_URL',
+    /** Shown immediately before the URL prompt to surface alternatives. */
+    urlPromptTip:
+      'Tip: you can also pass --database-url <url> on the command line, or set DATABASE_URL in your environment / .env file.',
     urlInvalid: 'Not a valid URL',
     urlFlagMalformed:
       'Invalid --database-url: not a parseable connection string',

--- a/packages/cli/tests/e2e/database-url.e2e.test.ts
+++ b/packages/cli/tests/e2e/database-url.e2e.test.ts
@@ -1,30 +1,32 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { messages } from '../../src/messages.js'
 import { render } from '../helpers/pty.js'
 
-/**
- * E2E coverage for the layered DATABASE_URL resolver. Each case spawns the
- * built `dist/bin/stash.js` and exercises a single resolution path —
- * `--database-url` flag, env, and the CI-guard fail-fast.
- *
- * The pty harness always provides a TTY, so the non-TTY path is covered by
- * the unit suite's `Object.defineProperty(process.stdin, 'isTTY', false)`
- * test in `src/__tests__/database-url.test.ts`.
- */
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Absolute path to the built CLI's `dist/index.js`. The test config imports
+// from this path because the tmp dir doesn't have a node_modules with
+// `@cipherstash/cli` symlinked. Real users get a clean
+// `import { resolveDatabaseUrl } from '@cipherstash/cli'`.
+const CLI_DIST_INDEX = path.resolve(__dirname, '../../dist/index.js')
+
 describe('db test-connection — DATABASE_URL resolver', () => {
   let tmpDir: string
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-db-url-e2e-'))
-    // A scaffold-shaped config that defers to env. The resolver populates
-    // env in-process before loadStashConfig runs.
+    // Config calls resolveDatabaseUrl() at evaluation time. The CLI's
+    // loadStashConfig wraps the jiti-import in withResolverContext so the
+    // function picks up `--database-url` / `--supabase` flags.
     fs.writeFileSync(
       path.join(tmpDir, 'stash.config.ts'),
-      `export default {
-         databaseUrl: process.env.DATABASE_URL,
+      `import { resolveDatabaseUrl } from '${CLI_DIST_INDEX}'
+       export default {
+         databaseUrl: await resolveDatabaseUrl(),
        }`,
     )
   })
@@ -37,8 +39,8 @@ describe('db test-connection — DATABASE_URL resolver', () => {
 
   it('uses --database-url flag and surfaces the source label', async () => {
     // Bogus host:port — connection will fail after the resolver succeeds.
-    // The test asserts on the log line + non-zero exit, NOT on the specific
-    // connection error (avoids flake if the port happens to be in use).
+    // The test asserts on the log line + non-zero exit, NOT on the
+    // specific connection error (avoids flake if the port is in use).
     const r = render(
       [
         'db',
@@ -53,6 +55,10 @@ describe('db test-connection — DATABASE_URL resolver', () => {
     const { exitCode } = await r.exit
     expect(exitCode).not.toBe(0)
     expect(r.output).toContain(messages.db.urlResolvedFromFlag)
+    // Belt-and-braces: the URL itself must never appear except where the
+    // user typed it (here, on argv — but the spawned process's logs
+    // shouldn't echo it back).
+    expect(r.output).not.toContain('postgresql://x:x@127.0.0.1:1/x')
   })
 
   it('CI=true with no DATABASE_URL and no flag exits 1 with the CI message', async () => {

--- a/packages/cli/tests/e2e/database-url.e2e.test.ts
+++ b/packages/cli/tests/e2e/database-url.e2e.test.ts
@@ -59,6 +59,13 @@ describe('db test-connection — DATABASE_URL resolver', () => {
     // user typed it (here, on argv — but the spawned process's logs
     // shouldn't echo it back).
     expect(r.output).not.toContain('postgresql://x:x@127.0.0.1:1/x')
+    // Connection failed → the failure hint should point users at the
+    // sources they can actually fix (flag / env / dotenv file). The tmp
+    // dir has no dotenv files so the hint defaults to `.env`. The OLD
+    // misleading "Check your databaseUrl in stash.config.ts" message
+    // must NOT appear — the URL doesn't live in that file anymore.
+    expect(r.output).toContain(messages.db.urlConnectionFailedHint('.env'))
+    expect(r.output).not.toContain('stash.config.ts or .env file')
   })
 
   it('CI=true with no DATABASE_URL and no flag exits 1 with the CI message', async () => {

--- a/packages/cli/tests/e2e/database-url.e2e.test.ts
+++ b/packages/cli/tests/e2e/database-url.e2e.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { messages } from '../../src/messages.js'
+import { render } from '../helpers/pty.js'
+
+/**
+ * E2E coverage for the layered DATABASE_URL resolver. Each case spawns the
+ * built `dist/bin/stash.js` and exercises a single resolution path —
+ * `--database-url` flag, env, and the CI-guard fail-fast.
+ *
+ * The pty harness always provides a TTY, so the non-TTY path is covered by
+ * the unit suite's `Object.defineProperty(process.stdin, 'isTTY', false)`
+ * test in `src/__tests__/database-url.test.ts`.
+ */
+describe('db test-connection — DATABASE_URL resolver', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-db-url-e2e-'))
+    // A scaffold-shaped config that defers to env. The resolver populates
+    // env in-process before loadStashConfig runs.
+    fs.writeFileSync(
+      path.join(tmpDir, 'stash.config.ts'),
+      `export default {
+         databaseUrl: process.env.DATABASE_URL,
+       }`,
+    )
+  })
+
+  afterEach(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses --database-url flag and surfaces the source label', async () => {
+    // Bogus host:port — connection will fail after the resolver succeeds.
+    // The test asserts on the log line + non-zero exit, NOT on the specific
+    // connection error (avoids flake if the port happens to be in use).
+    const r = render(
+      [
+        'db',
+        'test-connection',
+        '--database-url',
+        'postgresql://x:x@127.0.0.1:1/x',
+      ],
+      { cwd: tmpDir, env: { CI: 'false', DATABASE_URL: '' } },
+    )
+
+    await r.waitFor(messages.db.urlResolvedFromFlag, 10_000)
+    const { exitCode } = await r.exit
+    expect(exitCode).not.toBe(0)
+    expect(r.output).toContain(messages.db.urlResolvedFromFlag)
+  })
+
+  it('CI=true with no DATABASE_URL and no flag exits 1 with the CI message', async () => {
+    const r = render(['db', 'test-connection'], {
+      cwd: tmpDir,
+      env: { CI: 'true', DATABASE_URL: '' },
+    })
+
+    const { exitCode } = await r.exit
+    expect(exitCode).toBe(1)
+    expect(r.output).toContain(messages.db.urlMissingCi)
+  })
+})


### PR DESCRIPTION
Closes #376. Stacks on top of #375 (jiti default-export unwrap fix) — both together deliver the full onboarding experience.

## Problem

Running any DB-touching command without `DATABASE_URL` exported in the shell or in a loaded `.env*` file fails with the cryptic Zod error:

```
Error: Invalid stash.config.ts
  - databaseUrl: Invalid input: expected nonoptional, received undefined
```

Users provide DB URLs through many channels: `--database-url` flag, shell exports, `mise.toml`, `direnv`, `dotenv-cli`, local Supabase, or simply "let me paste it once". The CLI handled only the dotenv path.

## Fix

The scaffolded `stash.config.ts` now calls the resolver directly:

```ts
import { defineConfig, resolveDatabaseUrl } from '@cipherstash/cli'

export default defineConfig({
  databaseUrl: await resolveDatabaseUrl(),
  client: './src/encryption/index.ts',
})
```

`resolveDatabaseUrl()` walks sources in order; first hit wins:

1. `--database-url <url>` flag (explicit override)
2. `process.env.DATABASE_URL` (shell, mise, direnv, dotenv files already loaded by `bin/stash.ts`)
3. `supabase status --output env` → `DB_URL`, gated on `--supabase` or a `supabase/config.toml` in cwd
4. Interactive `p.text` prompt — skipped under `CI=true` or non-TTY stdin
5. Hard fail with a source-naming error message

CLI flag values are threaded into the user's config evaluation via an `AsyncLocalStorage` scope (`withResolverContext`) wrapped around the jiti import in `loadStashConfig`. **`process.env.DATABASE_URL` is never mutated by this code.** The connection string is never written to disk — `stash.config.ts` references the resolver, not a literal. Concurrent `loadStashConfig` calls each get their own ALS context (regression test included).

The source is logged (`Using DATABASE_URL from --database-url flag` / `from supabase status` / `from prompt`); the URL itself is never echoed to stdout.

After a prompt-sourced run, a `p.note` nudges the user to set `DATABASE_URL` in their existing dotenv file (detected from cwd, defaults to `.env`) so they don't get re-prompted next time.

## Surface

`--database-url <url>` accepted on all seven DB-touching commands: `db install`, `db push`, `db upgrade`, `db status`, `db validate`, `db test-connection`, `schema build`. HELP text updated.

`init`/build-schema is **not** wired through the resolver — it reads `process.env.DATABASE_URL` for provider hints pre-config and should not trigger the prompt flow.

## Test plan

- [x] `pnpm --filter @cipherstash/cli test` — 117 unit tests pass (+ new `__tests__/database-url.test.ts` covering each source, CI guard, concurrent ALS isolation, dotenv-file detection)
- [x] `pnpm --filter @cipherstash/cli test:e2e` — 10 E2E tests pass (+ new `tests/e2e/database-url.e2e.test.ts`: flag-source surfaces the label, CI guard exits 1 with the CI message)
- [x] `biome check` clean on changed files
- [x] `pnpm --filter @cipherstash/cli build` clean

### Manual verification

Verified each resolution path locally against the built `dist/bin/stash.js` with a temp `stash.config.ts` that calls `await resolveDatabaseUrl()`:

- [x] **Flag override** — `db test-connection --database-url <url>` logs `Using DATABASE_URL from --database-url flag`, then attempts connection. URL never echoed in output.
- [x] **Env source** — `DATABASE_URL=<url> db test-connection` runs silently (no source label, env is the default).
- [x] **CI guard** — `CI=true db test-connection` (no env, no flag) exits 1 with the CI-specific message; never prompts.
- [x] **Interactive prompt** — `db test-connection` (no env, no flag) shows the alternatives tip via `p.note`, then the URL prompt.
- [x] **Prompt + hint file detection** — with `.env.local` present, the post-prompt nudge says `Set DATABASE_URL in .env.local…`; with no dotenv file, defaults to `.env`. Tip note also matches the detected file.
- [x] **Malformed flag** — `--database-url not-a-url` exits 1 with `Invalid --database-url`.
- [x] **Cancel the prompt** — Ctrl-C at the URL prompt exits 0 with `Cancelled.`
- [x] **Supabase fallback** — against a real `supabase init && supabase start` project, the resolver shells out to `supabase status --output env`, parses `DB_URL`, logs `Using DATABASE_URL from supabase status`, and connects successfully.
- [x] **Connection-failure hint** — when the resolved URL fails to connect, the message points users at `--database-url` / env / the detected dotenv file, not at `stash.config.ts`.
- [x] **`process.env.DATABASE_URL` is unchanged after every scenario** — the resolver does not mutate the env.
- [x] **The URL value never appears in any log line** — only source labels (`from --database-url flag`, `from supabase status`, `from prompt`).

## Note on coverage

The unit tests use `vi.mock` to stub `node:child_process`, `@clack/prompts`, and `detectSupabaseProject`, so each source path is exercised in isolation. The E2E tests run the built `dist/bin/stash.js` through the pty harness against a temp `stash.config.ts` for the flag and CI-guard cases. The non-TTY path is covered by the unit suite (`Object.defineProperty(process.stdin, 'isTTY', false)`) since the pty harness always provides a TTY.

The ALS instance is parked on `globalThis` under a `Symbol.for` key — necessary because tsup ships the library (`dist/index.js`, what user configs import) and the binary (`dist/bin/stash.js`, what npx runs) as separate bundles, each with its own copy of `database-url.ts`. The `Symbol.for` rendezvous gives both bundles a single shared ALS for the lifetime of the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --database-url flag for DB and schema commands.
  * Exposed resolveDatabaseUrl and its options from the CLI API.

* **Improvements**
  * Layered DATABASE_URL resolution (flag → env → Supabase → interactive), no env mutation, CI/non‑TTY guards, dotenv-file hints, clearer source-aware messages.
  * Config loading accepts resolver options; scaffold templates use resolveDatabaseUrl().
  * CLI help/intros now reflect detected package manager.

* **Tests**
  * New unit and E2E tests covering precedence, CI behavior, Supabase discovery, prompt UX, cancellation, and concurrent isolation.

* **Docs**
  * Updated contributor guidance to require changesets for public-surface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->