### PR TITLE
fix: make Prisma example idempotent

### DIFF
--- a/examples/prisma/src/index.ts
+++ b/examples/prisma/src/index.ts
@@ -103,6 +103,7 @@ async function main() {
 
   const runtime = await db.connect({ url })
   try {
+    await clearUsers()
     await insertUsers()
     await searchByEq()
     await searchByIlikeAndDecrypt()
@@ -113,6 +114,13 @@ async function main() {
     await sortByEmailAsc()
   } finally {
     await runtime.close()
+  }
+}
+
+async function clearUsers(): Promise<void> {
+  const removed = await db.orm.User.where((u) => u.id.isNotNull()).deleteCount()
+  if (removed > 0) {
+    console.log(`--- Cleanup ---\nRemoved ${removed} existing user row(s).\n`)
   }
 }
 


### PR DESCRIPTION
When a user runs `pnpm start` in the Prisma example app at `examples/prisma`, it inserts seed users with hardcoded primary keys (`user-0`..`user-3`). 

The first run succeeds, but every subsequent run aborts with a unique key constraint violation before any of the codec demonstrations execute.

Make the demo idempotent, so a user can run it multiple times without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example with improved data initialization workflow to ensure clean state before seeding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/stack/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->