### PR TITLE
perf(stack/drizzle): wrap like/ilike in eql_v2.bloom_filter(...) @> ...

### DIFF
--- a/.changeset/drizzle-bloom-filter-like-ilike.md
+++ b/.changeset/drizzle-bloom-filter-like-ilike.md
@@ -1,0 +1,5 @@
+---
+"@cipherstash/stack": patch
+---
+
+perf(drizzle): wrap `like` / `ilike` / `notIlike` in `eql_v2.bloom_filter(...) @> eql_v2.bloom_filter(...)` so encrypted free-text searches engage the bloom_filter functional GIN index on Supabase and any `--exclude-operator-family` install. Previously the operators emitted `eql_v2.like(col, value)` / `eql_v2.ilike(col, value)` — the function bodies contain the inlinable bloom-filter form, but they're marked `VOLATILE` so the planner can't inline them, and the documented `bench_text_bloom_idx` GIN index never engages. Drizzle now emits the inlined form directly.

--- a/packages/bench/__tests__/drizzle/operators.explain.test.ts
+++ b/packages/bench/__tests__/drizzle/operators.explain.test.ts
@@ -156,22 +156,45 @@ describe('#421: equality and array operators', () => {
   })
 })
 
-// --- #422: investigation operators ----------------------------------------
+// --- like / ilike: bloom-filter containment ------------------------------
 //
