### PR TITLE
ci: install node-gyp before pnpm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      # node-pty's install hook falls back to `node-gyp rebuild` when no
+      # linux-x64 prebuild matches. pnpm/action-setup v6 no longer ships
+      # node-gyp on PATH, so install it explicitly.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,12 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      # node-pty's install hook falls back to `node-gyp rebuild` when no
+      # linux-x64 prebuild matches. pnpm/action-setup v6 no longer ships
+      # node-gyp on PATH, so install it explicitly.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -115,6 +121,12 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      # node-pty's install hook falls back to `node-gyp rebuild` when no
+      # linux-x64 prebuild matches. pnpm/action-setup v6 no longer ships
+      # node-gyp on PATH, so install it explicitly.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Adds an `npm install -g node-gyp` step before `pnpm install` in `tests.yml` (both jobs) and `release.yml`.
- Unblocks the `pnpm/action-setup` v4 → v6 bump in #390, which currently fails because v6 no longer ships node-gyp on PATH and `node-pty@1.1.0` falls back to `node-gyp rebuild` (no linux-x64 prebuild matches).

## Why
The failing log on #390 shows:
\`\`\`
node-pty install: > Rebuilding because directory .../prebuilds/linux-x64 does not exist
node-pty install: sh: 1: node-gyp: not found
ELIFECYCLE Command failed.
\`\`\`
Main is currently still on `pnpm/action-setup@v4` (which bundles node-gyp), so this change is a no-op on main today and only takes effect once #390 lands. Including the same step in `release.yml` so the release path doesn't break the moment #390 merges.