### PR TITLE
fix: make `stash impl` and `stash plan` not hang in non-TTY contexts

### DIFF
--- a/.changeset/handle-stdin-not-tty.md
+++ b/.changeset/handle-stdin-not-tty.md
@@ -1,0 +1,5 @@
+---
+"stash": patch
+---
+
+`stash impl` and `stash plan` no longer hang in non-TTY contexts (CI, pipes, automation harnesses). The agent-target picker previously read from `/dev/tty` and waited forever. You can now pass `--target <claude-code|codex|agents-md|wizard>` to select a handoff target non-interactively, and when neither `--target` nor a TTY is available the command prints a hint and exits cleanly instead of blocking.

--- a/packages/cli/src/bin/stash.ts
+++ b/packages/cli/src/bin/stash.ts
@@ -119,6 +119,10 @@ Plan Flags:
                            normally separates rollout from cutover. Only safe when this
                            database is not backing a deployed application (local dev,
                            sandbox, freshly seeded test environment).
+  --target <name>          Skip the agent-target picker and hand off directly to one of
+                           claude-code | codex | agents-md | wizard. Safe to call from
+                           non-TTY contexts (CI, pipes). Without --target in non-TTY,
+                           the command prints a hint and exits cleanly instead of hanging.
 
 Status Flags:
   --quest                  Force the quest-log output (emoji + progress bars)
@@ -130,6 +134,10 @@ Status Flags:
 Impl Flags:
   --continue-without-plan  Skip planning and go straight to implementation
                            (interactively confirms before proceeding)
+  --target <name>          Skip the agent-target picker and hand off directly to one of
+                           claude-code | codex | agents-md | wizard. Safe to call from
+                           non-TTY contexts (CI, pipes). Without --target in non-TTY,
+                           the command prints a hint and exits cleanly instead of hanging.
 
 DB Flags:
   --force                    (install) Reinstall / overwrite even if already installed
@@ -150,6 +158,7 @@ Examples:
   ${STASH} plan
   ${STASH} impl
   ${STASH} impl --continue-without-plan
+  ${STASH} impl --target claude-code
   ${STASH} status
   ${STASH} auth login
   ${STASH} wizard
