### PR TITLE
chore(deps): bump lodash to 4.18.1 (CVE-2026-4800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "test-exclude": "^7.0.1",
     "glob": ">=11.1.0",
     "qs": ">=6.14.1",
-    "lodash": ">=4.17.23",
+    "lodash": ">=4.18.0",
     "minimatch": ">=10.2.3",
     "@isaacs/brace-expansion": ">=5.0.1",
     "fast-xml-parser": ">=5.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2412,8 +2412,8 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4863,7 +4863,7 @@ snapshots:
       '@types/lodash': 4.17.21
       is-glob: 4.0.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.7.4
       tinyglobby: 0.2.15
@@ -4940,7 +4940,7 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   long@5.3.2:
     optional: true


### PR DESCRIPTION
## Summary
- Bumps transitive `lodash` from `4.17.23` → `4.18.1` to patch [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) / [CVE-2026-4800](https://nvd.nist.gov/vuln/detail/CVE-2026-4800) (high): code injection via `_.template` when `imports` keys are attacker-controlled.
- Closes Dependabot alert [#88](https://github.com/cipherstash/stack/security/dependabot/88).

## Why this looked like the vite case at first — and why it isn't
Like the vite alert, lodash here is a transitive dep with `manifest_path: pnpm-lock.yaml`. But unlike vite, lodash is a *normal* transitive (pulled in by `json-schema-to-typescript@15.0.4`, which declares `lodash: ^4.17.21`), not an optional peer auto-install. pnpm's `overrides` mechanism applies cleanly here.

The existing override at `>=4.17.23` already targeted lodash — it just hadn't been bumped past the patched cutoff. Raising it to `>=4.18.0` resolves to the patched line.

## Why a hand-edited lockfile (vs. `pnpm install`)
A full regen with the bumped override correctly picked `lodash@4.18.1`, but it also walked the rest of the tree and pulled in ~30 unrelated transitive bumps (`drizzle-orm 0.44.7 → 0.45.2`, `@types/node 22.19.3 → 22.19.17`, `drizzle-kit 0.30.6 → 0.31.10`, etc.). That's well outside the scope of a CVE patch, so I did a surgical 3-spot edit of the lockfile instead:

1. `lodash@4.17.23:` → `lodash@4.18.1:` with the new integrity hash (sourced from `npm view lodash@4.18.1 dist.integrity`).
2. `json-schema-to-typescript@15.0.4`'s snapshot dep ref `lodash: 4.17.23` → `lodash: 4.18.1`.
3. Snapshot key `lodash@4.17.23: {}` → `lodash@4.18.1: {}`.

`pnpm install --frozen-lockfile` accepts the lockfile and downloads `lodash@4.18.1` correctly.

Note: 4.18.1 satisfies `json-schema-to-typescript`'s declared `lodash: ^4.17.21` range, so no API compatibility risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum version requirement for the lodash dependency to ensure application stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->