### PR TITLE
fix(changesets): rename stale `@cipherstash/cli` key to `stash`

### DIFF
--- a/.changeset/cli-runner-aware-help-banners.md
+++ b/.changeset/cli-runner-aware-help-banners.md
@@ -1,5 +1,5 @@
 ---
-'@cipherstash/cli': patch
+'stash': patch
 ---
 
 Make `--help` banners and the post-install "Next steps" panel show commands using the package manager the user actually invoked the CLI with, instead of always emitting `npx`.

--- a/.changeset/package-manager-aware-output.md
+++ b/.changeset/package-manager-aware-output.md
@@ -1,5 +1,5 @@
 ---
-"@cipherstash/cli": patch
+"stash": patch
 "@cipherstash/wizard": patch
 "@cipherstash/protect": patch
 "@cipherstash/drizzle": patch


### PR DESCRIPTION
## Summary

- The CLI package was renamed `@cipherstash/cli` → `stash` in `packages/cli/package.json`, but two changesets on `main` still reference the old name.
- This breaks the changesets/version action on every push to `main`:
  ```
  Found changeset cli-runner-aware-help-banners for package @cipherstash/cli which is not in the workspace
  ```
- Renames the frontmatter package key in both files. Body copy that mentions `@cipherstash/cli` historically is left intact — changesets only validates frontmatter.

Files touched:
- `.changeset/cli-runner-aware-help-banners.md`
- `.changeset/package-manager-aware-output.md`

## Test plan

- [ ] Confirm changesets/version action succeeds once merged (next push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)