### PR TITLE
fix(dependabot): stop double scoping commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - dependencies
       - supply-chain
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: scope
     groups:
       dev-dependencies:
@@ -55,7 +55,8 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(actions)"
+      prefix: "chore"
+      include: scope
     groups:
       actions-minor-patch:
         patterns:


### PR DESCRIPTION
Stop applying two scopes to each upgrade commit message.

Dependabot misconfiguration meant commits weren't conventional.

Before:

```
chore(deps)(deps): bump the production-minor-patch group across 1 directory with 14 updates
```

After:

```
chore(deps): bump the production-minor-patch group across 1 directory with 14 updates
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to refine commit message formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/stack/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->