### PR TITLE
ci: drop unused CS_ZEROKMS_HOST and CS_CTS_HOST overrides

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,6 @@ jobs:
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> ./packages/protect/.env
           echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> ./packages/protect/.env
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> ./packages/protect/.env
-          echo "CS_ZEROKMS_HOST=https://ap-southeast-2.aws.zerokms.cipherstashmanaged.net" >> ./packages/protect/.env
-          echo "CS_CTS_HOST=https://ap-southeast-2.aws.cts.cipherstashmanaged.net" >> ./packages/protect/.env
 
       - name: Create .env file in ./packages/stack/
         run: |
@@ -54,8 +52,6 @@ jobs:
           echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> ./packages/stack/.env
           echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> ./packages/stack/.env
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> ./packages/stack/.env
-          echo "CS_ZEROKMS_HOST=https://ap-southeast-2.aws.zerokms.cipherstashmanaged.net" >> ./packages/stack/.env
-          echo "CS_CTS_HOST=https://ap-southeast-2.aws.cts.cipherstashmanaged.net" >> ./packages/stack/.env
 
       - name: Create .env file in ./packages/protect-dynamodb/
         run: |
@@ -64,8 +60,6 @@ jobs:
           echo "CS_CLIENT_ID=${{ secrets.CS_CLIENT_ID }}" >> ./packages/protect-dynamodb/.env
           echo "CS_CLIENT_KEY=${{ secrets.CS_CLIENT_KEY }}" >> ./packages/protect-dynamodb/.env
           echo "CS_CLIENT_ACCESS_KEY=${{ secrets.CS_CLIENT_ACCESS_KEY }}" >> ./packages/protect-dynamodb/.env
-          echo "CS_ZEROKMS_HOST=https://ap-southeast-2.aws.zerokms.cipherstashmanaged.net" >> ./packages/protect/.env
-          echo "CS_CTS_HOST=https://ap-southeast-2.aws.cts.cipherstashmanaged.net" >> ./packages/protect/.env
 
       - name: Create .env file in ./packages/drizzle/
         run: |
@@ -75,8 +69,6 @@ jobs:
           echo "CS_CLIENT_KEY=${{ secrets.CS_CLIENT_KEY }}" >> ./packages/drizzle/.env
           echo "CS_CLIENT_ACCESS_KEY=${{ secrets.CS_CLIENT_ACCESS_KEY }}" >> ./packages/drizzle/.env
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> ./packages/drizzle/.env
-          echo "CS_ZEROKMS_HOST=https://ap-southeast-2.aws.zerokms.cipherstashmanaged.net" >> ./packages/protect/.env
-          echo "CS_CTS_HOST=https://ap-southeast-2.aws.cts.cipherstashmanaged.net" >> ./packages/protect/.env
 
       # Run TurboRepo tests
       - name: Run tests


### PR DESCRIPTION
## Summary
- The protect SDK derives the CTS host from the workspace CRN and the ZeroKMS host from the services claims in the CTS-issued JWT, so the `CS_ZEROKMS_HOST` / `CS_CTS_HOST` lines we were echoing into the four package `.env` files in CI were never consulted at runtime.
- Remove them from the protect, stack, protect-dynamodb, and drizzle `.env`-creation steps. (Two of the four blocks also had a copy-paste typo writing the values into `./packages/protect/.env`; deleting them moots that as well.)

Same change is already on PR #393's branch and CI passed there with the dependabot secrets; landing it on `main` first ensures the standard Actions env stays green before we merge that PR.

## Test plan
- [x] CI \"Test JS\" workflow passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize environment variable handling during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->