@@ -400,10 +409,10 @@ async function main() {
       await initCommand(flags)
       break
     case 'plan':
-      await planCommand(flags)
+      await planCommand(flags, values)
       break
     case 'impl':
-      await implCommand(flags)
+      await implCommand(flags, values)
       break
     case 'status':
       await statusCommand({

--- a/packages/cli/src/commands/impl/__tests__/how-to-proceed.test.ts
+++ b/packages/cli/src/commands/impl/__tests__/how-to-proceed.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentEnvironment } from '../../init/detect-agents.js'
 import type { InitState } from '../../init/types.js'
-import { buildOptions, defaultChoice } from '../steps/how-to-proceed.js'
+import {
+  HANDOFF_CHOICES,
+  buildOptions,
+  defaultChoice,
+  resolveTarget,
+} from '../steps/how-to-proceed.js'
 
 function makeAgents(claudeCode: boolean, codex: boolean): AgentEnvironment {
   return {
@@ -62,5 +67,24 @@ describe('howToProceed — defaultChoice', () => {
     // is on PATH.
     expect(defaultChoice(noAgents, 'implement')).toBe('agents-md')
     expect(defaultChoice(noAgents, 'plan')).toBe('agents-md')
+  })
+})
+
+describe('howToProceed — resolveTarget', () => {
+  it('accepts every documented handoff target', () => {
+    for (const choice of HANDOFF_CHOICES) {
+      expect(resolveTarget(choice)).toBe(choice)
+    }
+  })
+
+  it('returns null for unknown values', () => {
+    expect(resolveTarget('claude')).toBeNull()
+    expect(resolveTarget('CLAUDE-CODE')).toBeNull()
+    expect(resolveTarget('agents.md')).toBeNull()
+    expect(resolveTarget('')).toBeNull()
+  })
+
+  it('returns null when the flag is absent', () => {
+    expect(resolveTarget(undefined)).toBeNull()
   })
 })

--- a/packages/cli/src/commands/impl/__tests__/impl.test.ts
+++ b/packages/cli/src/commands/impl/__tests__/impl.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { implCommand } from '../index.js'
+import { howToProceedStep } from '../steps/how-to-proceed.js'
+
+let originalIsTTY: boolean | undefined
+let originalCwd: string
+let tmpDir: string
+
+function writeContext() {
+  fs.mkdirSync(path.join(tmpDir, '.cipherstash'), { recursive: true })
+  fs.writeFileSync(
+    path.join(tmpDir, '.cipherstash', 'context.json'),
+    JSON.stringify({
+      integration: 'postgresql',
+      packageManager: 'npm',
+      schemas: [],
+    }),
+  )
+}
+
+function writePlan() {
+  fs.writeFileSync(path.join(tmpDir, '.cipherstash', 'plan.md'), '# Plan')
+}
+
+function setIsTTY(value: boolean) {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value,
+    configurable: true,
+  })
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-impl-test-'))
+  originalCwd = process.cwd()
+  originalIsTTY = process.stdout.isTTY
+  process.chdir(tmpDir)
+  writeContext()
+  writePlan()
+})
+
+afterEach(() => {
+  process.chdir(originalCwd)
+  Object.defineProperty(process.stdout, 'isTTY', {
+    value: originalIsTTY,
+    configurable: true,
+  })
+  vi.restoreAllMocks()
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+describe('implCommand — TTY handling', () => {
+  it('exits cleanly without running the agent-target picker when stdout is not a TTY and no --target is given', async () => {
+    setIsTTY(false)
+    const runSpy = vi
+      .spyOn(howToProceedStep, 'run')
+      .mockResolvedValue({} as never)
+
+    await expect(implCommand({}, {})).resolves.toBeUndefined()
+
+    // The whole point of the fix: when there's no TTY and no target, the
+    // command must NOT reach the picker (which reads from /dev/tty and
+    // would hang forever in automation).
+    expect(runSpy).not.toHaveBeenCalled()
+  })
+
+  it('runs the handoff with the pre-resolved target when --target is given in a non-TTY context', async () => {
+    setIsTTY(false)
+    const runSpy = vi
+      .spyOn(howToProceedStep, 'run')
+      .mockResolvedValue({} as never)
+
+    await implCommand({}, { target: 'agents-md' })
+
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    const state = runSpy.mock.calls[0][0]
+    expect(state.handoff).toBe('agents-md')
+  })
+
+  it('exits with status 1 when --target is an unknown value', async () => {
+    setIsTTY(false)
+    const runSpy = vi
+      .spyOn(howToProceedStep, 'run')
+      .mockResolvedValue({} as never)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+
+    await expect(implCommand({}, { target: 'bogus' })).rejects.toThrow(
+      'process.exit',
+    )
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(runSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/commands/impl/__tests__/impl.test.ts
+++ b/packages/cli/src/commands/impl/__tests__/impl.test.ts
@@ -25,8 +25,10 @@ function writePlan() {
   fs.writeFileSync(path.join(tmpDir, '.cipherstash', 'plan.md'), '# Plan')
 }
 
+// `implCommand` gates interactivity on `process.stdin.isTTY` (a redirected
+// stdin still hangs the agent-target picker), so the tests mock stdin.
 function setIsTTY(value: boolean) {
-  Object.defineProperty(process.stdout, 'isTTY', {
+  Object.defineProperty(process.stdin, 'isTTY', {
     value,
     configurable: true,
   })
@@ -35,7 +37,7 @@ function setIsTTY(value: boolean) {
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-impl-test-'))
   originalCwd = process.cwd()
-  originalIsTTY = process.stdout.isTTY
+  originalIsTTY = process.stdin.isTTY
   process.chdir(tmpDir)
   writeContext()
   writePlan()
@@ -43,7 +45,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.chdir(originalCwd)
-  Object.defineProperty(process.stdout, 'isTTY', {
+  Object.defineProperty(process.stdin, 'isTTY', {
     value: originalIsTTY,
     configurable: true,
   })
@@ -54,7 +56,7 @@ afterEach(() => {
 })
 
 describe('implCommand — TTY handling', () => {
-  it('exits cleanly without running the agent-target picker when stdout is not a TTY and no --target is given', async () => {
+  it('exits cleanly without running the agent-target picker when stdin is not a TTY and no --target is given', async () => {
     setIsTTY(false)
     const runSpy = vi
       .spyOn(howToProceedStep, 'run')

--- a/packages/cli/src/commands/impl/index.ts
+++ b/packages/cli/src/commands/impl/index.ts
@@ -168,7 +168,11 @@ export async function implCommand(
   const planPath = resolve(cwd, PLAN_REL_PATH)
   const planExists = existsSync(planPath)
   const continueWithoutPlan = flags['continue-without-plan'] === true
-  const isTTY = process.stdout.isTTY
+  // Interactive only when stdin is a real TTY and we're not in CI — the
+  // same gate the encrypt commands use. `process.stdout.isTTY` alone is
+  // wrong: a redirected stdin still hangs the agent-target picker (clack
+  // `select` reads from /dev/tty).
+  const isTTY = Boolean(process.stdin.isTTY) && process.env.CI !== 'true'
 
   let planStep: PlanStep | undefined
 

--- a/packages/cli/src/commands/impl/index.ts
+++ b/packages/cli/src/commands/impl/index.ts
@@ -21,7 +21,11 @@ import {
 } from '../init/lib/write-context.js'
 import { CancelledError, type InitState } from '../init/types.js'
 import { detectPackageManager, runnerCommand } from '../init/utils.js'
-import { howToProceedStep } from './steps/how-to-proceed.js'
+import {
+  HANDOFF_CHOICES,
+  howToProceedStep,
+  resolveTarget,
+} from './steps/how-to-proceed.js'
 
 function buildStateFromContext(
   ctx: ContextFile,
@@ -132,7 +136,10 @@ function printDeployGateBanner(cli: string): void {
  * dual-write code). After a rollout-step handoff, the outro is the
  * deploy-gate banner instead of a generic "verify state" pointer.
  */
-export async function implCommand(flags: Record<string, boolean>) {
+export async function implCommand(
+  flags: Record<string, boolean>,
+  values: Record<string, string> = {},
+) {
   const cwd = process.cwd()
   const pm = detectPackageManager()
   const cli = runnerCommand(pm, 'stash')
@@ -141,6 +148,17 @@ export async function implCommand(flags: Record<string, boolean>) {
   if (!ctx) {
     p.log.error(
       `No CipherStash context found at \`${CONTEXT_REL_PATH}\`. Run \`${cli} init\` first.`,
+    )
+    process.exit(1)
+  }
+
+  // Validate `--target` before printing the intro so the error sits at
+  // the top of the output instead of after a half-rendered prompt frame.
+  const targetFlag = values.target
+  const target = resolveTarget(targetFlag)
+  if (targetFlag && !target) {
+    p.log.error(
+      `Unknown --target \`${targetFlag}\`. Valid values: ${HANDOFF_CHOICES.join(', ')}.`,
     )
     process.exit(1)
   }
@@ -248,7 +266,18 @@ export async function implCommand(flags: Record<string, boolean>) {
     const agents = detectAgents(cwd, process.env)
     const state = buildStateFromContext(ctx, agents)
 
-    await howToProceedStep.run(state)
+    // Non-TTY without an explicit target would block forever on the
+    // agent-target picker (it reads from /dev/tty). Make the command
+    // safe to call from automation by short-circuiting with a hint.
+    if (!target && !isTTY) {
+      p.log.info(
+        `No agent selected. Plan is at \`${PLAN_REL_PATH}\`. Pass --target <${HANDOFF_CHOICES.join('|')}> to run the handoff non-interactively.`,
+      )
+      p.outro('No handoff performed.')
+      return
+    }
+
+    await howToProceedStep.run(target ? { ...state, handoff: target } : state)
 
     if (planStep === 'rollout') {
       printDeployGateBanner(cli)

--- a/packages/cli/src/commands/impl/steps/how-to-proceed.ts
+++ b/packages/cli/src/commands/impl/steps/how-to-proceed.ts
@@ -12,6 +12,31 @@ import { handoffCodexStep } from './handoff-codex.js'
 import { handoffWizardStep } from './handoff-wizard.js'
 
 /**
+ * The complete set of handoff targets accepted by `--target`. Kept as a
+ * runtime array (not just a type) so the CLI can validate user input
+ * against the same source of truth that drives the picker.
+ */
+export const HANDOFF_CHOICES: readonly HandoffChoice[] = [
+  'claude-code',
+  'codex',
+  'agents-md',
+  'wizard',
+] as const
+
+/**
+ * Validate a user-supplied `--target` value. Returns the canonical
+ * `HandoffChoice` if valid, or `null` otherwise. `undefined` input
+ * (flag absent) returns `null` too — callers distinguish absence from
+ * invalidity before calling this.
+ */
+export function resolveTarget(target: string | undefined): HandoffChoice | null {
+  if (!target) return null
+  return (HANDOFF_CHOICES as readonly string[]).includes(target)
+    ? (target as HandoffChoice)
+    : null
+}
+
+/**
  * Pick the default option in the menu.
  *
  * Detected CLIs win — Claude Code first, then Codex. Otherwise we default to
@@ -77,18 +102,28 @@ export const howToProceedStep: HandoffStep = {
   name: 'How to proceed',
   async run(state: InitState): Promise<InitState> {
     const mode: InitMode = state.mode ?? 'implement'
-    const message =
-      mode === 'plan'
-        ? 'Which agent should write the plan?'
-        : 'How would you like to finish setup?'
 
-    const choice = await p.select<HandoffChoice>({
-      message,
-      options: buildOptions(state, mode),
-      initialValue: defaultChoice(state, mode),
-    })
+    // Caller pre-resolved the handoff target (e.g. via `--target` on the
+    // CLI). Skip the interactive picker entirely so the command is safe
+    // to run from automation / non-TTY contexts.
+    let choice: HandoffChoice
+    if (state.handoff) {
+      choice = state.handoff
+    } else {
+      const message =
+        mode === 'plan'
+          ? 'Which agent should write the plan?'
+          : 'How would you like to finish setup?'
 
-    if (p.isCancel(choice)) throw new CancelledError()
+      const picked = await p.select<HandoffChoice>({
+        message,
+        options: buildOptions(state, mode),
+        initialValue: defaultChoice(state, mode),
+      })
+
+      if (p.isCancel(picked)) throw new CancelledError()
+      choice = picked
+    }
 
     const next: InitState = { ...state, handoff: choice }
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -116,9 +116,16 @@ export async function initCommand(flags: Record<string, boolean>) {
         await planCommand()
         return
       }
+      p.outro(`Next: run \`${cli} plan\` to draft your encryption plan.`)
+    } else {
+      // Non-TTY users (CI, agent Bash tools, pipes) will hit the same
+      // agent-target picker in `stash plan`, which only reads from
+      // /dev/tty. Steer them at `--target` up front so the next command
+      // doesn't surprise them.
+      p.outro(
+        `Next: run \`${cli} plan --target <claude-code|codex|agents-md|wizard>\` to draft your encryption plan. The \`--target\` flag is required when running non-interactively (skips the agent-target picker).`,
+      )
     }
-
-    p.outro(`Next: run \`${cli} plan\` to draft your encryption plan.`)
   } catch (err) {
     if (err instanceof CancelledError) {
       p.cancel('Setup cancelled.')

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,4 +1,5 @@
 import * as p from '@clack/prompts'
+import { HANDOFF_CHOICES } from '../impl/steps/how-to-proceed.js'
 import { planCommand } from '../plan/index.js'
 import { createBaseProvider } from './providers/base.js'
 import { createDrizzleProvider } from './providers/drizzle.js'
@@ -123,7 +124,7 @@ export async function initCommand(flags: Record<string, boolean>) {
       // /dev/tty. Steer them at `--target` up front so the next command
       // doesn't surprise them.
       p.outro(
-        `Next: run \`${cli} plan --target <claude-code|codex|agents-md|wizard>\` to draft your encryption plan. The \`--target\` flag is required when running non-interactively (skips the agent-target picker).`,
+        `Next: run \`${cli} plan --target <${HANDOFF_CHOICES.join('|')}>\` to draft your encryption plan. The \`--target\` flag is required when running non-interactively (skips the agent-target picker).`,
       )
     }
   } catch (err) {

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -177,9 +177,16 @@ export async function planCommand(
     const agents = detectAgents(cwd, process.env)
     const state = buildStateFromContext(ctx, agents, planStep)
 
-    // Non-TTY without --target would hang on the agent-target picker.
-    // Exit cleanly with a hint so automation users discover the flag.
-    if (!target && !process.stdout.isTTY) {
+    // Interactive only when stdin is a real TTY and we're not in CI — the
+    // same gate `stash impl` and the encrypt commands use. Keying off
+    // `process.stdout.isTTY` alone is wrong: a redirected stdin still
+    // hangs the agent-target picker (clack `select` reads from /dev/tty).
+    const isInteractive =
+      Boolean(process.stdin.isTTY) && process.env.CI !== 'true'
+
+    // Non-interactive without --target would hang on the agent-target
+    // picker. Exit cleanly with a hint so automation users discover the flag.
+    if (!target && !isInteractive) {
       p.log.info(
         `No agent selected. Pass --target <${HANDOFF_CHOICES.join('|')}> to run the handoff non-interactively.`,
       )
@@ -189,7 +196,7 @@ export async function planCommand(
 
     await howToProceedStep.run(target ? { ...state, handoff: target } : state)
 
-    if (process.stdout.isTTY) {
+    if (isInteractive) {
       const proceed = await p.confirm({
         message: `Plan drafted at \`${PLAN_REL_PATH}\`. Continue to \`${cli} impl\` now?`,
         initialValue: true,

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -2,7 +2,11 @@ import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { readManifest } from '@cipherstash/migrate'
 import * as p from '@clack/prompts'
-import { howToProceedStep } from '../impl/steps/how-to-proceed.js'
+import {
+  HANDOFF_CHOICES,
+  howToProceedStep,
+  resolveTarget,
+} from '../impl/steps/how-to-proceed.js'
 import { type AgentEnvironment, detectAgents } from '../init/detect-agents.js'
 import { readContextFile } from '../init/lib/read-context.js'
 import { detectColumnStates, rollupPlanStep } from '../init/lib/rollout-state.js'
@@ -119,7 +123,10 @@ async function detectPlanStep(cwd: string): Promise<PlanStep> {
  *                          one document with no deploy gate. Confirms
  *                          (default-no) before generating.
  */
-export async function planCommand(flags: Record<string, boolean> = {}) {
+export async function planCommand(
+  flags: Record<string, boolean> = {},
+  values: Record<string, string> = {},
+) {
   const cwd = process.cwd()
   const pm = detectPackageManager()
   const cli = runnerCommand(pm, 'stash')
@@ -128,6 +135,15 @@ export async function planCommand(flags: Record<string, boolean> = {}) {
   if (!ctx) {
     p.log.error(
       `No CipherStash context found at \`${CONTEXT_REL_PATH}\`. Run \`${cli} init\` first.`,
+    )
+    process.exit(1)
+  }
+
+  const targetFlag = values.target
+  const target = resolveTarget(targetFlag)
+  if (targetFlag && !target) {
+    p.log.error(
+      `Unknown --target \`${targetFlag}\`. Valid values: ${HANDOFF_CHOICES.join(', ')}.`,
     )
     process.exit(1)
   }
@@ -161,7 +177,17 @@ export async function planCommand(flags: Record<string, boolean> = {}) {
     const agents = detectAgents(cwd, process.env)
     const state = buildStateFromContext(ctx, agents, planStep)
 
-    await howToProceedStep.run(state)
+    // Non-TTY without --target would hang on the agent-target picker.
+    // Exit cleanly with a hint so automation users discover the flag.
+    if (!target && !process.stdout.isTTY) {
+      p.log.info(
+        `No agent selected. Pass --target <${HANDOFF_CHOICES.join('|')}> to run the handoff non-interactively.`,
+      )
+      p.outro('No handoff performed.')
+      return
+    }
+
+    await howToProceedStep.run(target ? { ...state, handoff: target } : state)
 
     if (process.stdout.isTTY) {
       const proceed = await p.confirm({
@@ -171,14 +197,20 @@ export async function planCommand(flags: Record<string, boolean> = {}) {
       if (!p.isCancel(proceed) && proceed) {
         p.outro('Plan complete — handing off to `stash impl`.')
         const { implCommand } = await import('../impl/index.js')
-        await implCommand({})
+        await implCommand({}, {})
         return
       }
+      p.outro(
+        `Plan drafted at \`${PLAN_REL_PATH}\`. Review it, then run \`${cli} impl\` to implement.`,
+      )
+    } else {
+      // Mirror init's non-TTY hint: the next command will also hit the
+      // agent-target picker, so name `--target` here rather than letting
+      // the user re-discover the flag on the next exit-cleanly hint.
+      p.outro(
+        `Plan drafted at \`${PLAN_REL_PATH}\`. Review it, then run \`${cli} impl --target <claude-code|codex|agents-md|wizard>\` to implement. The \`--target\` flag is required when running non-interactively.`,
+      )
     }
-
-    p.outro(
-      `Plan drafted at \`${PLAN_REL_PATH}\`. Review it, then run \`${cli} impl\` to implement.`,
-    )
   } catch (err) {
     if (err instanceof CancelledError) {
       p.cancel('Cancelled.')

--- a/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
+++ b/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runPiped } from '../helpers/spawn-piped.js'
+
+/**
+ * E2E coverage for the BUGS.md reproducer: `bunx stash impl < /dev/null`
+ * used to hang forever on the agent-target picker (clack `select` reads
+ * from `/dev/tty`). The fix short-circuits with a hint when there's no
+ * TTY and no `--target`, and accepts `--target <name>` as the
+ * non-interactive escape hatch.
+ *
+ * These tests spawn the built CLI through `runPiped` (not the PTY
+ * `render`) so the child actually sees `process.stdout.isTTY === false`,
+ * which is the precondition that triggered the original hang.
+ */
+describe('stash impl — non-TTY safety (BUGS.md reproducer)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stash-impl-non-tty-e2e-'))
+    fs.mkdirSync(path.join(tmpDir, '.cipherstash'))
+    fs.writeFileSync(
+      path.join(tmpDir, '.cipherstash', 'context.json'),
+      JSON.stringify({
+        integration: 'postgresql',
+        packageManager: 'npm',
+        schemas: [],
+      }),
+    )
+    // A plan file is required to reach the agent-target picker — without
+    // one, impl exits earlier on the "no plan + non-TTY" guard. The
+    // BUGS.md repro had a plan on disk, which is how the bug surfaced.
+    fs.writeFileSync(path.join(tmpDir, '.cipherstash', 'plan.md'), '# Plan')
+  })
+
+  afterEach(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('exits 0 with a hint instead of hanging on the agent-target picker', async () => {
+    // 5s is well over the time the fix needs (≈100ms in practice) and
+    // well under what would happen on a regression (the original bug
+    // hung indefinitely).
+    const r = await runPiped(['impl'], { cwd: tmpDir, timeoutMs: 5_000 })
+
+    expect(r.timedOut).toBe(false)
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain('No agent selected')
+    expect(r.stdout).toContain('--target')
+    expect(r.stdout).toContain('claude-code|codex|agents-md|wizard')
+  })
+
+  it('rejects an unknown --target with a clear error and exits 1', async () => {
+    const r = await runPiped(['impl', '--target', 'bogus'], {
+      cwd: tmpDir,
+      timeoutMs: 5_000,
+    })
+
+    expect(r.timedOut).toBe(false)
+    expect(r.exitCode).toBe(1)
+    const combined = r.stdout + r.stderr
+    expect(combined).toContain('Unknown --target')
+    expect(combined).toContain('bogus')
+    expect(combined).toContain('claude-code')
+    expect(combined).toContain('wizard')
+  })
+
+  it('--help documents the --target flag under Impl Flags', async () => {
+    const r = await runPiped(['--help'], { timeoutMs: 5_000 })
+
+    expect(r.timedOut).toBe(false)
+    expect(r.exitCode).toBe(0)
+    expect(r.stdout).toContain('Impl Flags:')
+    expect(r.stdout).toContain('--target')
+    expect(r.stdout).toContain('claude-code | codex | agents-md | wizard')
+  })
+})

--- a/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
+++ b/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { HANDOFF_CHOICES } from '../../src/commands/impl/steps/how-to-proceed.js'
 import { runPiped } from '../helpers/spawn-piped.js'
 
 /**
@@ -51,7 +52,9 @@ describe('stash impl — non-TTY safety (BUGS.md reproducer)', () => {
     expect(r.exitCode).toBe(0)
     expect(r.stdout).toContain('No agent selected')
     expect(r.stdout).toContain('--target')
-    expect(r.stdout).toContain('claude-code|codex|agents-md|wizard')
+    // Derive the target list from the same source the command renders it
+    // from, so adding a handoff target can't silently drift the test.
+    expect(r.stdout).toContain(HANDOFF_CHOICES.join('|'))
   })
 
   it('rejects an unknown --target with a clear error and exits 1', async () => {

--- a/packages/cli/tests/helpers/spawn-piped.ts
+++ b/packages/cli/tests/helpers/spawn-piped.ts
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process'
+import { STASH_BIN } from './pty.js'
+
+/**
+ * Non-PTY counterpart to `render()` in `./pty.ts`. Spawns the built CLI
+ * with all three stdio channels as pipes — so the child sees
+ * `process.stdout.isTTY === false` and `/dev/tty` is unavailable. This is
+ * the exact "non-TTY context" the BUGS.md reproducer described:
+ * `bunx stash impl < /dev/null` from CI, automation harnesses, or the
+ * Claude Code Bash tool.
+ *
+ * Use this — not `render()` — when the behaviour under test depends on
+ * non-TTY stdio. `render()` (node-pty) always gives the child a real
+ * terminal.
+ */
+export interface PipedResult {
+  /** `null` only when the process was SIGKILLed by the timeout. */
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  /** True when the timeout fired and we had to kill the process. */
+  timedOut: boolean
+}
+
+export interface PipedOptions {
+  cwd?: string
+  env?: Record<string, string>
+  /** Default 10s — short enough that a regression of the hang surfaces fast. */
+  timeoutMs?: number
+}
+
+export function runPiped(
+  args: string[],
+  opts: PipedOptions = {},
+): Promise<PipedResult> {
+  return new Promise((resolvePromise, reject) => {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      NO_COLOR: '1',
+      FORCE_COLOR: '0',
+      ...(opts.env ?? {}),
+    }
+
+    const child = spawn(process.execPath, [STASH_BIN, ...args], {
+      cwd: opts.cwd ?? process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    child.stdout?.on('data', (d: Buffer) => {
+      stdout += d.toString()
+    })
+    child.stderr?.on('data', (d: Buffer) => {
+      stderr += d.toString()
+    })
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, opts.timeoutMs ?? 10_000)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolvePromise({ exitCode: code, stdout, stderr, timedOut })
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}

--- a/skills/stash-cli/SKILL.md
+++ b/skills/stash-cli/SKILL.md
@@ -42,6 +42,17 @@ The setup lifecycle is split across four explicit save-points. Each command can 
 | `stash impl` | Executes the plan via agent handoff. Refuses cutover-step plans without a recorded `dual_writing` event; prints the deploy-gate banner after a rollout-step run. | Deploy-gate banner (rollout) or "verify state" (cutover/new) |
 | `stash status` | The encryption-rollout quest log — per-column "where am I" map, runs in ms | — |
 
+### Running from automation (non-TTY)
+
+If you're invoking `stash plan` or `stash impl` from a non-TTY context — CI, a pipe, or an agent's Bash tool — **always pass `--target <claude-code|codex|agents-md|wizard>`**. Both commands present an interactive agent-target picker that reads from `/dev/tty`; without `--target` they print a "no agent selected" hint and exit 0 without performing the handoff. With `--target`, the picker is skipped and the named handoff runs non-interactively.
+
+```bash
+stash plan --target claude-code
+stash impl --target agents-md
+```
+
+`stash init` and `stash status` are safe to call from any context — they detect non-TTY and adapt automatically.
+
 ### Rolling encryption out to production
 
 Two paths to a fully-encrypted column:
@@ -139,9 +150,12 @@ The `--supabase` and `--drizzle` flags tailor the intro message and EQL install 
 ```bash
 stash plan
 stash plan --complete-rollout
+stash plan --target claude-code        # non-interactive — skip the agent picker
 ```
 
 `plan` is the **draft for review** save-point. Pre-flights `.cipherstash/context.json` (errors with a "Run `stash init` first" pointer if missing). Hands off to a coding agent — all four targets are offered: Claude Code, Codex, AGENTS.md (for Cursor/Windsurf/Cline), and the CipherStash Agent (`@cipherstash/wizard`).
+
+`--target <claude-code|codex|agents-md|wizard>` skips the interactive agent-target picker. **Required when invoking `plan` from a non-TTY context** (CI, pipes, an agent's Bash tool) — without it, `plan` prints a "no agent selected" hint and exits 0 without performing the handoff. In a TTY, `--target` is optional; it just bypasses the picker.
 
 `plan` is **state-driven**. It reads `.cipherstash/migrations.json` and `cs_migrations` and dispatches to one of three plan templates:
 
@@ -168,19 +182,24 @@ There is no atomic way to replace a populated plaintext column with an encrypted
 ```bash
 stash impl
 stash impl --continue-without-plan
+stash impl --target claude-code        # non-interactive — skip the agent picker
 ```
 
 `impl` is the **execute** save-point. Pre-flights `.cipherstash/context.json`. Behaviour branches on disk state:
 
 | State | Behaviour |
 |-------|-----------|
-| Plan exists, TTY | Parses the summary block. Enforces the deploy gate (see below). Renders a confirm panel describing the plan scope. Default-yes confirm. |
-| Plan exists, non-TTY | Logs and proceeds without confirm (CI/pipe-safe). The deploy-gate check still runs. |
+| Plan exists, TTY, no `--target` | Parses the summary block. Enforces the deploy gate (see below). Renders a confirm panel describing the plan scope. Default-yes confirm, then the agent-target picker. |
+| Plan exists, TTY, `--target X` | Same confirm panel, but skips the picker and runs handoff `X`. |
+| Plan exists, non-TTY, `--target X` | Logs the plan path, skips both the confirm and the picker, runs handoff `X`. |
+| Plan exists, non-TTY, no `--target` | Logs the plan path, prints a "No agent selected — pass `--target`" hint, and exits 0 without performing the handoff. The deploy-gate check still runs first. |
 | No plan, TTY | Interactive `p.select`: "Draft a plan first (recommended)" / "Continue without a plan" / cancel. "Draft" delegates to `stash plan`. "Continue" goes through a security confirm (default-no) before implementing. |
 | No plan, `--continue-without-plan` | Skips the picker, runs the security confirm (still default-no), then implements. |
 | No plan, non-TTY, no flag | Errors out with "Run `stash plan` first, or pass `--continue-without-plan` to skip planning." Forces explicit intent in CI. |
 
-Once the user clears the gate, `impl` dispatches to a handoff target (Claude Code, Codex, AGENTS.md for Cursor/Windsurf/Cline, or `@cipherstash/wizard`) and the agent executes the plan: schema edits, migrations, `stash encrypt {backfill,cutover,drop}` as appropriate. (Proxy users also run `stash db push` where indicated in the plan.)
+`--target <claude-code|codex|agents-md|wizard>` skips the interactive agent-target picker. **Required when invoking `impl` from a non-TTY context** (CI, pipes, an agent's Bash tool); without it, `impl` exits cleanly with a hint rather than hanging on `/dev/tty`. In a TTY, `--target` is optional.
+
+Once the user clears the gate, `impl` dispatches to a handoff target (Claude Code, Codex, AGENTS.md for Cursor/Windsurf/Cline, or `@cipherstash/wizard`) and the agent executes the plan: schema edits, migrations, `stash db push`, `stash encrypt {backfill,cutover,drop}` as appropriate.
 
 #### Deploy-gate enforcement
 


### PR DESCRIPTION
The agent-target picker previously read from `/dev/tty` and waited forever. This caused problems when running `impl` or `plan` in CI, pipes, and automation harnesses.

This fix allows users to pass `--target <claude-code|codex|agents-md|wizard>` to select a handoff target non-interactively.

When neither `--target` nor a TTY is available the command prints a hint and exits cleanly instead of blocking.

Fixes #445.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--target` flag to `stash plan` and `stash impl` for non-interactive agent selection in automation environments (supports: claude-code, codex, agents-md, wizard).

* **Bug Fixes**
  * Commands no longer hang in non-TTY environments (CI/pipes); they exit cleanly with helpful hints when `--target` is not provided.

* **Documentation**
  * Updated guidance for running commands in non-interactive/automation contexts with examples and required `--target` usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/stack/pull/446)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->