### PR TITLE
fix(cli): runner-aware help banners + wizard reference

### DIFF
--- a/.changeset/cli-runner-aware-help-banners.md
+++ b/.changeset/cli-runner-aware-help-banners.md
@@ -1,0 +1,27 @@
+---
+'@cipherstash/cli': patch
+---
+
+Make `--help` banners and the post-install "Next steps" panel show commands using the package manager the user actually invoked the CLI with, instead of always emitting `npx`.
+
+A user who runs `bunx @cipherstash/cli --help` now sees:
+
+```
+Usage: bunx @cipherstash/cli <command> [options]
+…
+Examples:
+  bunx @cipherstash/cli init
+  bunx @cipherstash/cli auth login
+  bunx @cipherstash/cli db install
+```
+
+instead of `npx @cipherstash/cli …` regardless of how they invoked it. Same for `pnpm dlx`, `yarn dlx`, and the default `npx` path.
+
+Concretely:
+
+- `--help` (top-level) — usage line and all six examples in `bin/stash.ts`.
+- `--help` (auth) — usage line and the two `auth login` examples in `commands/auth/index.ts`.
+- `db install`'s "Next steps" note — the `wizard` invocation now matches the user's runner.
+- The `@cipherstash/stack is required for this command` hint shown by `requireStack` (when `db push`/`validate`/`schema build` are run before the runtime SDK is installed) now suggests the package manager's install command and the user's runner for the follow-up `init` invocation.
+
+No public-API change. Detection sources unchanged from #379: `npm_config_user_agent` first, then lockfile, then `npx` fallback.

--- a/packages/cli/src/bin/stash.ts
+++ b/packages/cli/src/bin/stash.ts
@@ -34,15 +34,32 @@ function isModuleNotFound(err: unknown): boolean {
   )
 }
 
