### PR TITLE
chore(deps): bump uuid 13.0.0 -> 14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -205,7 +205,7 @@
 		"@byteslice/result": "0.2.0",
 		"@cipherstash/protect-ffi": "0.21.4",
 		"evlog": "1.9.0",
-		"uuid": "13.0.0",
+		"uuid": "14.0.0",
 		"zod": "3.24.2"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: 1.9.0
         version: 1.9.0
       uuid:
-        specifier: 13.0.0
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
       zod:
         specifier: 3.24.2
         version: 3.24.2
@@ -3132,8 +3132,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -4200,7 +4200,7 @@ snapshots:
 
   '@types/uuid@11.0.0':
     dependencies:
-      uuid: 13.0.0
+      uuid: 14.0.0
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5633,7 +5633,7 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
Bumps \`uuid\` from \`13.0.0\` → \`14.0.0\` (a major bump) to patch [GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) (medium): missing buffer-bounds check in \`v3()\`/\`v5()\`/\`v6()\` when a \`buf\` argument is provided.

Closes alerts:
- [#100](https://github.com/cipherstash/stack/security/dependabot/100) — direct dep in \`packages/stack\`
- [#101](https://github.com/cipherstash/stack/security/dependabot/101) — transitive via \`@types/uuid\`, which auto-resolves to the new uuid version

## Why the major is safe here
Our only uuid call site is \`uuidValidate\` from \`packages/stack/src/encryption/index.ts\` — validating UUID strings. Not affected by the vulnerability (which is in the buffer-write path) and the API is unchanged.

uuid 14.0 breaking changes — none apply:
| Break | Repo state |
|---|---|
| Requires global \`crypto\` (Node 20+) | repo \`engines.node: ">=22"\` |
| Drops Node 18 | same |
| Requires TypeScript 5.4.3+ | catalog at 5.6.3 |

## Changes
- \`packages/stack/package.json\`: \`"uuid": "13.0.0"\` → \`"14.0.0"\`
- Surgical \`pnpm-lock.yaml\` edit (importer ref, package def + integrity, snapshot key, \`@types/uuid\`'s dep ref)

## Test plan
- [x] \`pnpm install --frozen-lockfile\` from clean \`node_modules\` validates.
- [x] \`uuid@14.0.0\` confirmed installed.
- [x] \`pnpm --filter @cipherstash/stack build\` passes.
- [ ] Watch CI on this PR.
- [ ] After merge, alerts #100 and #101 auto-close.