### PR TITLE
test(integration): self-create the protect-ci fixture table

### DIFF
--- a/packages/drizzle/__tests__/drizzle.test.ts
+++ b/packages/drizzle/__tests__/drizzle.test.ts
@@ -117,6 +117,24 @@ beforeAll(async () => {
   postgresClient = postgres(process.env.DATABASE_URL as string)
   db = drizzle({ client: postgresClient })
 
+  // Idempotent fixture setup. The `protect-ci` table is shared across the
+  // drizzle + protect/supabase + stack/supabase integration suites; each
+  // suite's beforeAll runs the same CREATE TABLE so a fresh database is
+  // ready without manual DBA work. The schema is the union of every
+  // column those suites read or write.
+  await postgresClient`
+    CREATE TABLE IF NOT EXISTS "protect-ci" (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      email eql_v2_encrypted,
+      age eql_v2_encrypted,
+      score eql_v2_encrypted,
+      profile eql_v2_encrypted,
+      encrypted eql_v2_encrypted,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      test_run_id TEXT
+    )
+  `
+
   const encryptedUsers = unwrapResult(
     await protectClient.bulkEncryptModels(userSeedData, users),
     'bulkEncryptModels',

--- a/packages/protect/__tests__/supabase.test.ts
+++ b/packages/protect/__tests__/supabase.test.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config'
 import { csColumn, csTable } from '@cipherstash/schema'
+import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
   type Encrypted,
@@ -17,6 +18,9 @@ if (!process.env.SUPABASE_URL) {
 }
 if (!process.env.SUPABASE_ANON_KEY) {
   throw new Error('Missing env.SUPABASE_ANON_KEY')
+}
+if (!process.env.DATABASE_URL) {
+  throw new Error('Missing env.DATABASE_URL — needed for fixture setup DDL')
 }
 
 const supabase = createClient(
@@ -41,6 +45,33 @@ const TEST_RUN_ID = `test-run-${Date.now()}-${Math.random().toString(36).slice(2
 const insertedIds: number[] = []
 
 beforeAll(async () => {
+  // Idempotent fixture setup. The `protect-ci` table is shared across the
+  // drizzle + protect/supabase + stack/supabase integration suites; each
+  // suite's beforeAll runs the same CREATE TABLE so a fresh database is
+  // ready without manual DBA work. The schema is the union of every
+  // column those suites read or write.
+  const sql = postgres(process.env.DATABASE_URL as string, { prepare: false })
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS "protect-ci" (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        email eql_v2_encrypted,
+        age eql_v2_encrypted,
+        score eql_v2_encrypted,
+        profile eql_v2_encrypted,
+        encrypted eql_v2_encrypted,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        test_run_id TEXT
+      )
+    `
+    // Tell PostgREST to refresh its schema cache so the supabase-js client
+    // can see a freshly created table without waiting for the polling
+    // interval. No-op on plain Postgres (no listener bound).
+    await sql`NOTIFY pgrst, 'reload schema'`
+  } finally {
+    await sql.end()
+  }
+
   // Clean up any data from this specific test run (safe for concurrent runs)
   const { error } = await supabase
     .from('protect-ci')
@@ -50,7 +81,7 @@ beforeAll(async () => {
   if (error) {
     console.warn(`[protect]: Failed to clean up test data: ${error.message}`)
   }
-})
+}, 30000)
 
 afterAll(async () => {
   // Clean up all data from this test run

--- a/packages/stack/__tests__/supabase.test.ts
+++ b/packages/stack/__tests__/supabase.test.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import { Encryption } from '@/index'
 import { encryptedColumn, encryptedTable } from '@/schema'
 import { encryptedSupabase } from '@/supabase'
+import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { createClient } from '@supabase/supabase-js'
@@ -11,6 +12,9 @@ if (!process.env.SUPABASE_URL) {
 }
 if (!process.env.SUPABASE_ANON_KEY) {
   throw new Error('Missing env.SUPABASE_ANON_KEY')
+}
+if (!process.env.DATABASE_URL) {
+  throw new Error('Missing env.DATABASE_URL — needed for fixture setup DDL')
 }
 
 const supabase = createClient(
@@ -42,6 +46,33 @@ const TEST_RUN_ID = `test-run-${Date.now()}-${Math.random().toString(36).slice(2
 const insertedIds: number[] = []
 
 beforeAll(async () => {
+  // Idempotent fixture setup. The `protect-ci` table is shared across the
+  // drizzle + protect/supabase + stack/supabase integration suites; each
+  // suite's beforeAll runs the same CREATE TABLE so a fresh database is
+  // ready without manual DBA work. The schema is the union of every
+  // column those suites read or write.
+  const sql = postgres(process.env.DATABASE_URL as string, { prepare: false })
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS "protect-ci" (
+        id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        email eql_v2_encrypted,
+        age eql_v2_encrypted,
+        score eql_v2_encrypted,
+        profile eql_v2_encrypted,
+        encrypted eql_v2_encrypted,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        test_run_id TEXT
+      )
+    `
+    // Tell PostgREST to refresh its schema cache so the supabase-js client
+    // can see a freshly created table without waiting for the polling
+    // interval. No-op on plain Postgres (no listener bound).
+    await sql`NOTIFY pgrst, 'reload schema'`
+  } finally {
+    await sql.end()
+  }
+
   // Clean up any data from this specific test run (safe for concurrent runs)
   const { error } = await supabase
     .from('protect-ci')


### PR DESCRIPTION
## Summary

The integration suites under \`packages/{drizzle,protect,stack}\` all INSERT into a \`protect-ci\` table that was previously assumed to exist (originally created by hand on the shared CI Supabase project). On a **fresh database** — e.g. the new Supabase instance now provisioned for Dependabot CI runs — these suites fail with:

\`\`\`
PostgresError: relation "protect-ci" does not exist
\`\`\`

This PR makes the suites self-create their fixture, mirroring the pattern already used in \`packages/{protect,stack}/__tests__/searchable-json-pg.test.ts\` for the \`protect-ci-jsonb\` table.

## What changed

Added an idempotent \`CREATE TABLE IF NOT EXISTS "protect-ci" (...)\` to the \`beforeAll\` of:

- \`packages/drizzle/__tests__/drizzle.test.ts\` — already has a postgres-js connection, so the DDL goes inline.
- \`packages/protect/__tests__/supabase.test.ts\` — opens a short-lived postgres-js connection just for the DDL, closes it before tests run via the supabase client.
- \`packages/stack/__tests__/supabase.test.ts\` — same pattern as protect/supabase.

The two supabase suites also send \`NOTIFY pgrst, 'reload schema'\` after the DDL so PostgREST picks up the new table immediately rather than waiting for its polling interval. No-op on plain Postgres.

The two supabase suites now also require \`DATABASE_URL\` (for the DDL step). The CI workflow already populates it in those packages' \`.env\` files; local devs running these suites need it set.

## Schema

The CREATE TABLE covers the **union** of every column the three suites read or write:

\`\`\`sql
CREATE TABLE IF NOT EXISTS "protect-ci" (
  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
  email      eql_v2_encrypted,   -- drizzle suite
  age        eql_v2_encrypted,   -- drizzle + supabase
  score      eql_v2_encrypted,   -- drizzle + supabase
  profile    eql_v2_encrypted,   -- drizzle suite
  encrypted  eql_v2_encrypted,   -- supabase suites
  created_at TIMESTAMPTZ DEFAULT NOW(),
  test_run_id TEXT
)
\`\`\`

All encrypted columns are nullable, so each suite only populates the subset it needs.

## Out of scope

- The \`protect-ci-jsonb\` table already self-creates via the searchable-json-pg suites; not touched here.
- Cross-suite consolidation (a shared SQL fixture file) — the per-suite duplication is small and clear; abstraction would mostly add indirection.
- Pre-existing typecheck errors in \`encrypt-query-searchable-json.test.ts\` and \`searchable-json-pg.test.ts\` (unrelated to this change).