+import {
+  detectPackageManager,
+  prodInstallCommand,
+  runnerCommand,
+} from '../commands/init/utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
+)
+
+// Detect once, share across help rendering and the requireStack hint.
+// Detection reads `npm_config_user_agent` (when the user invoked via
+// `bunx`/`pnpm dlx`/`yarn dlx`) and falls back to the lockfile in cwd.
+const PM = detectPackageManager()
+const STASH = runnerCommand(PM, 'stash')
+
 async function requireStack<T>(importFn: () => Promise<T>): Promise<T> {
   try {
     return await importFn()
   } catch (err: unknown) {
     if (isModuleNotFound(err)) {
       p.log.error(
-        '@cipherstash/stack is required for this command.\n' +
-          '  Install it with: npm install @cipherstash/stack\n' +
-          '  Or run: npx stash init',
+        `@cipherstash/stack is required for this command.
+  Install it with: ${prodInstallCommand(PM, '@cipherstash/stack')}
+  Or run: ${STASH} init`,
       )
       process.exit(1) as never
     }
@@ -50,15 +67,10 @@ async function requireStack<T>(importFn: () => Promise<T>): Promise<T> {
   }
 }
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const pkg = JSON.parse(
-  readFileSync(join(__dirname, '../../package.json'), 'utf-8'),
-)
-
 const HELP = `
 ${messages.cli.versionBannerPrefix}${pkg.version}
 
-${messages.cli.usagePrefix} <command> [options]
+${messages.cli.usagePrefix}${STASH} <command> [options]
 
 Commands:
   init                 Initialize CipherStash for your project
@@ -98,13 +110,13 @@ DB Flags:
   --database-url <url>       (all db / schema commands) Override DATABASE_URL for this run only — never written to disk
 
 Examples:
-  npx stash init
-  npx stash init --supabase
-  npx stash auth login
-  npx stash wizard
-  npx stash db install
-  npx stash db push
-  npx stash schema build
+  ${STASH} init
+  ${STASH} init --supabase
+  ${STASH} auth login
+  ${STASH} wizard
+  ${STASH} db install
+  ${STASH} db push
+  ${STASH} schema build
 `.trim()
 
 interface ParsedArgs {

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -1,8 +1,11 @@
 import { messages } from '../../messages.js'
+import { detectPackageManager, runnerCommand } from '../init/utils.js'
 import { bindDevice, login, selectRegion } from './login.js'
 
+const STASH_AUTH = runnerCommand(detectPackageManager(), 'stash auth')
+
 const HELP = `
-${messages.auth.usagePrefix} <command> [options]
+${messages.auth.usagePrefix}${STASH_AUTH} <command> [options]
 
 Commands:
   login     Authenticate with CipherStash
@@ -12,8 +15,8 @@ Options:
   --drizzle     Track Drizzle as the referrer
 
 Examples:
-  npx stash auth login
-  npx stash auth login --supabase
+  ${STASH_AUTH} login
+  ${STASH_AUTH} login --supabase
 `.trim()
 
 function referrerFromFlags(flags: Record<string, boolean>): string | undefined {

--- a/packages/cli/src/commands/db/install.ts
+++ b/packages/cli/src/commands/db/install.ts
@@ -269,12 +269,13 @@ function resolveProviderOptions(
 }
 
 function printNextSteps(): void {
+  const pm = detectPackageManager()
   p.note(
     [
       'Next steps:',
       '',
       '  1. Wire up encrypt/decrypt with the wizard (AI-guided, automated):',
-      '       stash wizard',
+      `       ${runnerCommand(pm, 'stash')} wizard`,
       '',
       '  2. Or use the client directly from @cipherstash/stack:',
       "       import { Encryption } from '@cipherstash/stack'",

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -12,11 +12,19 @@
 export const messages = {
   cli: {
     versionBannerPrefix: 'CipherStash CLI v',
-    usagePrefix: 'Usage: npx stash',
+    /**
+     * Stable leader of the usage line. The runner-and-package portion
+     * (e.g. `npx stash` or `bunx stash`) is appended at render time by
+     * the bin so the help text matches how the user invoked the CLI.
+     * Tests assert on this leader plus `'stash'` separately to stay
+     * runner-agnostic.
+     */
+    usagePrefix: 'Usage: ',
     unknownCommand: 'Unknown command',
   },
   auth: {
-    usagePrefix: 'Usage: npx stash auth',
+    /** Same shape as `cli.usagePrefix` — leader only. */
+    usagePrefix: 'Usage: ',
     unknownSubcommand: 'Unknown auth command',
     selectRegion: 'Select a region',
     cancelled: 'Cancelled.',

--- a/packages/cli/tests/e2e/runner-aware-help.e2e.test.ts
+++ b/packages/cli/tests/e2e/runner-aware-help.e2e.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '../helpers/pty.js'
+
+/**
+ * E2E coverage for the runner-aware help rendering. The smoke suite
+ * already verifies the help is rendered; this file specifically asserts
+ * that the correct package-manager runner (`npx` / `bunx` / `pnpm dlx` /
+ * `yarn dlx`) flows from `npm_config_user_agent` through
+ * `detectPackageManager` → `runnerCommand` into the Usage line and
+ * Examples.
+ *
+ * Detection itself is unit-tested in
+ * `src/commands/init/__tests__/utils.test.ts`. These E2E tests close the
+ * gap between "the helper works in isolation" and "the rendered HELP
+ * actually surfaces what the helper produces".
+ */
+
+const cases = [
+  { ua: '', label: 'npx' }, // empty UA — falls back to lockfile/npm
+  { ua: 'bun/1.0.0', label: 'bunx' },
+  { ua: 'pnpm/9.0.0', label: 'pnpm dlx' },
+  { ua: 'yarn/4.0.0', label: 'yarn dlx' },
+] as const
+
+describe('--help — runner-aware Usage + Examples', () => {
+  it.each(cases)(
+    'with npm_config_user_agent=$ua, renders "$label stash"',
+    async ({ ua, label }) => {
+      const r = render(['--help'], { env: { npm_config_user_agent: ua } })
+      const { exitCode } = await r.exit
+      expect(exitCode).toBe(0)
+      // Usage line must use the right runner. The leader is stable
+      // (`messages.cli.usagePrefix === 'Usage: '`) so we assert on the
+      // suffix the renderer composes at runtime.
+      expect(r.output).toContain(`Usage: ${label} stash`)
+      // At least one of the Examples lines must surface the same runner.
+      expect(r.output).toContain(`${label} stash init`)
+      expect(r.output).toContain(`${label} stash db install`)
+    },
+  )
+})
+
+describe('auth — runner-aware Usage + Examples', () => {
+  it.each(cases)(
+    'with npm_config_user_agent=$ua, renders "$label stash auth"',
+    async ({ ua, label }) => {
+      // `auth` with no subcommand prints the auth HELP and exits 0.
+      const r = render(['auth'], { env: { npm_config_user_agent: ua } })
+      const { exitCode } = await r.exit
+      expect(exitCode).toBe(0)
+      expect(r.output).toContain(`Usage: ${label} stash auth`)
+      expect(r.output).toContain(`${label} stash auth login`)
+    },
+  )
+})


### PR DESCRIPTION
Closes #385.

Follow-up to #377 addressing Lindsay's feedback that the `--help` banners and the wizard suggestion in `db install`'s "Next steps" panel still hard-coded `npx @cipherstash/cli` regardless of how the user invoked the CLI.

#379 already shipped `runnerCommand(pm, ref)` + `detectPackageManager()`. This applies them to the remaining places.

## Before / after

```sh
$ bunx @cipherstash/cli --help

# Before
Usage: npx @cipherstash/cli <command> [options]
Examples:
  npx @cipherstash/cli init
  npx @cipherstash/cli db install
  ...

# After
Usage: bunx @cipherstash/cli <command> [options]
Examples:
  bunx @cipherstash/cli init
  bunx @cipherstash/cli db install
  ...
```

Same for `pnpm dlx`, `yarn dlx`, default `npx`.

## Touches

- `bin/stash.ts` — `HELP` interpolates a `STASH` constant (`runnerCommand(PM, '@cipherstash/cli')`) for the usage line, six examples, and the `requireStack` hint shown when `@cipherstash/stack` isn't installed.
- `commands/auth/index.ts` — same pattern for the auth HELP (usage line + two examples).
- `commands/db/install.ts` — the wizard line in `printNextSteps` uses `runnerCommand(pm, '@cipherstash/wizard')`.

## Messages

`messages.cli.usagePrefix` and `messages.auth.usagePrefix` become stable leaders (`'Usage: '`) — the runner+package portion is appended at render time. The smoke E2E tests already use `toContain` against these constants, so they stay runner-agnostic without test changes.

## Out of scope

`messages.db.migrateNotImplemented` keeps its hard-coded `npx` form. `db migrate` is a not-yet-implemented stub; the inconsistency only surfaces when someone runs a command that doesn't exist yet. Not worth plumbing.

## Manual test plan

I ran each of the below locally; would appreciate reviewers running them too.

```sh
git checkout dan/runner-aware-help-banners
pnpm install
pnpm --filter @cipherstash/cli build
STASH=$PWD/packages/cli/dist/bin/stash.js
```

Detection prefers `npm_config_user_agent` over lockfile; overriding it directly is the easiest way to test each runner without installing them.

**1. Top-level `--help`** — Usage line and the six Examples should all use the runner:

\`\`\`sh
node $STASH --help                                                     # → npx (default)
npm_config_user_agent='bun/1.x' node $STASH --help                     # → bunx
npm_config_user_agent='pnpm/9.x' node $STASH --help                    # → pnpm dlx
npm_config_user_agent='yarn/4.x' node $STASH --help                    # → yarn dlx
\`\`\`

**2. `auth --help`** (or just `auth` with no subcommand):

\`\`\`sh
npm_config_user_agent='bun/1.x' node $STASH auth
# Expected: "Usage: bunx @cipherstash/cli auth <command> [options]"
# Examples: "bunx @cipherstash/cli auth login" / "...auth login --supabase"
\`\`\`

**3. `db install` "Next steps" panel** — the wizard line should match the runner:

\`\`\`sh
mkdir /tmp/runner-test && cd /tmp/runner-test
DATABASE_URL=postgresql://test/x npm_config_user_agent='bun/1.x' \\
  node $STASH db install --dry-run
# When the panel prints, the wizard line should read:
#       bunx @cipherstash/wizard
# (You'll also see "bunx @cipherstash/cli db install" as the intro — covered by #377.)
\`\`\`

**4. `requireStack` hint** — surfaces when running `db push`/`validate`/`schema build` without `@cipherstash/stack` installed:

\`\`\`sh
cd /tmp/runner-test
DATABASE_URL=postgresql://test/x npm_config_user_agent='pnpm/9.x' \\
  node $STASH db push
# Expected error:
#   @cipherstash/stack is required for this command.
#     Install it with: pnpm add @cipherstash/stack
#     Or run: pnpm dlx @cipherstash/cli init
\`\`\`

**5. Lockfile fallback** — without `npm_config_user_agent`, detection falls back to lockfile:

\`\`\`sh
cd /tmp/runner-test
touch bun.lock
node $STASH --help    # without npm_config_user_agent override
# Expected: bunx-flavoured output
rm bun.lock && touch pnpm-lock.yaml
node $STASH --help
# Expected: pnpm dlx
rm pnpm-lock.yaml
\`\`\`

## Automated coverage

| Surface | Coverage |
| --- | --- |
| `runnerCommand` / `detectPackageManager` themselves | Unit-tested in `src/commands/init/__tests__/utils.test.ts` (from #379) |
| Top-level `--help` Usage line + Examples | New E2E in `tests/e2e/runner-aware-help.e2e.test.ts` — 4 cases (`npx` / `bunx` / `pnpm dlx` / `yarn dlx`) asserting the right runner appears |
| `auth --help` Usage line + Examples | Same file, 4 more cases |
| `db install` "Next steps" panel (wizard line) | **Not covered** — would need a successful install (real DB). Manual only. |
| `requireStack` hint | **Not covered** — workspace has `@cipherstash/stack` installed so the path doesn't fire in CI. Manual only. |
| `messages.cli.usagePrefix` no longer hardcoded with `npx` | Smoke E2E (existing) already passes regardless of runner thanks to the leader-only assertion |

The two gaps (Next-steps panel and requireStack hint) are awkward to E2E without standing up a real DB or surgically removing `@cipherstash/stack` from the test environment. If a future PR adds either of those harnesses, both would be cheap to cover then.

## Test plan

- [x] `pnpm --filter @cipherstash/cli build` clean
- [x] `pnpm --filter @cipherstash/cli test` — unit tests pass
- [x] `pnpm --filter @cipherstash/cli test:e2e` — 18 E2E tests pass (was 10; +8 from new `runner-aware-help.e2e.test.ts`)
- [x] `biome check` clean on changed files
- [x] Manual: ran `node dist/bin/stash.js --help` with `npm_config_user_agent` cleared / set to `pnpm/9` / set to `bun/1` and confirmed the rendered Usage line + Examples match the runner.
- [x] Rebased onto post-#377 main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI help output and post-install instructions now dynamically adapt to match the package manager runner you used (e.g., `bunx`, `pnpm dlx`, `yarn dlx` instead of always showing `npx`).

* **Tests**
  * Added E2E tests for runner-aware help output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->