-// We don't yet know which call-shaped forms the planner inlines. Record plan
-// shape; assertions land in a follow-up once #422 closes.
-describe('#422: call-shaped operators (recorded, not asserted)', () => {
-  it('records like / ilike plan shapes', async () => {
-    await tryExplainWhere(
-      'like',
-      (await ops.like(benchTable.encText, '%value-00000%')) as SQL,
+// `eql_v2.like` and `eql_v2.ilike` are SQL functions whose bodies are already
+// `SELECT eql_v2.bloom_filter(a) @> eql_v2.bloom_filter(b)` — but they're
+// marked VOLATILE, so the planner won't inline them into the index match.
+// Drizzle now emits the inlined containment form directly so the bloom GIN
+// index engages. The wildcard pattern is irrelevant at the SQL layer —
+// bloom-filter match works on the encrypted token set, not LIKE syntax.
+describe('like / ilike: engage bloom_filter functional index', () => {
+  // The pattern needs to be selective — `%value-0000042%` is unique to one
+  // seeded row, whereas a broad pattern like `%value-00000%` is shared by
+  // every row in the fixture (all seed values start with `value-`), and
+  // the planner correctly picks seq scan when the predicate matches every
+  // row.
+  it('like engages bench_text_bloom_idx', async () => {
+    const plan = await explainWhere(
+      (await ops.like(benchTable.encText, '%value-0000042%')) as SQL,
     )
-    await tryExplainWhere(
-      'ilike',
-      (await ops.ilike(benchTable.encText, '%VALUE-00000%')) as SQL,
-    )
+    recordObservation('like', plan)
+    expect(hasSeqScan(plan), summarize(plan)).toBe(false)
   })
 
+  it('ilike engages bench_text_bloom_idx', async () => {
+    const plan = await explainWhere(
+      (await ops.ilike(benchTable.encText, '%VALUE-0000042%')) as SQL,
+    )
+    recordObservation('ilike', plan)
+    expect(hasSeqScan(plan), summarize(plan)).toBe(false)
+  })
+})
+
+// --- #422: remaining call-shaped operators (recorded, not asserted) ------
+//
+// gt/gte/lt/lte/between have no Supabase functional index path today (OPE
+// work is still in flight in EQL). jsonb_path_* don't have an obvious
+// containment form on ste_vec. order_by has no Supabase index path either.
+// Record plan shape for the investigation log; assertions land in a
+// follow-up once EQL ships the relevant index recipes.
+describe('#422: remaining call-shaped operators (recorded, not asserted)', () => {
   it('records gt / gte / lt / lte plan shapes', async () => {
     for (const [name, build] of [
       ['gt', () => ops.gt(benchTable.encInt, 5000)],

--- a/packages/stack/src/drizzle/operators.ts
+++ b/packages/stack/src/drizzle/operators.ts
@@ -851,7 +851,19 @@ function createTextSearchOperator(
       )
     }
 
-    const sqlFn = sql`eql_v2.${sql.raw(operator === 'notIlike' ? 'ilike' : operator)}(${left}, ${bindIfParam(encrypted, left)})`
+    // Emit the bloom-filter containment form directly. `eql_v2.like` /
+    // `eql_v2.ilike` are themselves a single-statement `SELECT
+    // eql_v2.bloom_filter(a) @> eql_v2.bloom_filter(b)` — but the functions
+    // are marked VOLATILE, so the planner won't inline them, and the
+    // documented `bench_text_bloom_idx` GIN functional index never engages.
+    // Inlining by hand here lets the planner match the index on every
+    // install, including Supabase. (Same shape as the hmac_256 wrap for
+    // eq/ne/inArray.)
+    //
+    // `like` and `ilike` resolve to the same SQL post-encryption — case
+    // sensitivity is determined by the column's `freeTextSearch` token
+    // filters, not by which operator the user picked.
+    const sqlFn = sql`eql_v2.bloom_filter(${left}) @> eql_v2.bloom_filter(${bindIfParam(encrypted, left)}::eql_v2_encrypted)`
     return operator === 'notIlike' ? sql`NOT (${sqlFn})` : sqlFn
   }
 


### PR DESCRIPTION
## Summary

Stacked on #425.

Addresses the `like` / `ilike` slice of #422. `eql_v2.like` and `eql_v2.ilike` are SQL functions whose bodies are already a single inlinable `SELECT eql_v2.bloom_filter(a) @> eql_v2.bloom_filter(b)` — but they're marked `VOLATILE`, which blocks the planner from inlining them into an index match. The documented `bench_text_bloom_idx` GIN functional index never engages on Supabase, so every encrypted free-text search silently seq-scans.

Drizzle now emits the inlined containment form directly, bypassing the function indirection. Same shape as #425's `hmac_256` wrap for eq/ne/inArray.

## What changed

`packages/stack/src/drizzle/operators.ts` (around line 854): emitted SQL changes from

```sql
WHERE eql_v2.like(col, $1)
```

to

```sql
WHERE eql_v2.bloom_filter(col) @> eql_v2.bloom_filter($1::eql_v2_encrypted)
```

`like` and `ilike` resolve to the same post-encryption SQL — case sensitivity is determined by the column's `freeTextSearch` token filters (e.g. `downcase`), not by which operator the user picked. The wrapped form preserves that.

`notIlike` becomes `NOT (bloom_filter(col) @> bloom_filter(value))` (same `NOT` wrap as before).

## Plan-shape verification

Same 10k-row fixture as #425. Note: the search pattern needs to be selective — the bench was using `%value-00000%` which is shared by every seeded row, so the planner correctly picked seq scan even with the index available. Updated to `%value-0000042%` (matches one row).

| Operator | Before fix | After fix                                  |
| -------- | ---------- | ------------------------------------------ |
| `like`   | Seq Scan   | **Bitmap Heap Scan** (on `bench_text_bloom_idx`) |
| `ilike`  | Seq Scan   | **Bitmap Heap Scan** (on `bench_text_bloom_idx`) |

## Proper fix (EQL-side, follow-up)

The durable cleanup is to mark `eql_v2.like` and `eql_v2.ilike` as `IMMUTABLE` in EQL itself — they're already single-statement `LANGUAGE sql` functions, so they'd inline cleanly and the planner would match the index without any Drizzle change. That helps every consumer of EQL (raw SQL, other ORMs, etc.), not just Drizzle. Will file an issue against `cipherstash/encrypt-query-language` describing the volatility fix.

This Drizzle-side wrap is the same kind of workaround #425 introduced for hmac_256 — it gets users the speedup immediately while the EQL fix lands.

## What's NOT in this PR

Issue #422 also covers `gt` / `gte` / `lt` / `lte` / `between` / `order_by` / `jsonb_path_*`. None of those have a stack-side wrap available today:

- **`gt` / `gte` / `lt` / `lte` / `between` / `order_by`**: no Supabase functional index path exists in EQL today. Blocked on the OPE work in flight in `cipherstash/encrypt-query-language`.
- **`jsonb_path_query_first` / `jsonb_path_exists` / `jsonbGet`**: function bodies don't reduce to a containment shape on `eql_v2.ste_vec(col)`. Needs an EQL-side investigation.
- **`jsonbPathQueryFirst` / `jsonbGet` typing**: tracked separately in #423.

The bench's `#422: remaining call-shaped operators` suite continues to record their plan shapes (still seq scan) without asserting; tests won't block CI.

## Test plan

- [ ] On this branch in `packages/bench`: `pnpm db:setup && pnpm test:local`. Expect 10/10 green on `__tests__/drizzle/operators.explain.test.ts`.
- [ ] Inspect `packages/bench/results/explain-shape.json` — `like` and `ilike` should report `Bitmap Heap Scan`.
- [ ] Existing `@cipherstash/stack` unit tests still pass: `pnpm -F @cipherstash/stack test`.