### PR TITLE
chore(deps): bump @clerk/nextjs to 6.39.3 (GHSA-w24r-5266-9c3c)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ catalogs:
       version: 3.1.3
   security:
     '@clerk/nextjs':
-      specifier: 6.39.2
-      version: 6.39.2
+      specifier: 6.39.3
+      version: 6.39.3
 
 importers:
 
@@ -227,7 +227,7 @@ importers:
     devDependencies:
       '@clerk/nextjs':
         specifier: catalog:security
-        version: 6.39.2(next@15.5.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 6.39.3(next@15.5.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -660,8 +660,8 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/nextjs@6.39.2':
-    resolution: {integrity: sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw==}
+  '@clerk/nextjs@6.39.3':
+    resolution: {integrity: sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       next: ^13.5.7 || ^14.2.25 || ^15.2.3 || ^16
@@ -3575,7 +3575,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tslib: 2.8.1
 
-  '@clerk/nextjs@6.39.2(next@15.5.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@clerk/nextjs@6.39.3(next@15.5.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@clerk/backend': 2.33.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@clerk/clerk-react': 5.61.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalogs:
     typescript: 5.6.3
     vitest: 3.1.3
   security:
-    '@clerk/nextjs': 6.39.2
+    '@clerk/nextjs': 6.39.3
     next: 15.5.10
     vite: 8.0.9
 


### PR DESCRIPTION
## Summary
- Bumps \`@clerk/nextjs\` from \`6.39.2\` → \`6.39.3\` to patch [GHSA-w24r-5266-9c3c](https://github.com/advisories/GHSA-w24r-5266-9c3c) (high): authorization bypass when combining organization, billing, or reverification checks.
- Closes Dependabot alert [#105](https://github.com/cipherstash/stack/security/dependabot/105).

## Changes
- \`pnpm-workspace.yaml\` security catalog: \`@clerk/nextjs: 6.39.2\` → \`6.39.3\`
- Surgical \`pnpm-lock.yaml\` edit: catalog block, importer ref, package def + integrity (sourced from \`npm view\`), snapshot key

The internal \`@clerk/*\` sub-deps (\`types\`, \`shared\`, \`backend\`, \`clerk-react\`) in our lockfile already satisfy 6.39.3's bumped peer ranges, so no cascading changes needed.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` from clean \`node_modules\` validates.
- [x] \`@clerk/nextjs@6.39.3\` confirmed installed.
- [ ] Watch CI on this PR.
- [ ] After merge, alert #105 auto-closes.