### PR TITLE
test(integration): add otherField column to protect-ci fixture

### DIFF
--- a/packages/drizzle/__tests__/drizzle.test.ts
+++ b/packages/drizzle/__tests__/drizzle.test.ts
@@ -130,9 +130,16 @@ beforeAll(async () => {
       score eql_v2_encrypted,
       profile eql_v2_encrypted,
       encrypted eql_v2_encrypted,
+      "otherField" TEXT,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       test_run_id TEXT
     )
+  `
+  // Backfill any column added after the table was first created on a
+  // long-lived CI database. CREATE TABLE IF NOT EXISTS is a no-op on
+  // those, so new columns need an explicit ADD COLUMN IF NOT EXISTS.
+  await postgresClient`
+    ALTER TABLE "protect-ci" ADD COLUMN IF NOT EXISTS "otherField" TEXT
   `
 
   const encryptedUsers = unwrapResult(

--- a/packages/protect/__tests__/supabase.test.ts
+++ b/packages/protect/__tests__/supabase.test.ts
@@ -60,9 +60,16 @@ beforeAll(async () => {
         score eql_v2_encrypted,
         profile eql_v2_encrypted,
         encrypted eql_v2_encrypted,
+        "otherField" TEXT,
         created_at TIMESTAMPTZ DEFAULT NOW(),
         test_run_id TEXT
       )
+    `
+    // Backfill any column added after the table was first created on a
+    // long-lived CI database. CREATE TABLE IF NOT EXISTS is a no-op on
+    // those, so new columns need an explicit ADD COLUMN IF NOT EXISTS.
+    await sql`
+      ALTER TABLE "protect-ci" ADD COLUMN IF NOT EXISTS "otherField" TEXT
     `
     // Tell PostgREST to refresh its schema cache so the supabase-js client
     // can see a freshly created table without waiting for the polling

--- a/packages/stack/__tests__/supabase.test.ts
+++ b/packages/stack/__tests__/supabase.test.ts
@@ -61,9 +61,16 @@ beforeAll(async () => {
         score eql_v2_encrypted,
         profile eql_v2_encrypted,
         encrypted eql_v2_encrypted,
+        "otherField" TEXT,
         created_at TIMESTAMPTZ DEFAULT NOW(),
         test_run_id TEXT
       )
+    `
+    // Backfill any column added after the table was first created on a
+    // long-lived CI database. CREATE TABLE IF NOT EXISTS is a no-op on
+    // those, so new columns need an explicit ADD COLUMN IF NOT EXISTS.
+    await sql`
+      ALTER TABLE "protect-ci" ADD COLUMN IF NOT EXISTS "otherField" TEXT
     `
     // Tell PostgREST to refresh its schema cache so the supabase-js client
     // can see a freshly created table without waiting for the polling


### PR DESCRIPTION
## Summary
- The supabase test suites write a non-encrypted \`otherField\` text column to \`protect-ci\`. PR #400's union schema missed it, so PR #393's CI fails on the supabase suite with \`Could not find the 'otherField' column\`.
- Add the column to all three \`CREATE TABLE IF NOT EXISTS\` bodies (drizzle, protect/supabase, stack/supabase).
- Also add an \`ALTER TABLE ADD COLUMN IF NOT EXISTS\` so long-lived CI databases — where the CREATE is a no-op — get the column backfilled on the next test run, no manual DBA step needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test database infrastructure to ensure consistent schema setup across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->