### PR TITLE
test(e2e): add outside-in walkthrough of the prisma example README

### DIFF
--- a/.github/workflows/prisma-example-readme-e2e.yml
+++ b/.github/workflows/prisma-example-readme-e2e.yml
@@ -1,0 +1,81 @@
+name: Prisma Example README E2E
+
+# Outside-in walkthrough of `examples/prisma/README.md`'s "Run it"
+# section: copies .env.example, brings up the bundled Postgres, runs
+# `pnpm install`, `pnpm emit`, `pnpm migration:plan --name initial`,
+# `pnpm migration:apply`, then `pnpm start`, asserting each command
+# exits 0 and that `pnpm start` prints the documented "Expected
+# output" lines.
+#
+# Lives in the root `e2e/` workspace as
+# `tests/prisma-example-readme.e2e.test.ts`. Auth-gated: skips
+# cleanly on fork PRs where ZeroKMS secrets are unavailable.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/prisma/**'
+      - '.github/workflows/prisma-example-readme-e2e.yml'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'examples/prisma/**'
+      - '.github/workflows/prisma-example-readme-e2e.yml'
+
+jobs:
+  walkthrough:
+    name: Run README walkthrough
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    # Skip cleanly on fork PRs where secrets aren't available. The
+    # test's `describe.skipIf(!authConfigured)` would also skip, but
+    # gating at the job level produces a clean "skipped" status.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    env:
+      CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
+      CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
+      CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
+      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6.0.7
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      # node-pty's install hook falls back to `node-gyp rebuild` when no
+      # linux-x64 prebuild matches. pnpm/action-setup v6 no longer ships
+      # node-gyp on PATH, so install it explicitly.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build via turbo so `^build` on `@cipherstash/prisma-next` and
+      # its `@cipherstash/stack` peer is honoured. The test's
+      # `pnpm install` subprocess inside `examples/prisma/` is a no-op
+      # given the lockfile is already in steady state from this step.
+      - name: Build @cipherstash/prisma-next
+        run: pnpm exec turbo run build --filter @cipherstash/prisma-next
+
+      - name: Run README walkthrough e2e
+        run: pnpm exec turbo run test:e2e --filter @cipherstash/e2e -- --run tests/prisma-example-readme.e2e.test.ts
+
+      - name: Tear down bundled Postgres (best-effort)
+        if: always()
+        working-directory: examples/prisma
+        run: docker compose down -v || true

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -24,7 +24,7 @@ pnpm --filter @cipherstash/e2e exec vitest run tests/package-managers.e2e.test.t
 | --- | --- |
 | `tests/package-managers.e2e.test.ts` | The `init` providers and the wizard binary render `bunx`/`pnpm dlx`/`yarn dlx`/`npx` based on detected package manager. |
 | `tests/supply-chain.e2e.test.ts` | Lockfile/registry/CODEOWNERS controls from `skills/stash-supply-chain-security` are still enforced. |
-| `tests/prisma-example-readme.e2e.test.ts` | Walks every command in `examples/prisma/README.md`'s "Run it" section (skips `stash auth login`) and asserts `pnpm start` matches the documented "Expected output". |
+| `tests/prisma-example-readme.e2e.test.ts` | Parses `examples/prisma/README.md`'s "Run it" section and asserts every command (skipping `stash auth login`) exits 0. |
 
 ## Auth-dependent suites
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,8 @@ pnpm --filter @cipherstash/e2e exec vitest run tests/package-managers.e2e.test.t
 | Test file | Scope |
 | --- | --- |
 | `tests/package-managers.e2e.test.ts` | The `init` providers and the wizard binary render `bunx`/`pnpm dlx`/`yarn dlx`/`npx` based on detected package manager. |
