### PR TITLE
perf(stack/drizzle): wrap eq/ne/inArray/notInArray in eql_v2.hmac_256(...)

### DIFF
--- a/.changeset/drizzle-hmac-256-equality.md
+++ b/.changeset/drizzle-hmac-256-equality.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/stack": patch
+---
+
+perf(drizzle): wrap `eq` / `ne` / `inArray` / `notInArray` in `eql_v2.hmac_256(...)` so encrypted equality lookups engage the hmac_256 functional hash index on Supabase and any `--exclude-operator-family` install. Previously the operators emitted bare `col = value` SQL that only matched the `eql_v2.encrypted_operator_class` btree index, which doesn't exist on those deployments — so every encrypted equality lookup silently fell back to a sequential scan.

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -17,8 +17,8 @@ on a Supabase-shaped install (no operator classes). It runs in two layers:
   ```bash
   cd ../../local && docker compose up -d
   ```
-- A CipherStash profile signed in (`stash login`). Auth is read from the
-  CipherStash profile; no environment variables required.
+- A CipherStash profile signed in (`npx stash auth login`). Auth is read from
+  the CipherStash profile; no environment variables required.
 - `DATABASE_URL` only needs to be set if you want to override the default
   (`postgres://cipherstash:password@localhost:5432/cipherstash`).
 
@@ -32,7 +32,7 @@ the repo's CI `test` step (the scripts are deliberately named `test:local` /
 # Credential-free smoke (verifies schema + EXPLAIN harness):
 pnpm test:local -- db-only
 
-# Full suite (requires CipherStash auth via `stash login`, seeds 10k rows on first run):
+# Full suite (requires CipherStash auth via `npx stash auth login`, seeds 10k rows on first run):
 pnpm db:setup                   # apply schema + seed BENCH_ROWS rows (default 10k)
 pnpm test:local                 # EXPLAIN-shape assertions for #421 / #422
 pnpm bench:local                # timing benches (slow)

--- a/packages/stack/src/drizzle/operators.ts
+++ b/packages/stack/src/drizzle/operators.ts
@@ -1484,15 +1484,26 @@ export function createEncryptionOperators(encryptionClient: EncryptionClient): {
       tableCache,
     )
 
+    // Fail fast if any value failed to encrypt — silently dropping a value
+    // would change query semantics (matches that should be found get missed).
+    if (encryptedValues.some((encrypted) => encrypted === undefined)) {
+      throw new EncryptionOperatorError(
+        'Encryption failed for one or more inArray values',
+        {
+          columnName: columnInfo.columnName,
+          tableName: columnInfo.tableName,
+          operator: 'inArray',
+        },
+      )
+    }
+
     // Wrap each comparison in eql_v2.hmac_256(...) so the hmac_256 functional
     // hash index engages. Postgres can BitmapOr several hash-index scans, so
     // OR-of-eq stays as fast as a single equality lookup per value.
-    const conditions = encryptedValues
-      .filter((encrypted) => encrypted !== undefined)
-      .map(
-        (encrypted) =>
-          sql`eql_v2.hmac_256(${left}) = eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
-      )
+    const conditions = encryptedValues.map(
+      (encrypted) =>
+        sql`eql_v2.hmac_256(${left}) = eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
+    )
 
     if (conditions.length === 0) {
       return sql`false`
@@ -1535,16 +1546,27 @@ export function createEncryptionOperators(encryptionClient: EncryptionClient): {
       tableCache,
     )
 
+    // Fail fast if any value failed to encrypt — silently dropping a value
+    // from a NOT IN list would admit rows that should be excluded.
+    if (encryptedValues.some((encrypted) => encrypted === undefined)) {
+      throw new EncryptionOperatorError(
+        'Encryption failed for one or more notInArray values',
+        {
+          columnName: columnInfo.columnName,
+          tableName: columnInfo.tableName,
+          operator: 'notInArray',
+        },
+      )
+    }
+
     // Wrap each comparison in eql_v2.hmac_256(...) for index engagement (see
     // encryptedInArray above for rationale). NOT IN is naturally low-
     // selectivity, so the planner may still pick a seq scan — the wrap keeps
     // it correct on Supabase and lets the planner decide.
-    const conditions = encryptedValues
-      .filter((encrypted) => encrypted !== undefined)
-      .map(
-        (encrypted) =>
-          sql`eql_v2.hmac_256(${left}) <> eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
-      )
+    const conditions = encryptedValues.map(
+      (encrypted) =>
+        sql`eql_v2.hmac_256(${left}) <> eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
+    )
 
     if (conditions.length === 0) {
       return sql`true`

--- a/packages/stack/src/drizzle/operators.ts
+++ b/packages/stack/src/drizzle/operators.ts
@@ -725,7 +725,11 @@ function createComparisonOperator(
           },
         )
       }
