### PR TITLE
ci(dependabot): ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,10 +34,13 @@ updates:
       type-definitions:
         patterns:
           - "@types/*"
-    # Major bumps stay un-grouped → one PR each, easier to review.
     ignore:
       # Catalog-managed; bump manually via pnpm-workspace.yaml + changeset.
       - dependency-name: "@cipherstash/auth"
+      # Major bumps are reviewed and applied manually, not by Dependabot.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   # ── GitHub Actions ─────────────────────────────────────────────
   - package-ecosystem: github-actions
@@ -60,3 +63,8 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Major bumps are reviewed and applied manually, not by Dependabot.
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Add an ignore rule for major semver version upgrades to both the npm and github-actions ecosystem blocks in `.github/dependabot.yml`.

We use the major versions we use for a reason, and dependabot creating PRs just creates noise. 

Major version bumps will be done by humans.

Adjacently: PRs #456 and #459 have been closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to explicitly ignore semver-major version updates for project dependencies and for GitHub Actions, preserving an existing ignore for a specific internal package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/stack/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->