+| `tests/supply-chain.e2e.test.ts` | Lockfile/registry/CODEOWNERS controls from `skills/stash-supply-chain-security` are still enforced. |
+| `tests/prisma-example-readme.e2e.test.ts` | Walks every command in `examples/prisma/README.md`'s "Run it" section (skips `stash auth login`) and asserts `pnpm start` matches the documented "Expected output". |
 
 ## Auth-dependent suites
 

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -16,6 +16,47 @@ const authConfigured = (() => {
   return existsSync(join(home, '.cipherstash', 'auth.json'))
 })()
 
+interface StepResult {
+  readonly label: string
+  readonly status: number | null
+  readonly signal: NodeJS.Signals | null
+  readonly stdout: string
+  readonly stderr: string
+  readonly error: Error | undefined
+}
+
+function describeSpawnFailure(result: StepResult): string {
+  const lines = [`step \`${result.label}\` failed.`]
+  if (result.error) lines.push(`  spawn error: ${result.error.message}`)
+  if (result.signal) lines.push(`  killed by signal: ${result.signal}`)
+  if (typeof result.status === 'number') lines.push(`  exit status: ${result.status}`)
+  if (result.stderr.trim()) lines.push(`--- stderr ---\n${result.stderr.trim()}`)
+  if (result.stdout.trim()) lines.push(`--- stdout ---\n${result.stdout.trim()}`)
+  return lines.join('\n')
+}
+
+function runStep(
+  label: string,
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; timeoutMs?: number; env?: NodeJS.ProcessEnv } = {},
+): StepResult {
+  const result: SpawnSyncReturns<Buffer> = spawnSync(cmd, args, {
+    cwd: opts.cwd ?? EXAMPLE_DIR,
+    timeout: opts.timeoutMs ?? 120_000,
+    stdio: 'pipe',
+    env: opts.env ?? process.env,
+  })
+  return {
+    label,
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+    error: result.error,
+  }
+}
+
 describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
   it('placeholder — replaced in subsequent tasks', () => {
     expect(authConfigured).toBe(true)

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -93,17 +93,52 @@ async function wipeTransientOutputs(): Promise<void> {
   }
 }
 
-interface Outcomes {
-  cpEnv?: StepResult
-  dockerUp?: StepResult
-  pnpmInstall?: StepResult
-  pnpmEmit?: StepResult
-  pnpmPlan?: StepResult
-  pnpmApply?: StepResult
-  pnpmStart?: StepResult
+// Parses the bash code fence directly under `## Run it` in the example's
+// README. Strips inline ` # ...` comments, trims, drops blank lines, and
+// preserves order. Throws with a descriptive message if the heading or
+// fence isn't found — that way a malformed README surfaces at test-collection
+// time, not as an opaque parse error mid-run.
+function parseRunItCommands(readme: string): string[] {
+  const match = readme.match(/^## Run it\b[\s\S]*?\n```bash\n([\s\S]*?)\n```/m)
+  if (!match) {
+    throw new Error(
+      'parseRunItCommands: could not locate the bash code fence under `## Run it` in the README. ' +
+        'Check examples/prisma/README.md structure (expected `## Run it` heading followed by a ```bash fenced block).',
+    )
+  }
+  return match[1]!
+    .split('\n')
+    .map((line) => line.replace(/\s+#\s.*$/, '').trim())
+    .filter((line) => line.length > 0)
 }
 
-const outcomes: Outcomes = {}
+// Interactive commands the test must skip in CI. `stash auth login` is PKCE;
+// it blocks on a browser. Exact-match by design — if the README's wording
+// drifts, the test fails loudly rather than silently over-skipping.
+const SKIP_COMMANDS = new Set<string>(['stash auth login'])
+
+const TIMEOUT_BY_PREFIX: Array<readonly [RegExp, number]> = [
+  [/^cp\b/, 5_000],
+  [/^docker compose up\b/, 180_000],
+  [/^pnpm install\b/, 180_000],
+  [/^pnpm migration:apply\b/, 180_000],
+  [/^pnpm start\b/, 180_000],
+]
+const DEFAULT_TIMEOUT_MS = 60_000
+function timeoutFor(line: string): number {
+  for (const [re, ms] of TIMEOUT_BY_PREFIX) if (re.test(line)) return ms
+  return DEFAULT_TIMEOUT_MS
+}
+
+// Parse the README at module load (test collection time) so per-step `it()`s
+// can be registered dynamically. The README is in-repo and small; a sync read
+// here is the right call.
+const README_COMMANDS = parseRunItCommands(
+  readFileSync(resolve(EXAMPLE_DIR, 'README.md'), 'utf8'),
+)
+const EXECUTED_COMMANDS = README_COMMANDS.filter((line) => !SKIP_COMMANDS.has(line))
+
+const outcomes = new Map<string, StepResult>()
 let snapDir: string
 
 describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
@@ -111,51 +146,16 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
     snapDir = await snapshotTransientOutputs()
     await wipeTransientOutputs()
 
-    // Step 1: cp .env.example .env
-    // Run via `cp` for fidelity to the README; falls back to ENOENT spawn
-    // error on Windows runners (we only target Linux/macOS in CI).
-    outcomes.cpEnv = runStep('cp .env.example .env', 'cp', ['.env.example', '.env'], {
-      timeoutMs: 5_000,
-    })
-
-    // Step 2: docker compose up -d
-    outcomes.dockerUp = runStep(
-      'docker compose up -d',
-      'docker',
-      ['compose', 'up', '-d', '--wait'],
-      { timeoutMs: 180_000 },
-    )
-
-    // Step 3: pnpm install
-    outcomes.pnpmInstall = runStep('pnpm install', 'pnpm', ['install'], {
-      timeoutMs: 180_000,
-    })
-
-    // Step 4: pnpm emit
-    outcomes.pnpmEmit = runStep('pnpm emit', 'pnpm', ['emit'], {
-      timeoutMs: 60_000,
-    })
-
-    // Step 5: pnpm migration:plan --name initial
-    outcomes.pnpmPlan = runStep(
-      'pnpm migration:plan --name initial',
-      'pnpm',
-      ['migration:plan', '--name', 'initial'],
-      { timeoutMs: 60_000 },
-    )
-
-    // Step 6: pnpm migration:apply
-    outcomes.pnpmApply = runStep(
-      'pnpm migration:apply',
-      'pnpm',
-      ['migration:apply'],
-      { timeoutMs: 120_000 },
-    )
-
-    // Step 7: pnpm start
-    outcomes.pnpmStart = runStep('pnpm start', 'pnpm', ['start'], {
-      timeoutMs: 120_000,
-    })
+    // Drive the walkthrough straight from the parsed README. `bash -c` keeps
+    // fidelity with what a user actually types — no argv tokenizer needed,
+    // future README evolutions (operators, quoting) Just Work.
+    for (const line of README_COMMANDS) {
+      if (SKIP_COMMANDS.has(line)) {
+        console.log(`[readme-walkthrough] skip: ${line}`)
+        continue
+      }
+      outcomes.set(line, runStep(line, 'bash', ['-c', line], { timeoutMs: timeoutFor(line) }))
+    }
   }, 600_000) // 10 min total budget for the cold path
 
   afterAll(async () => {
@@ -172,17 +172,21 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
     rmSync(join(EXAMPLE_DIR, '.env'), { force: true })
   }, 120_000)
 
-  it('cp .env.example .env succeeded', () => {
-    const r = outcomes.cpEnv!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
+  // Per-step exit-zero assertion, registered once per non-skipped README line.
+  it.each(EXECUTED_COMMANDS)('README "Run it" step exited 0: %s', (line) => {
+    const r = outcomes.get(line)
+    expect(r, `no outcome recorded for \`${line}\` — beforeAll did not run this step`).toBeDefined()
+    expect(r!.status, describeSpawnFailure(r!)).toBe(0)
+  })
+
+  // Side-effect assertions: observe the final state after the walkthrough.
+  // Not driven by README parse — these guard against "exit 0 but produced
+  // no output" regressions that pure exit-zero checks can't catch.
+  it('cp produced examples/prisma/.env', () => {
     expect(existsSync(join(EXAMPLE_DIR, '.env'))).toBe(true)
   })
 
-  it('docker compose up -d succeeded and Postgres became ready', () => {
-    const r = outcomes.dockerUp!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
-    // Compose --wait already gates on the healthcheck. Double-check by
-    // exec'ing pg_isready against the container the README owns.
+  it('Postgres container is ready', () => {
     const ready = runStep(
       'pg_isready',
       'docker',
@@ -192,41 +196,22 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
     expect(ready.status, describeSpawnFailure(ready)).toBe(0)
   })
 
-  it('pnpm install succeeded', () => {
-    const r = outcomes.pnpmInstall!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
-  })
-
-  it('pnpm emit succeeded and wrote contract.{json,d.ts}', () => {
-    const r = outcomes.pnpmEmit!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
+  it('pnpm emit wrote contract.{json,d.ts}', () => {
     expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.json'))).toBe(true)
     expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.d.ts'))).toBe(true)
   })
 
-  it('pnpm migration:plan --name initial succeeded and produced an initial migration', () => {
-    const r = outcomes.pnpmPlan!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
+  it('pnpm migration:plan produced an initial migration', () => {
     const appDir = join(EXAMPLE_DIR, 'migrations/app')
     expect(existsSync(appDir)).toBe(true)
     const entries = readdirSync(appDir)
-    // CLI names the migration `<timestamp>_initial`; assert at least one
-    // entry matches that suffix.
     expect(entries.some((e) => /_initial$/.test(e))).toBe(true)
   })
 
-  it('pnpm migration:apply succeeded', () => {
-    const r = outcomes.pnpmApply!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
-  })
-
-  it('pnpm start exited 0', () => {
-    const r = outcomes.pnpmStart!
-    expect(r.status, describeSpawnFailure(r)).toBe(0)
-  })
-
   it('pnpm start output contains every documented codec demo heading', () => {
-    const stdout = outcomes.pnpmStart!.stdout
+    const startLine = README_COMMANDS.find((l) => /^pnpm start\b/.test(l))
+    expect(startLine, '`pnpm start` not found in README walkthrough').toBeDefined()
+    const stdout = outcomes.get(startLine!)?.stdout ?? ''
 
     // Headings from README "Expected output" — every one must appear.
     const headings = [
@@ -245,7 +230,9 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
   })
 
   it('pnpm start output contains the documented row counts and email values', () => {
-    const stdout = outcomes.pnpmStart!.stdout
+    const startLine = README_COMMANDS.find((l) => /^pnpm start\b/.test(l))
+    expect(startLine, '`pnpm start` not found in README walkthrough').toBeDefined()
+    const stdout = outcomes.get(startLine!)?.stdout ?? ''
     const expectations = [
       'Inserted 4 rows across six cipherstash codecs.',
       'Found 1 row(s) for alice@example.com.',

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -57,8 +57,59 @@ function runStep(
   }
 }
 
+const TRANSIENT_PATHS = [
+  'migrations/app',
+  'src/prisma/contract.json',
+  'src/prisma/contract.d.ts',
+] as const
+
+async function snapshotTransientOutputs(): Promise<string> {
+  const snap = mkdtempSync(join(tmpdir(), 'prisma-readme-e2e-snap-'))
+  const { cpSync, mkdirSync } = await import('node:fs')
+  for (const rel of TRANSIENT_PATHS) {
+    const src = join(EXAMPLE_DIR, rel)
+    if (!existsSync(src)) continue
+    const dest = join(snap, rel)
+    mkdirSync(dirname(dest), { recursive: true })
+    cpSync(src, dest, { recursive: true })
+  }
+  return snap
+}
+
+async function restoreTransientOutputs(snap: string): Promise<void> {
+  const { cpSync } = await import('node:fs')
+  for (const rel of TRANSIENT_PATHS) {
+    const src = join(snap, rel)
+    const dest = join(EXAMPLE_DIR, rel)
+    rmSync(dest, { recursive: true, force: true })
+    if (existsSync(src)) {
+      cpSync(src, dest, { recursive: true })
+    }
+  }
+  rmSync(snap, { recursive: true, force: true })
+}
+
+async function wipeTransientOutputs(): Promise<void> {
+  for (const rel of TRANSIENT_PATHS) {
+    rmSync(join(EXAMPLE_DIR, rel), { recursive: true, force: true })
+  }
+}
+
 describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
-  it('placeholder — replaced in subsequent tasks', () => {
-    expect(authConfigured).toBe(true)
+  let snapDir: string
+
+  beforeAll(async () => {
+    snapDir = await snapshotTransientOutputs()
+    await wipeTransientOutputs()
+  }, 60_000)
+
+  afterAll(async () => {
+    await restoreTransientOutputs(snapDir)
+  }, 60_000)
+
+  it('wipes transient outputs and restores from snapshot', () => {
+    // Mid-test: contract.json is gone (wipe ran in beforeAll).
+    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.json'))).toBe(false)
+    expect(existsSync(join(EXAMPLE_DIR, 'migrations/app'))).toBe(false)
   })
 })

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -65,7 +65,6 @@ const TRANSIENT_PATHS = [
 
 async function snapshotTransientOutputs(): Promise<string> {
   const snap = mkdtempSync(join(tmpdir(), 'prisma-readme-e2e-snap-'))
-  const { cpSync, mkdirSync } = await import('node:fs')
   for (const rel of TRANSIENT_PATHS) {
     const src = join(EXAMPLE_DIR, rel)
     if (!existsSync(src)) continue
@@ -77,7 +76,6 @@ async function snapshotTransientOutputs(): Promise<string> {
 }
 
 async function restoreTransientOutputs(snap: string): Promise<void> {
-  const { cpSync } = await import('node:fs')
   for (const rel of TRANSIENT_PATHS) {
     const src = join(snap, rel)
     const dest = join(EXAMPLE_DIR, rel)
@@ -176,6 +174,54 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
 
   it('cp .env.example .env succeeded', () => {
     const r = outcomes.cpEnv!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+    expect(existsSync(join(EXAMPLE_DIR, '.env'))).toBe(true)
+  })
+
+  it('docker compose up -d succeeded and Postgres became ready', () => {
+    const r = outcomes.dockerUp!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+    // Compose --wait already gates on the healthcheck. Double-check by
+    // exec'ing pg_isready against the container the README owns.
+    const ready = runStep(
+      'pg_isready',
+      'docker',
+      ['exec', 'cipherstash-prisma-example-pg', 'pg_isready', '-U', 'postgres', '-d', 'cipherstash_prisma_example'],
+      { timeoutMs: 10_000 },
+    )
+    expect(ready.status, describeSpawnFailure(ready)).toBe(0)
+  })
+
+  it('pnpm install succeeded', () => {
+    const r = outcomes.pnpmInstall!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+  })
+
+  it('pnpm emit succeeded and wrote contract.{json,d.ts}', () => {
+    const r = outcomes.pnpmEmit!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.json'))).toBe(true)
+    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.d.ts'))).toBe(true)
+  })
+
+  it('pnpm migration:plan --name initial succeeded and produced an initial migration', () => {
+    const r = outcomes.pnpmPlan!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+    const appDir = join(EXAMPLE_DIR, 'migrations/app')
+    expect(existsSync(appDir)).toBe(true)
+    const entries = readdirSync(appDir)
+    // CLI names the migration `<timestamp>_initial`; assert at least one
+    // entry matches that suffix.
+    expect(entries.some((e) => /_initial$/.test(e))).toBe(true)
+  })
+
+  it('pnpm migration:apply succeeded', () => {
+    const r = outcomes.pnpmApply!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
+  })
+
+  it('pnpm start exited 0', () => {
+    const r = outcomes.pnpmStart!
     expect(r.status, describeSpawnFailure(r)).toBe(0)
   })
 })

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -95,21 +95,87 @@ async function wipeTransientOutputs(): Promise<void> {
   }
 }
 
-describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
-  let snapDir: string
+interface Outcomes {
+  cpEnv?: StepResult
+  dockerUp?: StepResult
+  pnpmInstall?: StepResult
+  pnpmEmit?: StepResult
+  pnpmPlan?: StepResult
+  pnpmApply?: StepResult
+  pnpmStart?: StepResult
+}
 
+const outcomes: Outcomes = {}
+let snapDir: string
+
+describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
   beforeAll(async () => {
     snapDir = await snapshotTransientOutputs()
     await wipeTransientOutputs()
-  }, 60_000)
+
+    // Step 1: cp .env.example .env
+    // Run via `cp` for fidelity to the README; falls back to ENOENT spawn
+    // error on Windows runners (we only target Linux/macOS in CI).
+    outcomes.cpEnv = runStep('cp .env.example .env', 'cp', ['.env.example', '.env'], {
+      timeoutMs: 5_000,
+    })
+
+    // Step 2: docker compose up -d
+    outcomes.dockerUp = runStep(
+      'docker compose up -d',
+      'docker',
+      ['compose', 'up', '-d', '--wait'],
+      { timeoutMs: 180_000 },
+    )
+
+    // Step 3: pnpm install
+    outcomes.pnpmInstall = runStep('pnpm install', 'pnpm', ['install'], {
+      timeoutMs: 180_000,
+    })
+
+    // Step 4: pnpm emit
+    outcomes.pnpmEmit = runStep('pnpm emit', 'pnpm', ['emit'], {
+      timeoutMs: 60_000,
+    })
+
+    // Step 5: pnpm migration:plan --name initial
+    outcomes.pnpmPlan = runStep(
+      'pnpm migration:plan --name initial',
+      'pnpm',
+      ['migration:plan', '--name', 'initial'],
+      { timeoutMs: 60_000 },
+    )
+
+    // Step 6: pnpm migration:apply
+    outcomes.pnpmApply = runStep(
+      'pnpm migration:apply',
+      'pnpm',
+      ['migration:apply'],
+      { timeoutMs: 120_000 },
+    )
+
+    // Step 7: pnpm start
+    outcomes.pnpmStart = runStep('pnpm start', 'pnpm', ['start'], {
+      timeoutMs: 120_000,
+    })
+  }, 600_000) // 10 min total budget for the cold path
 
   afterAll(async () => {
+    // Teardown the bundled Postgres container regardless of outcome.
+    runStep(
+      'docker compose down -v',
+      'docker',
+      ['compose', 'down', '-v'],
+      { timeoutMs: 60_000 },
+    )
+    // Restore the transient outputs from snapshot so the working tree is clean.
     await restoreTransientOutputs(snapDir)
-  }, 60_000)
+    // Remove the .env we copied in the walkthrough (not tracked anyway).
+    rmSync(join(EXAMPLE_DIR, '.env'), { force: true })
+  }, 120_000)
 
-  it('wipes transient outputs and restores from snapshot', () => {
-    // Mid-test: contract.json is gone (wipe ran in beforeAll).
-    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.json'))).toBe(false)
-    expect(existsSync(join(EXAMPLE_DIR, 'migrations/app'))).toBe(false)
+  it('cp .env.example .env succeeded', () => {
+    const r = outcomes.cpEnv!
+    expect(r.status, describeSpawnFailure(r)).toBe(0)
   })
 })

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -177,77 +177,5 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
     const r = outcomes.get(line)
     expect(r, `no outcome recorded for \`${line}\` — beforeAll did not run this step`).toBeDefined()
     expect(r!.status, describeSpawnFailure(r!)).toBe(0)
-  })
-
-  // Side-effect assertions: observe the final state after the walkthrough.
-  // Not driven by README parse — these guard against "exit 0 but produced
-  // no output" regressions that pure exit-zero checks can't catch.
-  it('cp produced examples/prisma/.env', () => {
-    expect(existsSync(join(EXAMPLE_DIR, '.env'))).toBe(true)
-  })
-
-  it('Postgres container is ready', () => {
-    const ready = runStep(
-      'pg_isready',
-      'docker',
-      ['exec', 'cipherstash-prisma-example-pg', 'pg_isready', '-U', 'postgres', '-d', 'cipherstash_prisma_example'],
-      { timeoutMs: 10_000 },
-    )
-    expect(ready.status, describeSpawnFailure(ready)).toBe(0)
-  })
-
-  it('pnpm emit wrote contract.{json,d.ts}', () => {
-    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.json'))).toBe(true)
-    expect(existsSync(join(EXAMPLE_DIR, 'src/prisma/contract.d.ts'))).toBe(true)
-  })
-
-  it('pnpm migration:plan produced an initial migration', () => {
-    const appDir = join(EXAMPLE_DIR, 'migrations/app')
-    expect(existsSync(appDir)).toBe(true)
-    const entries = readdirSync(appDir)
-    expect(entries.some((e) => /_initial$/.test(e))).toBe(true)
-  })
-
-  it('pnpm start output contains every documented codec demo heading', () => {
-    const startLine = README_COMMANDS.find((l) => /^pnpm start\b/.test(l))
-    expect(startLine, '`pnpm start` not found in README walkthrough').toBeDefined()
-    const stdout = outcomes.get(startLine!)?.stdout ?? ''
-
-    // Headings from README "Expected output" — every one must appear.
-    const headings = [
-      '--- Insert (mixed-codec round-trip) ---',
-      '--- cipherstashEq (string equality) ---',
-      '--- cipherstashIlike (string free-text-search) ---',
-      '--- cipherstashGt (double order-and-range) ---',
-      '--- cipherstashBetween (date order-and-range) ---',
-      '--- cipherstashInArray (bigint equality) ---',
-      '--- cipherstashInArray (boolean equality-only) ---',
-      '--- cipherstashAsc (bare-column ORDER BY) ---',
-    ]
-    for (const heading of headings) {
-      expect(stdout, `missing heading: ${heading}`).toContain(heading)
-    }
-  })
-
-  it('pnpm start output contains the documented row counts and email values', () => {
-    const startLine = README_COMMANDS.find((l) => /^pnpm start\b/.test(l))
-    expect(startLine, '`pnpm start` not found in README walkthrough').toBeDefined()
-    const stdout = outcomes.get(startLine!)?.stdout ?? ''
-    const expectations = [
-      'Inserted 4 rows across six cipherstash codecs.',
-      'Found 1 row(s) for alice@example.com.',
-      'Found 3 row(s) matching %@example.com.',
-      'Found 2 user(s) with salary > 100,000.',
-      'Found 3 user(s) born between 1985 and 1995.',
-      'Found 2 user(s) whose accountId is in the supplied array.',
-      'Found 3 user(s) with emailVerified = true.',
-      'alice@example.com',
-      'bob@example.com',
-      'carol@example.com',
-      'dave@otherorg.test',
-    ]
-    for (const line of expectations) {
-      expect(stdout, `missing expected line: ${line}`).toContain(line)
-    }
   })
 })

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -224,4 +224,43 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
     const r = outcomes.pnpmStart!
     expect(r.status, describeSpawnFailure(r)).toBe(0)
   })
+
+  it('pnpm start output contains every documented codec demo heading', () => {
+    const stdout = outcomes.pnpmStart!.stdout
+
+    // Headings from README "Expected output" — every one must appear.
+    const headings = [
+      '--- Insert (mixed-codec round-trip) ---',
+      '--- cipherstashEq (string equality) ---',
+      '--- cipherstashIlike (string free-text-search) ---',
+      '--- cipherstashGt (double order-and-range) ---',
+      '--- cipherstashBetween (date order-and-range) ---',
+      '--- cipherstashInArray (bigint equality) ---',
+      '--- cipherstashInArray (boolean equality-only) ---',
+      '--- cipherstashAsc (bare-column ORDER BY) ---',
+    ]
+    for (const heading of headings) {
+      expect(stdout, `missing heading: ${heading}`).toContain(heading)
+    }
+  })
+
+  it('pnpm start output contains the documented row counts and email values', () => {
+    const stdout = outcomes.pnpmStart!.stdout
+    const expectations = [
+      'Inserted 4 rows across six cipherstash codecs.',
+      'Found 1 row(s) for alice@example.com.',
+      'Found 3 row(s) matching %@example.com.',
+      'Found 2 user(s) with salary > 100,000.',
+      'Found 3 user(s) born between 1985 and 1995.',
+      'Found 2 user(s) whose accountId is in the supplied array.',
+      'Found 3 user(s) with emailVerified = true.',
+      'alice@example.com',
+      'bob@example.com',
+      'carol@example.com',
+      'dave@otherorg.test',
+    ]
+    for (const line of expectations) {
+      expect(stdout, `missing expected line: ${line}`).toContain(line)
+    }
+  })
 })

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -1,0 +1,23 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '../..')
+const EXAMPLE_DIR = resolve(REPO_ROOT, 'examples/prisma')
+
+const authConfigured = (() => {
+  if (process.env.CS_CLIENT_ID && process.env.CS_CLIENT_KEY) return true
+  const home = process.env.HOME
+  if (!home) return false
+  return existsSync(join(home, '.cipherstash', 'auth.json'))
+})()
+
+describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', () => {
+  it('placeholder — replaced in subsequent tasks', () => {
+    expect(authConfigured).toBe(true)
+  })
+})

--- a/e2e/tests/prisma-example-readme.e2e.test.ts
+++ b/e2e/tests/prisma-example-readme.e2e.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -35,20 +35,15 @@ function describeSpawnFailure(result: StepResult): string {
   return lines.join('\n')
 }
 
-function runStep(
-  label: string,
-  cmd: string,
-  args: string[],
-  opts: { cwd?: string; timeoutMs?: number; env?: NodeJS.ProcessEnv } = {},
-): StepResult {
-  const result: SpawnSyncReturns<Buffer> = spawnSync(cmd, args, {
-    cwd: opts.cwd ?? EXAMPLE_DIR,
-    timeout: opts.timeoutMs ?? 120_000,
+function runStep(commandLine: string, timeoutMs: number): StepResult {
+  const result = spawnSync('bash', ['-c', commandLine], {
+    cwd: EXAMPLE_DIR,
+    timeout: timeoutMs,
     stdio: 'pipe',
-    env: opts.env ?? process.env,
+    env: process.env,
   })
   return {
-    label,
+    label: commandLine,
     status: result.status,
     signal: result.signal,
     stdout: result.stdout?.toString() ?? '',
@@ -154,18 +149,13 @@ describe.skipIf(!authConfigured)('examples/prisma README "Run it" walkthrough', 
         console.log(`[readme-walkthrough] skip: ${line}`)
         continue
       }
-      outcomes.set(line, runStep(line, 'bash', ['-c', line], { timeoutMs: timeoutFor(line) }))
+      outcomes.set(line, runStep(line, timeoutFor(line)))
     }
   }, 600_000) // 10 min total budget for the cold path
 
   afterAll(async () => {
     // Teardown the bundled Postgres container regardless of outcome.
-    runStep(
-      'docker compose down -v',
-      'docker',
-      ['compose', 'down', '-v'],
-      { timeoutMs: 60_000 },
-    )
+    runStep('docker compose down -v', 60_000)
     // Restore the transient outputs from snapshot so the working tree is clean.
     await restoreTransientOutputs(snapDir)
     // Remove the .env we copied in the walkthrough (not tracked anyway).


### PR DESCRIPTION
Add an e2e test and CI workflow that runs the steps documented in the `README.md` for the Prisma example app.

Background:

- The `examples/prisma` app ships a README with a "Run it" section documenting the commands to run the example app
- Nothing verified the documentation was runnable
- Because the README is the entry point for new users, any breakages were invisible until a new user follows it and gets stuck