-      return operator === 'eq' ? eq(left, encrypted) : ne(left, encrypted)
+      // Wrap both sides in eql_v2.hmac_256(...) so the hmac_256 functional
+      // hash index engages. Bare `col = value` falls back to a seq scan on
+      // any install without `eql_v2.encrypted_operator_class` (i.e. Supabase).
+      const op = sql.raw(operator === 'eq' ? '=' : '<>')
+      return sql`eql_v2.hmac_256(${left}) ${op} eql_v2.hmac_256(${bindIfParam(encrypted, left)})`
     }
 
     return createLazyOperator(
@@ -1480,10 +1484,15 @@ export function createEncryptionOperators(encryptionClient: EncryptionClient): {
       tableCache,
     )
 
-    // Use regular eq for each encrypted value - PostgreSQL operators handle it
+    // Wrap each comparison in eql_v2.hmac_256(...) so the hmac_256 functional
+    // hash index engages. Postgres can BitmapOr several hash-index scans, so
+    // OR-of-eq stays as fast as a single equality lookup per value.
     const conditions = encryptedValues
       .filter((encrypted) => encrypted !== undefined)
-      .map((encrypted) => eq(left, encrypted))
+      .map(
+        (encrypted) =>
+          sql`eql_v2.hmac_256(${left}) = eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
+      )
 
     if (conditions.length === 0) {
       return sql`false`
@@ -1526,10 +1535,16 @@ export function createEncryptionOperators(encryptionClient: EncryptionClient): {
       tableCache,
     )
 
-    // Use regular ne for each encrypted value - PostgreSQL operators handle it
+    // Wrap each comparison in eql_v2.hmac_256(...) for index engagement (see
+    // encryptedInArray above for rationale). NOT IN is naturally low-
+    // selectivity, so the planner may still pick a seq scan — the wrap keeps
+    // it correct on Supabase and lets the planner decide.
     const conditions = encryptedValues
       .filter((encrypted) => encrypted !== undefined)
-      .map((encrypted) => ne(left, encrypted))
+      .map(
+        (encrypted) =>
+          sql`eql_v2.hmac_256(${left}) <> eql_v2.hmac_256(${bindIfParam(encrypted, left)})`,
+      )
 
     if (conditions.length === 0) {
       return sql`true`


### PR DESCRIPTION
## Summary

Stacked on #424.

Fixes #421. Bare `col = value` (and `<>`, `IN`, `NOT IN`) only engages the `eql_v2.encrypted_operator_class` btree index, which doesn't exist on Supabase or any `--exclude-operator-family` install. Customers there silently seq-scan every encrypted equality lookup at any scale.

This change wraps both sides of the comparison in `eql_v2.hmac_256(...)` so the canonical hmac_256 functional hash index engages on every install.

## What changed

`packages/stack/src/drizzle/operators.ts`:

- **`eq` / `ne`** (around line 728): emitted SQL goes from `col = $1` to `eql_v2.hmac_256(col) = eql_v2.hmac_256($1)` (and `<>` for `ne`).
- **`inArray` / `notInArray`** (around lines 1486 / 1532): each comparison in the OR/AND chain wraps both sides in `eql_v2.hmac_256(...)`. Postgres can BitmapOr several hash-index scans, so the OR-of-eq stays as fast as a single equality lookup per value.

## Plan-shape verification

`EXPLAIN` on the same 10k-row fixture (from #424's bench), before vs after:

| Operator    | Before fix             | After fix                              |
| ----------- | ---------------------- | -------------------------------------- |
| `eq`        | Seq Scan               | **Index Scan on bench_text_hmac_idx** |
| `inArray`   | Seq Scan               | **Bitmap Heap Scan**                  |
| `ne`        | Seq Scan               | Seq Scan (low-selectivity, expected)  |
| `notInArray`| Seq Scan               | Seq Scan (low-selectivity, expected)  |

`ne` and `notInArray` continue to seq-scan post-fix, but for the right reason: `<>` against a single value matches ~all rows, so the planner correctly avoids the index. The SQL form is now correct on Supabase and the planner makes the right call regardless.

## Wall-clock benchmark

`pnpm -F @cipherstash/bench bench:local` against the same 10k-row fixture, vitest `--bench` (tinybench under the hood). Higher `hz` is better; lower `mean` is better.

| Operator                     |   Before (hz) | After (hz) |  Before mean (ms) | After mean (ms) |    Speedup |
| ---------------------------- | ------------: | ---------: | ----------------: | --------------: | ---------: |
| `eq` (string match)          |          5.53 |   1,910.73 |             180.7 |            0.52 |   **~345×** |
| `inArray` (3 string matches) |          1.46 |   1,696.64 |             686.4 |            0.59 |  **~1163×** |
| `like` (prefix)              |          1.33 |       1.38 |             754.6 |           724.8 |       — (#422) |
| `gt` (int)                   |          2.03 |       1.95 |             493.0 |           513.4 |       — (#422) |
| `between` (int)              |          1.25 |       1.27 |             798.1 |           787.0 |       — (#422) |
| `orderBy desc + limit 10`    |          2.99 |       3.09 |             334.8 |           323.2 |       — (#422) |

Operators outside the scope of this fix (`like`, `gt`, `between`, `orderBy`) are unchanged within noise — those still seq-scan because their call-shaped forms aren't being inlined by the planner. Tracked separately in #422.

## What's NOT in this PR

- The legacy `packages/drizzle/src/pg/operators.ts:731` has the identical bug. Tracked in #426.
- #422 (call-shaped operators not engaging functional indexes) is broader and likely needs an EQL-side fix to function inlinability. Tracked separately.
- #423 (`jsonbPathQueryFirst` / `jsonbGet` typed as predicates but return `eql_v2_encrypted`) is an API-shape bug surfaced by the same bench. Tracked separately.

## Test plan

- [ ] On this branch, in `packages/bench`: `pnpm db:setup && pnpm test:local`. Expect 9/9 green on `__tests__/drizzle/operators.explain.test.ts`.
- [ ] Inspect `packages/bench/results/explain-shape.json` — `eq` should report `Index Scan on bench_text_hmac_idx`; `inArray` should report `Bitmap Heap Scan`.
- [ ] Existing `@cipherstash/stack` unit tests still pass: `pnpm -F @cipherstash/stack test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved query performance for encrypted columns. Equality checks, inequality comparisons, and array filtering operations now execute significantly faster, reducing database query latency and improving overall application responsiveness. This enhancement delivers consistent performance benefits when filtering or searching encrypted data, resulting in a noticeably faster user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->