### PR TITLE
fix(stack): restore runtime null guards in encryption operations

### DIFF
--- a/.changeset/restore-null-guards-in-encryption-ops.md
+++ b/.changeset/restore-null-guards-in-encryption-ops.md
@@ -1,0 +1,23 @@
+---
+"@cipherstash/stack": patch
+---
+
+Fix: restore runtime null short-circuits in the encryption operation classes.
+
+A prior refactor (`feat(stack): remove null from Encrypted type`) tightened the type signatures to disallow `null` and, alongside that, deleted the `if (value === null) return null` guards from every operation in `packages/stack/src/encryption/operations/`. The type guard does not survive runtime: callers reaching the operation through a cast (e.g. `null as any`), dynamic model walking, or JS interop would then have their null silently encrypted by protect-ffi into a real SteVec ciphertext (`{ k: 'sv', v: 2, ... }`) — which is observable, surprising, and breaks symmetry with the model-helpers layer that does still treat null as "absent" at the field level.
+
+Restored, mirroring the pattern in `@cipherstash/protect`:
+
+- `encrypt` / `encryptWithLockContext`: `if (plaintext === null) return null`.
+- `bulkEncrypt` / `bulkEncryptWithLockContext`: per-element null filter; nulls are preserved in position in the output.
+- `decrypt` / `decryptWithLockContext`: `if (encryptedData === null) return null`.
+- `bulkDecrypt` / `bulkDecryptWithLockContext`: per-element null filter, position-preserving merge.
+- `encryptQuery` / `encryptQueryWithLockContext`: `if (plaintext === null || plaintext === undefined) return { data: null }`.
+- `batchEncryptQuery` / `batchEncryptQueryWithLockContext`: per-element null/undefined filter; null slots in the input array stay null in the result array.
+
+Type adjustments to support the runtime behavior honestly:
+
+- `BulkEncryptPayload['plaintext']`, `BulkEncryptedData['data']`, `BulkDecryptPayload['data']`, and the `T` of `BulkDecryptedData` all widen to `... | null`. Bulk APIs now accept and return mixed nullable arrays without filtering ahead of time.
+- `EncryptedQueryResult` widens to include `null` so the batch query path can return position-stable arrays with null slots.
+- `Encryption.decrypt()` accepts `Encrypted | null` (returns null for null input).
+- `Encryption.encrypt()`'s public signature is unchanged — still `JsPlaintext` (no null). The runtime guard is defense in depth for the cases the type system can't catch.

--- a/.changeset/restore-null-guards-in-encryption-ops.md
+++ b/.changeset/restore-null-guards-in-encryption-ops.md
@@ -1,5 +1,5 @@
 ---
-"@cipherstash/stack": patch
+"@cipherstash/stack": minor
 ---
 
 Fix: restore runtime null short-circuits in the encryption operation classes.

--- a/.changeset/restore-null-guards-in-encryption-ops.md
+++ b/.changeset/restore-null-guards-in-encryption-ops.md
@@ -19,5 +19,4 @@ Type adjustments to support the runtime behavior honestly:
 
 - `BulkEncryptPayload['plaintext']`, `BulkEncryptedData['data']`, `BulkDecryptPayload['data']`, and the `T` of `BulkDecryptedData` all widen to `... | null`. Bulk APIs now accept and return mixed nullable arrays without filtering ahead of time.
 - `EncryptedQueryResult` widens to include `null` so the batch query path can return position-stable arrays with null slots.
-- `Encryption.decrypt()` accepts `Encrypted | null` (returns null for null input).
-- `Encryption.encrypt()`'s public signature is unchanged — still `JsPlaintext` (no null). The runtime guard is defense in depth for the cases the type system can't catch.
+- `Encryption.encrypt()` and `Encryption.decrypt()` public signatures are unchanged — still narrow (`JsPlaintext` / `Encrypted` input, `Encrypted` / `JsPlaintext` non-nullable output). The runtime null short-circuit in `EncryptOperation` / `DecryptOperation` is defense in depth for callers reaching the operation classes through casts, dynamic field walking, or JS interop. The narrow-return contract holds for any caller that respects the input contract.

--- a/packages/stack/__tests__/null-guards.test.ts
+++ b/packages/stack/__tests__/null-guards.test.ts
@@ -1,0 +1,108 @@
+// Defense-in-depth tests for the runtime null short-circuits restored
+// across the encryption operation classes. These hit the operation
+// constructors directly rather than going through `Encryption()` so they
+// don't need credentials or a network — the guard short-circuits before
+// any FFI call. See `fix(stack): restore runtime null guards in
+// encryption operations` for context.
+
+import { BatchEncryptQueryOperation } from '@/encryption/operations/batch-encrypt-query'
+import { BulkDecryptOperation } from '@/encryption/operations/bulk-decrypt'
+import { BulkEncryptOperation } from '@/encryption/operations/bulk-encrypt'
+import { DecryptOperation } from '@/encryption/operations/decrypt'
+import { EncryptQueryOperation } from '@/encryption/operations/encrypt-query'
+import { EncryptOperation } from '@/encryption/operations/encrypt'
+import { encryptedColumn, encryptedTable } from '@/schema'
+import { describe, expect, it } from 'vitest'
+
+const table = encryptedTable('null-guards-test', {
+  metadata: encryptedColumn('metadata').searchableJson(),
+})
+
+// Any truthy stand-in — the guard returns before the client is touched.
+const stubClient = {} as any
+
+describe('runtime null guards (defense in depth)', () => {
+  it('encrypt(null) short-circuits without an FFI call', async () => {
+    const op = new EncryptOperation(stubClient, null, {
+      column: table.metadata,
+      table,
+    })
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toBeNull()
+  })
+
+  it('decrypt(null) short-circuits without an FFI call', async () => {
+    const op = new DecryptOperation(stubClient, null)
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toBeNull()
+  })
+
+  it('bulkEncrypt preserves null positions in mixed arrays', async () => {
+    // Single null-only input — no FFI call should happen, the all-null
+    // fast path returns a {data: null} placeholder per element.
+    const op = new BulkEncryptOperation(
+      stubClient,
+      [{ id: 'a', plaintext: null }],
+      { column: table.metadata, table },
+    )
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toEqual([{ id: 'a', data: null }])
+  })
+
+  it('bulkDecrypt preserves null positions in mixed arrays', async () => {
+    const op = new BulkDecryptOperation(stubClient, [{ id: 'a', data: null }])
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toEqual([{ id: 'a', data: null }])
+  })
+
+  it('encryptQuery(null) short-circuits to { data: null }', async () => {
+    const op = new EncryptQueryOperation(stubClient, null, {
+      column: table.metadata,
+      table,
+      queryType: 'steVecSelector',
+      returnType: 'composite-literal',
+    } as any)
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toBeNull()
+  })
+
+  it('encryptQuery(undefined) short-circuits to { data: null }', async () => {
+    const op = new EncryptQueryOperation(stubClient, undefined, {
+      column: table.metadata,
+      table,
+      queryType: 'steVecSelector',
+      returnType: 'composite-literal',
+    } as any)
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toBeNull()
+  })
+
+  it('batchEncryptQuery preserves null/undefined slots position-stably', async () => {
+    // All-null/undefined batch — no FFI call needed.
+    const op = new BatchEncryptQueryOperation(stubClient, [
+      {
+        column: table.metadata,
+        table,
+        queryType: 'steVecSelector',
+        returnType: 'composite-literal',
+        value: null,
+      } as any,
+      {
+        column: table.metadata,
+        table,
+        queryType: 'steVecSelector',
+        returnType: 'composite-literal',
+        value: undefined,
+      } as any,
+    ])
+    const result = await op.execute()
+    if (result.failure) throw new Error(result.failure.message)
+    expect(result.data).toEqual([null, null])
+  })
+})

--- a/packages/stack/src/encryption/index.ts
+++ b/packages/stack/src/encryption/index.ts
@@ -311,7 +311,7 @@ export class EncryptionClient {
    * @see {@link LockContext}
    * @see {@link DecryptOperation}
    */
-  decrypt(encryptedData: Encrypted): DecryptOperation {
+  decrypt(encryptedData: Encrypted | null): DecryptOperation {
     return new DecryptOperation(this.client, encryptedData)
   }
 

--- a/packages/stack/src/encryption/index.ts
+++ b/packages/stack/src/encryption/index.ts
@@ -308,10 +308,17 @@ export class EncryptionClient {
    *      .withLockContext(lockContext)
    * ```
    *
+   * @remarks
+   * The public input type rejects null, but at runtime `decrypt` will
+   * short-circuit and return null when given a null ciphertext
+   * (defense in depth for legacy / manually-NULLed DB rows reached via
+   * casts or dynamic field walking). The narrow return type holds for
+   * any caller that respects the input contract.
+   *
    * @see {@link LockContext}
    * @see {@link DecryptOperation}
    */
-  decrypt(encryptedData: Encrypted | null): DecryptOperation {
+  decrypt(encryptedData: Encrypted): DecryptOperation {
     return new DecryptOperation(this.client, encryptedData)
   }
 

--- a/packages/stack/src/encryption/operations/batch-encrypt-query.ts
+++ b/packages/stack/src/encryption/operations/batch-encrypt-query.ts
@@ -6,6 +6,7 @@ import type { Client, EncryptedQueryResult, ScalarQueryTerm } from '@/types'
 import { createRequestLogger } from '@/utils/logger'
 import { type Result, withResult } from '@byteslice/result'
 import {
+  type JsPlaintext,
   type QueryPayload,
   encryptQueryBulk as ffiEncryptQueryBulk,
 } from '@cipherstash/protect-ffi'
@@ -20,6 +21,21 @@ import {
 } from '../helpers/validation'
 import { noClientError } from '../index'
 import { EncryptionOperation } from './base-operation'
+
+// Separates null/undefined values from non-null terms in the input array
+// so they bypass the FFI call. Original indices are tracked so the
+// reassembled result preserves position.
+function filterNullTerms(terms: readonly ScalarQueryTerm[]): {
+  nonNullTerms: { term: ScalarQueryTerm; originalIndex: number }[]
+} {
+  const nonNullTerms: { term: ScalarQueryTerm; originalIndex: number }[] = []
+  terms.forEach((term, index) => {
+    if (term.value !== null && term.value !== undefined) {
+      nonNullTerms.push({ term, originalIndex: index })
+    }
+  })
+  return { nonNullTerms }
+}
 
 /**
  * Validates and transforms a single term into a QueryPayload.
@@ -42,7 +58,7 @@ function buildQueryPayload(
   assertValueIndexCompatibility(term.value, indexType, term.column.getName())
 
   const payload: QueryPayload = {
-    plaintext: term.value,
+    plaintext: term.value as JsPlaintext,
     column: term.column.getName(),
     table: term.table.tableName,
     indexType,
@@ -57,15 +73,22 @@ function buildQueryPayload(
 }
 
 /**
- * Maps encrypted values to formatted results based on term.returnType.
+ * Reassembles the result array, slotting null at the original indices of
+ * filtered-out terms and formatting encrypted values for non-null terms.
  */
 function assembleResults(
-  terms: readonly ScalarQueryTerm[],
+  totalLength: number,
   encryptedValues: (CipherStashEncrypted | CipherStashEncryptedQuery)[],
+  nonNullTerms: { term: ScalarQueryTerm; originalIndex: number }[],
 ): EncryptedQueryResult[] {
-  return terms.map((term, i) =>
-    formatEncryptedResult(encryptedValues[i], term.returnType),
-  )
+  const results: EncryptedQueryResult[] = new Array(totalLength).fill(null)
+  nonNullTerms.forEach(({ term, originalIndex }, i) => {
+    results[originalIndex] = formatEncryptedResult(
+      encryptedValues[i],
+      term.returnType,
+    )
+  })
+  return results
 }
 
 /**
@@ -107,13 +130,20 @@ export class BatchEncryptQueryOperation extends EncryptionOperation<
       return { data: [] }
     }
 
+    const { nonNullTerms } = filterNullTerms(this.terms)
+
+    if (nonNullTerms.length === 0) {
+      log.emit()
+      return { data: this.terms.map(() => null) }
+    }
+
     const result = await withResult(
       async () => {
         if (!this.client) throw noClientError()
 
         const { metadata } = this.getAuditData()
 
-        const queries: QueryPayload[] = this.terms.map((term) =>
+        const queries: QueryPayload[] = nonNullTerms.map(({ term }) =>
           buildQueryPayload(term),
         )
 
@@ -122,7 +152,7 @@ export class BatchEncryptQueryOperation extends EncryptionOperation<
           unverifiedContext: metadata,
         })
 
-        return assembleResults(this.terms, encrypted)
+        return assembleResults(this.terms.length, encrypted, nonNullTerms)
       },
       (error: unknown) => {
         log.set({ errorCode: getErrorCode(error) ?? 'unknown' })
@@ -169,6 +199,15 @@ export class BatchEncryptQueryOperationWithLockContext extends EncryptionOperati
       return { data: [] }
     }
 
+    // Check for all-null terms BEFORE fetching lockContext to avoid an
+    // unnecessary network call.
+    const { nonNullTerms } = filterNullTerms(this.terms)
+
+    if (nonNullTerms.length === 0) {
+      log.emit()
+      return { data: this.terms.map(() => null) }
+    }
+
     const lockContextResult = await this.lockContext.getLockContext()
     if (lockContextResult.failure) {
       log.emit()
@@ -183,7 +222,7 @@ export class BatchEncryptQueryOperationWithLockContext extends EncryptionOperati
 
         const { metadata } = this.getAuditData()
 
-        const queries: QueryPayload[] = this.terms.map((term) =>
+        const queries: QueryPayload[] = nonNullTerms.map(({ term }) =>
           buildQueryPayload(term, context),
         )
 
@@ -193,7 +232,7 @@ export class BatchEncryptQueryOperationWithLockContext extends EncryptionOperati
           unverifiedContext: metadata,
         })
 
-        return assembleResults(this.terms, encrypted)
+        return assembleResults(this.terms.length, encrypted, nonNullTerms)
       },
       (error: unknown) => {
         log.set({ errorCode: getErrorCode(error) ?? 'unknown' })

--- a/packages/stack/src/encryption/operations/bulk-decrypt.ts
+++ b/packages/stack/src/encryption/operations/bulk-decrypt.ts
@@ -5,40 +5,53 @@ import type { BulkDecryptPayload, BulkDecryptedData, Client } from '@/types'
 import { createRequestLogger } from '@/utils/logger'
 import { type Result, withResult } from '@byteslice/result'
 import {
+  type Encrypted as CipherStashEncrypted,
   type DecryptResult,
   decryptBulkFallible,
 } from '@cipherstash/protect-ffi'
 import { noClientError } from '../index'
 import { EncryptionOperation } from './base-operation'
 
-// Helper functions for better composability
+// Drops nulls so they don't reach protect-ffi's bulk decrypt. The
+// dropped positions are re-inserted as null in `mapDecryptedDataToResult`.
 const createDecryptPayloads = (
   encryptedPayloads: BulkDecryptPayload,
   lockContext?: Context,
 ) => {
-  return encryptedPayloads.map(({ id, data }) => ({
-    id,
-    ciphertext: data,
-    ...(lockContext && { lockContext }),
-  }))
+  return encryptedPayloads
+    .filter(({ data }) => data !== null)
+    .map(({ id, data }) => ({
+      id,
+      ciphertext: data as CipherStashEncrypted,
+      ...(lockContext && { lockContext }),
+    }))
 }
+
+const createNullResult = (
+  encryptedPayloads: BulkDecryptPayload,
+): BulkDecryptedData =>
+  encryptedPayloads.map(({ id }) => ({ id, data: null }))
 
 const mapDecryptedDataToResult = (
   encryptedPayloads: BulkDecryptPayload,
   decryptedData: DecryptResult[],
 ): BulkDecryptedData => {
-  return decryptedData.map((decryptResult, i) => {
-    if ('error' in decryptResult) {
-      return {
-        id: encryptedPayloads[i].id,
-        error: decryptResult.error,
+  const result: BulkDecryptedData = new Array(encryptedPayloads.length)
+  let decryptedIndex = 0
+  for (let i = 0; i < encryptedPayloads.length; i++) {
+    if (encryptedPayloads[i].data === null) {
+      result[i] = { id: encryptedPayloads[i].id, data: null }
+    } else {
+      const decryptResult = decryptedData[decryptedIndex]
+      if ('error' in decryptResult) {
+        result[i] = { id: encryptedPayloads[i].id, error: decryptResult.error }
+      } else {
+        result[i] = { id: encryptedPayloads[i].id, data: decryptResult.data }
       }
+      decryptedIndex++
     }
-    return {
-      id: encryptedPayloads[i].id,
-      data: decryptResult.data,
-    }
-  })
+  }
+  return result
 }
 
 export class BulkDecryptOperation extends EncryptionOperation<BulkDecryptedData> {
@@ -71,12 +84,16 @@ export class BulkDecryptOperation extends EncryptionOperation<BulkDecryptedData>
         if (!this.encryptedPayloads || this.encryptedPayloads.length === 0)
           return []
 
-        const payloads = createDecryptPayloads(this.encryptedPayloads)
+        const nonNullPayloads = createDecryptPayloads(this.encryptedPayloads)
+
+        if (nonNullPayloads.length === 0) {
+          return createNullResult(this.encryptedPayloads)
+        }
 
         const { metadata } = this.getAuditData()
 
         const decryptedData = await decryptBulkFallible(this.client, {
-          ciphertexts: payloads,
+          ciphertexts: nonNullPayloads,
           unverifiedContext: metadata,
         })
 
@@ -140,15 +157,19 @@ export class BulkDecryptOperationWithLockContext extends EncryptionOperation<Bul
           throw new Error(`[encryption]: ${context.failure.message}`)
         }
 
-        const payloads = createDecryptPayloads(
+        const nonNullPayloads = createDecryptPayloads(
           encryptedPayloads,
           context.data.context,
         )
 
+        if (nonNullPayloads.length === 0) {
+          return createNullResult(encryptedPayloads)
+        }
+
         const { metadata } = this.getAuditData()
 
         const decryptedData = await decryptBulkFallible(client, {
-          ciphertexts: payloads,
+          ciphertexts: nonNullPayloads,
           serviceToken: context.data.ctsToken,
           unverifiedContext: metadata,
         })

--- a/packages/stack/src/encryption/operations/bulk-encrypt.ts
+++ b/packages/stack/src/encryption/operations/bulk-encrypt.ts
@@ -14,25 +14,51 @@ import type {
   EncryptOptions,
 } from '@/types'
 import { createRequestLogger } from '@/utils/logger'
+import type { Encrypted } from '@/types'
 import { type Result, withResult } from '@byteslice/result'
-import { encryptBulk } from '@cipherstash/protect-ffi'
+import { type JsPlaintext, encryptBulk } from '@cipherstash/protect-ffi'
 import { noClientError } from '../index'
 import { EncryptionOperation } from './base-operation'
 
-// Helper functions for better composability
+// Drops nulls so they don't reach protect-ffi (which would otherwise
+// produce a SteVec wrapping the JSON null). The dropped positions are
+// re-inserted as null in `mapEncryptedDataToResult`.
 const createEncryptPayloads = (
   plaintexts: BulkEncryptPayload,
   column: EncryptedColumn | EncryptedField,
   table: EncryptedTable<EncryptedTableColumn>,
   lockContext?: Context,
 ) => {
-  return plaintexts.map(({ id, plaintext }) => ({
-    id,
-    plaintext,
-    column: column.getName(),
-    table: table.tableName,
-    ...(lockContext && { lockContext }),
-  }))
+  return plaintexts
+    .filter(({ plaintext }) => plaintext !== null)
+    .map(({ id, plaintext }) => ({
+      id,
+      plaintext: plaintext as JsPlaintext,
+      column: column.getName(),
+      table: table.tableName,
+      ...(lockContext && { lockContext }),
+    }))
+}
+
+const createNullResult = (
+  plaintexts: BulkEncryptPayload,
+): BulkEncryptedData => plaintexts.map(({ id }) => ({ id, data: null }))
+
+const mapEncryptedDataToResult = (
+  plaintexts: BulkEncryptPayload,
+  encryptedData: Encrypted[],
+): BulkEncryptedData => {
+  const result: BulkEncryptedData = new Array(plaintexts.length)
+  let encryptedIndex = 0
+  for (let i = 0; i < plaintexts.length; i++) {
+    if (plaintexts[i].plaintext === null) {
+      result[i] = { id: plaintexts[i].id, data: null }
+    } else {
+      result[i] = { id: plaintexts[i].id, data: encryptedData[encryptedIndex] }
+      encryptedIndex++
+    }
+  }
+  return result
 }
 
 export class BulkEncryptOperation extends EncryptionOperation<BulkEncryptedData> {
@@ -78,23 +104,24 @@ export class BulkEncryptOperation extends EncryptionOperation<BulkEncryptedData>
           return []
         }
 
-        const payloads = createEncryptPayloads(
+        const nonNullPayloads = createEncryptPayloads(
           this.plaintexts,
           this.column,
           this.table,
         )
 
+        if (nonNullPayloads.length === 0) {
+          return createNullResult(this.plaintexts)
+        }
+
         const { metadata } = this.getAuditData()
 
         const encryptedData = await encryptBulk(this.client, {
-          plaintexts: payloads,
+          plaintexts: nonNullPayloads,
           unverifiedContext: metadata,
         })
 
-        return encryptedData.map((data, i) => ({
-          id: this.plaintexts[i].id,
-          data,
-        }))
+        return mapEncryptedDataToResult(this.plaintexts, encryptedData)
       },
       (error: unknown) => {
         log.set({ errorCode: getErrorCode(error) ?? 'unknown' })
@@ -164,25 +191,26 @@ export class BulkEncryptOperationWithLockContext extends EncryptionOperation<Bul
           throw new Error(`[encryption]: ${context.failure.message}`)
         }
 
-        const payloads = createEncryptPayloads(
+        const nonNullPayloads = createEncryptPayloads(
           plaintexts,
           column,
           table,
           context.data.context,
         )
 
+        if (nonNullPayloads.length === 0) {
+          return createNullResult(plaintexts)
+        }
+
         const { metadata } = this.getAuditData()
 
         const encryptedData = await encryptBulk(client, {
-          plaintexts: payloads,
+          plaintexts: nonNullPayloads,
           serviceToken: context.data.ctsToken,
           unverifiedContext: metadata,
         })
 
-        return encryptedData.map((data, i) => ({
-          id: plaintexts[i].id,
-          data,
-        }))
+        return mapEncryptedDataToResult(plaintexts, encryptedData)
       },
       (error: unknown) => {
         log.set({ errorCode: getErrorCode(error) ?? 'unknown' })

--- a/packages/stack/src/encryption/operations/bulk-encrypt.ts
+++ b/packages/stack/src/encryption/operations/bulk-encrypt.ts
@@ -11,10 +11,10 @@ import type {
   BulkEncryptPayload,
   BulkEncryptedData,
   Client,
+  Encrypted,
   EncryptOptions,
 } from '@/types'
 import { createRequestLogger } from '@/utils/logger'
-import type { Encrypted } from '@/types'
 import { type Result, withResult } from '@byteslice/result'
 import { type JsPlaintext, encryptBulk } from '@cipherstash/protect-ffi'
 import { noClientError } from '../index'

--- a/packages/stack/src/encryption/operations/decrypt.ts
+++ b/packages/stack/src/encryption/operations/decrypt.ts
@@ -15,10 +15,12 @@ import { EncryptionOperation } from './base-operation'
  * Decrypts an encrypted payload using the provided client.
  * This is the type returned by the {@link EncryptionClient.decrypt | decrypt} method of the {@link EncryptionClient}.
  */
-export class DecryptOperation extends EncryptionOperation<JsPlaintext | null> {
+export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
   private client: Client
-  // Widened to allow null so legacy / manually-NULLed rows can be
-  // round-tripped through decrypt without misbehaving in protect-ffi.
+  // Internally widened to allow null so the runtime guard below can
+  // short-circuit on legacy / manually-NULLed rows. The public
+  // `Encryption.decrypt()` signature still rejects null at the type
+  // layer; this is defense in depth for direct construction.
   private encryptedData: Encrypted | null
 
   constructor(client: Client, encryptedData: Encrypted | null) {
@@ -33,7 +35,7 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext | null> {
     return new DecryptOperationWithLockContext(this, lockContext)
   }
 
-  public async execute(): Promise<Result<JsPlaintext | null, EncryptionError>> {
+  public async execute(): Promise<Result<JsPlaintext, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'decrypt',
@@ -47,7 +49,8 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext | null> {
         }
 
         if (this.encryptedData === null) {
-          return null
+          // See encrypt.ts for the same defense-in-depth pattern.
+          return null as unknown as JsPlaintext
         }
 
         const { metadata } = this.getAuditData()
@@ -83,9 +86,7 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext | null> {
   }
 }
 
-export class DecryptOperationWithLockContext extends EncryptionOperation<
-  JsPlaintext | null
-> {
+export class DecryptOperationWithLockContext extends EncryptionOperation<JsPlaintext> {
   private operation: DecryptOperation
   private lockContext: LockContext
 
@@ -99,7 +100,7 @@ export class DecryptOperationWithLockContext extends EncryptionOperation<
     }
   }
 
-  public async execute(): Promise<Result<JsPlaintext | null, EncryptionError>> {
+  public async execute(): Promise<Result<JsPlaintext, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'decrypt',
@@ -115,7 +116,7 @@ export class DecryptOperationWithLockContext extends EncryptionOperation<
         }
 
         if (encryptedData === null) {
-          return null
+          return null as unknown as JsPlaintext
         }
 
         const { metadata } = this.getAuditData()

--- a/packages/stack/src/encryption/operations/decrypt.ts
+++ b/packages/stack/src/encryption/operations/decrypt.ts
@@ -15,11 +15,13 @@ import { EncryptionOperation } from './base-operation'
  * Decrypts an encrypted payload using the provided client.
  * This is the type returned by the {@link EncryptionClient.decrypt | decrypt} method of the {@link EncryptionClient}.
  */
-export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
+export class DecryptOperation extends EncryptionOperation<JsPlaintext | null> {
   private client: Client
-  private encryptedData: Encrypted
+  // Widened to allow null so legacy / manually-NULLed rows can be
+  // round-tripped through decrypt without misbehaving in protect-ffi.
+  private encryptedData: Encrypted | null
 
-  constructor(client: Client, encryptedData: Encrypted) {
+  constructor(client: Client, encryptedData: Encrypted | null) {
     super()
     this.client = client
     this.encryptedData = encryptedData
@@ -31,7 +33,7 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
     return new DecryptOperationWithLockContext(this, lockContext)
   }
 
-  public async execute(): Promise<Result<JsPlaintext, EncryptionError>> {
+  public async execute(): Promise<Result<JsPlaintext | null, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'decrypt',
@@ -42,6 +44,10 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
       async () => {
         if (!this.client) {
           throw noClientError()
+        }
+
+        if (this.encryptedData === null) {
+          return null
         }
 
         const { metadata } = this.getAuditData()
@@ -66,7 +72,7 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
 
   public getOperation(): {
     client: Client
-    encryptedData: Encrypted
+    encryptedData: Encrypted | null
     auditData?: Record<string, unknown>
   } {
     return {
@@ -77,7 +83,9 @@ export class DecryptOperation extends EncryptionOperation<JsPlaintext> {
   }
 }
 
-export class DecryptOperationWithLockContext extends EncryptionOperation<JsPlaintext> {
+export class DecryptOperationWithLockContext extends EncryptionOperation<
+  JsPlaintext | null
+> {
   private operation: DecryptOperation
   private lockContext: LockContext
 
@@ -91,7 +99,7 @@ export class DecryptOperationWithLockContext extends EncryptionOperation<JsPlain
     }
   }
 
-  public async execute(): Promise<Result<JsPlaintext, EncryptionError>> {
+  public async execute(): Promise<Result<JsPlaintext | null, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'decrypt',
@@ -104,6 +112,10 @@ export class DecryptOperationWithLockContext extends EncryptionOperation<JsPlain
 
         if (!client) {
           throw noClientError()
+        }
+
+        if (encryptedData === null) {
+          return null
         }
 
         const { metadata } = this.getAuditData()

--- a/packages/stack/src/encryption/operations/encrypt-query.ts
+++ b/packages/stack/src/encryption/operations/encrypt-query.ts
@@ -20,9 +20,7 @@ import { EncryptionOperation } from './base-operation'
 /**
  * @internal Use {@link EncryptionClient.encryptQuery} instead.
  */
-export class EncryptQueryOperation extends EncryptionOperation<
-  EncryptedQueryResult | null
-> {
+export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryResult> {
   constructor(
     private client: Client,
     private plaintext: JsPlaintext | null | undefined,
@@ -44,7 +42,7 @@ export class EncryptQueryOperation extends EncryptionOperation<
   }
 
   public async execute(): Promise<
-    Result<EncryptedQueryResult | null, EncryptionError>
+    Result<EncryptedQueryResult, EncryptionError>
   > {
     const log = createRequestLogger()
     log.set({
@@ -60,7 +58,9 @@ export class EncryptQueryOperation extends EncryptionOperation<
       return { data: null }
     }
 
-    const validationError = validateNumericValue(this.plaintext)
+    const plaintext: JsPlaintext = this.plaintext
+
+    const validationError = validateNumericValue(plaintext)
     if (validationError?.failure) {
       log.emit()
       return { failure: validationError.failure }
@@ -75,18 +75,18 @@ export class EncryptQueryOperation extends EncryptionOperation<
         const { indexType, queryOp } = resolveIndexType(
           this.opts.column,
           this.opts.queryType,
-          this.plaintext as JsPlaintext,
+          plaintext,
         )
 
         // Validate value/index compatibility
         assertValueIndexCompatibility(
-          this.plaintext as JsPlaintext,
+          plaintext,
           indexType,
           this.opts.column.getName(),
         )
 
         const encrypted = await ffiEncryptQuery(this.client, {
-          plaintext: this.plaintext as JsPlaintext,
+          plaintext,
           column: this.opts.column.getName(),
           table: this.opts.table.tableName,
           indexType,
@@ -117,9 +117,7 @@ export class EncryptQueryOperation extends EncryptionOperation<
 /**
  * @internal Use {@link EncryptionClient.encryptQuery} with `.withLockContext()` instead.
  */
-export class EncryptQueryOperationWithLockContext extends EncryptionOperation<
-  EncryptedQueryResult | null
-> {
+export class EncryptQueryOperationWithLockContext extends EncryptionOperation<EncryptedQueryResult> {
   constructor(
     private client: Client,
     private plaintext: JsPlaintext | null | undefined,
@@ -132,7 +130,7 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<
   }
 
   public async execute(): Promise<
-    Result<EncryptedQueryResult | null, EncryptionError>
+    Result<EncryptedQueryResult, EncryptionError>
   > {
     const log = createRequestLogger()
     log.set({
@@ -148,7 +146,9 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<
       return { data: null }
     }
 
-    const validationError = validateNumericValue(this.plaintext)
+    const plaintext: JsPlaintext = this.plaintext
+
+    const validationError = validateNumericValue(plaintext)
     if (validationError?.failure) {
       log.emit()
       return { failure: validationError.failure }
@@ -171,18 +171,18 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<
         const { indexType, queryOp } = resolveIndexType(
           this.opts.column,
           this.opts.queryType,
-          this.plaintext as JsPlaintext,
+          plaintext,
         )
 
         // Validate value/index compatibility
         assertValueIndexCompatibility(
-          this.plaintext as JsPlaintext,
+          plaintext,
           indexType,
           this.opts.column.getName(),
         )
 
         const encrypted = await ffiEncryptQuery(this.client, {
-          plaintext: this.plaintext as JsPlaintext,
+          plaintext,
           column: this.opts.column.getName(),
           table: this.opts.table.tableName,
           indexType,

--- a/packages/stack/src/encryption/operations/encrypt-query.ts
+++ b/packages/stack/src/encryption/operations/encrypt-query.ts
@@ -20,10 +20,12 @@ import { EncryptionOperation } from './base-operation'
 /**
  * @internal Use {@link EncryptionClient.encryptQuery} instead.
  */
-export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryResult> {
+export class EncryptQueryOperation extends EncryptionOperation<
+  EncryptedQueryResult | null
+> {
   constructor(
     private client: Client,
-    private plaintext: JsPlaintext,
+    private plaintext: JsPlaintext | null | undefined,
     private opts: EncryptQueryOptions,
   ) {
     super()
@@ -42,7 +44,7 @@ export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryRes
   }
 
   public async execute(): Promise<
-    Result<EncryptedQueryResult, EncryptionError>
+    Result<EncryptedQueryResult | null, EncryptionError>
   > {
     const log = createRequestLogger()
     log.set({
@@ -52,6 +54,11 @@ export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryRes
       queryType: this.opts.queryType,
       lockContext: false,
     })
+
+    if (this.plaintext === null || this.plaintext === undefined) {
+      log.emit()
+      return { data: null }
+    }
 
     const validationError = validateNumericValue(this.plaintext)
     if (validationError?.failure) {
@@ -68,18 +75,18 @@ export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryRes
         const { indexType, queryOp } = resolveIndexType(
           this.opts.column,
           this.opts.queryType,
-          this.plaintext,
+          this.plaintext as JsPlaintext,
         )
 
         // Validate value/index compatibility
         assertValueIndexCompatibility(
-          this.plaintext,
+          this.plaintext as JsPlaintext,
           indexType,
           this.opts.column.getName(),
         )
 
         const encrypted = await ffiEncryptQuery(this.client, {
-          plaintext: this.plaintext,
+          plaintext: this.plaintext as JsPlaintext,
           column: this.opts.column.getName(),
           table: this.opts.table.tableName,
           indexType,
@@ -110,10 +117,12 @@ export class EncryptQueryOperation extends EncryptionOperation<EncryptedQueryRes
 /**
  * @internal Use {@link EncryptionClient.encryptQuery} with `.withLockContext()` instead.
  */
-export class EncryptQueryOperationWithLockContext extends EncryptionOperation<EncryptedQueryResult> {
+export class EncryptQueryOperationWithLockContext extends EncryptionOperation<
+  EncryptedQueryResult | null
+> {
   constructor(
     private client: Client,
-    private plaintext: JsPlaintext,
+    private plaintext: JsPlaintext | null | undefined,
     private opts: EncryptQueryOptions,
     private lockContext: LockContext,
     auditMetadata?: Record<string, unknown>,
@@ -123,7 +132,7 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<En
   }
 
   public async execute(): Promise<
-    Result<EncryptedQueryResult, EncryptionError>
+    Result<EncryptedQueryResult | null, EncryptionError>
   > {
     const log = createRequestLogger()
     log.set({
@@ -133,6 +142,11 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<En
       queryType: this.opts.queryType,
       lockContext: true,
     })
+
+    if (this.plaintext === null || this.plaintext === undefined) {
+      log.emit()
+      return { data: null }
+    }
 
     const validationError = validateNumericValue(this.plaintext)
     if (validationError?.failure) {
@@ -157,18 +171,18 @@ export class EncryptQueryOperationWithLockContext extends EncryptionOperation<En
         const { indexType, queryOp } = resolveIndexType(
           this.opts.column,
           this.opts.queryType,
-          this.plaintext,
+          this.plaintext as JsPlaintext,
         )
 
         // Validate value/index compatibility
         assertValueIndexCompatibility(
-          this.plaintext,
+          this.plaintext as JsPlaintext,
           indexType,
           this.opts.column.getName(),
         )
 
         const encrypted = await ffiEncryptQuery(this.client, {
-          plaintext: this.plaintext,
+          plaintext: this.plaintext as JsPlaintext,
           column: this.opts.column.getName(),
           table: this.opts.table.tableName,
           indexType,

--- a/packages/stack/src/encryption/operations/encrypt.ts
+++ b/packages/stack/src/encryption/operations/encrypt.ts
@@ -17,7 +17,7 @@ import {
 import { noClientError } from '../index'
 import { EncryptionOperation } from './base-operation'
 
-export class EncryptOperation extends EncryptionOperation<Encrypted | null> {
+export class EncryptOperation extends EncryptionOperation<Encrypted> {
   private client: Client
   // Internally widened to allow null so the runtime guard below can
   // short-circuit. The public `Encryption.encrypt()` signature still
@@ -45,7 +45,7 @@ export class EncryptOperation extends EncryptionOperation<Encrypted | null> {
     return new EncryptOperationWithLockContext(this, lockContext)
   }
 
-  public async execute(): Promise<Result<Encrypted | null, EncryptionError>> {
+  public async execute(): Promise<Result<Encrypted, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'encrypt',
@@ -61,7 +61,13 @@ export class EncryptOperation extends EncryptionOperation<Encrypted | null> {
         }
 
         if (this.plaintext === null) {
-          return null
+          // Defense in depth: the public `Encryption.encrypt()` signature
+          // rejects null, but null can still arrive here via casts or
+          // dynamic field walking. Return null directly so the result
+          // matches DB NULL semantics rather than encrypting JSON null
+          // into a SteVec. The cast acknowledges the type-narrow
+          // contract at the public boundary.
+          return null as unknown as Encrypted
         }
 
         if (
@@ -115,7 +121,7 @@ export class EncryptOperation extends EncryptionOperation<Encrypted | null> {
   }
 }
 
-export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypted | null> {
+export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypted> {
   private operation: EncryptOperation
   private lockContext: LockContext
 
@@ -129,7 +135,7 @@ export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypt
     }
   }
 
-  public async execute(): Promise<Result<Encrypted | null, EncryptionError>> {
+  public async execute(): Promise<Result<Encrypted, EncryptionError>> {
     const { client, plaintext, column, table } = this.operation.getOperation()
 
     const log = createRequestLogger()
@@ -147,7 +153,7 @@ export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypt
         }
 
         if (plaintext === null) {
-          return null
+          return null as unknown as Encrypted
         }
 
         const { metadata } = this.getAuditData()

--- a/packages/stack/src/encryption/operations/encrypt.ts
+++ b/packages/stack/src/encryption/operations/encrypt.ts
@@ -17,13 +17,21 @@ import {
 import { noClientError } from '../index'
 import { EncryptionOperation } from './base-operation'
 
-export class EncryptOperation extends EncryptionOperation<Encrypted> {
+export class EncryptOperation extends EncryptionOperation<Encrypted | null> {
   private client: Client
-  private plaintext: JsPlaintext
+  // Internally widened to allow null so the runtime guard below can
+  // short-circuit. The public `Encryption.encrypt()` signature still
+  // rejects null at the type layer; this is defense in depth for callers
+  // that reach this class through casts or dynamic field walking.
+  private plaintext: JsPlaintext | null
   private column: EncryptedColumn | EncryptedField
   private table: EncryptedTable<EncryptedTableColumn>
 
-  constructor(client: Client, plaintext: JsPlaintext, opts: EncryptOptions) {
+  constructor(
+    client: Client,
+    plaintext: JsPlaintext | null,
+    opts: EncryptOptions,
+  ) {
     super()
     this.client = client
     this.plaintext = plaintext
@@ -37,7 +45,7 @@ export class EncryptOperation extends EncryptionOperation<Encrypted> {
     return new EncryptOperationWithLockContext(this, lockContext)
   }
 
-  public async execute(): Promise<Result<Encrypted, EncryptionError>> {
+  public async execute(): Promise<Result<Encrypted | null, EncryptionError>> {
     const log = createRequestLogger()
     log.set({
       op: 'encrypt',
@@ -50,6 +58,10 @@ export class EncryptOperation extends EncryptionOperation<Encrypted> {
       async () => {
         if (!this.client) {
           throw noClientError()
+        }
+
+        if (this.plaintext === null) {
+          return null
         }
 
         if (
@@ -90,7 +102,7 @@ export class EncryptOperation extends EncryptionOperation<Encrypted> {
 
   public getOperation(): {
     client: Client
-    plaintext: JsPlaintext
+    plaintext: JsPlaintext | null
     column: EncryptedColumn | EncryptedField
     table: EncryptedTable<EncryptedTableColumn>
   } {
@@ -103,7 +115,7 @@ export class EncryptOperation extends EncryptionOperation<Encrypted> {
   }
 }
 
-export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypted> {
+export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypted | null> {
   private operation: EncryptOperation
   private lockContext: LockContext
 
@@ -117,7 +129,7 @@ export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypt
     }
   }
 
-  public async execute(): Promise<Result<Encrypted, EncryptionError>> {
+  public async execute(): Promise<Result<Encrypted | null, EncryptionError>> {
     const { client, plaintext, column, table } = this.operation.getOperation()
 
     const log = createRequestLogger()
@@ -132,6 +144,10 @@ export class EncryptOperationWithLockContext extends EncryptionOperation<Encrypt
       async () => {
         if (!client) {
           throw noClientError()
+        }
+
+        if (plaintext === null) {
+          return null
         }
 
         const { metadata } = this.getAuditData()

--- a/packages/stack/src/types.ts
+++ b/packages/stack/src/types.ts
@@ -133,7 +133,14 @@ export type EncryptedSearchTerm = Encrypted | EncryptedQuery | string
 /** Result of encryptQuery (single or batch). `eql` return type yields either a
  * storage payload (`Encrypted`) or a query-only term (`EncryptedQuery`); the
  * `composite-literal` return types yield a string. */
-export type EncryptedQueryResult = Encrypted | EncryptedQuery | string
+// null elements appear in the batch path when a term has a null/undefined
+// value — the operation preserves position so callers can correlate results
+// with their input array.
+export type EncryptedQueryResult =
+  | Encrypted
+  | EncryptedQuery
+  | string
+  | null
 
 // ---------------------------------------------------------------------------
 // Model field types (encrypted vs decrypted views)
@@ -191,14 +198,19 @@ export type EncryptedFromSchema<T, S extends EncryptedTableColumn> = {
 // Bulk operations
 // ---------------------------------------------------------------------------
 
+// Bulk payloads admit null elements — bulk operations pass them through
+// untouched (encrypt(null) -> null, decrypt(null) -> null) so callers can
+// process mixed nullable arrays without filtering ahead of time. The
+// runtime guards in the operation classes preserve the null in the
+// position-stable output.
 export type BulkEncryptPayload = Array<{
   id?: string
-  plaintext: JsPlaintext
+  plaintext: JsPlaintext | null
 }>
 
-export type BulkEncryptedData = Array<{ id?: string; data: Encrypted }>
-export type BulkDecryptPayload = Array<{ id?: string; data: Encrypted }>
-export type BulkDecryptedData = Array<DecryptionResult<JsPlaintext>>
+export type BulkEncryptedData = Array<{ id?: string; data: Encrypted | null }>
+export type BulkDecryptPayload = Array<{ id?: string; data: Encrypted | null }>
+export type BulkDecryptedData = Array<DecryptionResult<JsPlaintext | null>>
 
 type DecryptionSuccess<T> = { error?: never; data: T; id?: string }
 type DecryptionError<T> = { error: T; id?: string; data?: never }


### PR DESCRIPTION
Fixes #494.

## Summary

Restores the `if (value === null) return null` guards that were stripped from every operation in `packages/stack/src/encryption/operations/` by commit `5b7288b feat(stack): remove null from Encrypted type`. That commit was meant as a type-level tightening but also deleted the matching runtime guards — so callers reaching an operation through a cast, dynamic model walking, or JS interop would silently get their null encrypted into a real SteVec ciphertext (`{ k: 'sv', v: 2, ... }`).

Discovered via the newly-ported `round-trips null values` integration test in #328, which calls `encrypt(null)` directly and asserts the round-trip preserves null. Without these guards, that test fails with:

> AssertionError: expected `{ k: 'sv', v: 2, i: { …(2) }, …(1) }` to be null

## What changed

Mirrors the `@cipherstash/protect` pattern across all six operations:

| Operation | Restored guard |
|---|---|
| `encrypt` / `*WithLockContext` | early `return null` on null plaintext |
| `bulkEncrypt` / `*WithLockContext` | filter-null + position-preserving merge |
| `decrypt` / `*WithLockContext` | early `return null` on null ciphertext |
| `bulkDecrypt` / `*WithLockContext` | filter-null + position-preserving merge |
| `encryptQuery` / `*WithLockContext` | return `{ data: null }` for null/undefined |
| `batchEncryptQuery` / `*WithLockContext` | per-element filter, position-stable result |

Type adjustments so the restored guards compile and honestly reflect runtime:

- `BulkEncryptPayload['plaintext']`, `BulkEncryptedData['data']`, `BulkDecryptPayload['data']`, and the `T` of `BulkDecryptedData` widen to `... | null`. Bulk APIs now accept and return mixed nullable arrays without ahead-of-time filtering.
- `EncryptedQueryResult` widens to include `null` for batch-path position-stability.
- `Encryption.decrypt()` accepts `Encrypted | null`.
- `Encryption.encrypt()` public signature is **unchanged** (still `JsPlaintext`). The runtime guard is defense in depth.

## Test plan

- [x] CI green on this branch
- [x] Rebase #328 on top of this branch and verify the re-enabled `round-trips null values` test passes
- [x] Verify no regressions in `__tests__/nested-models.test.ts` and `__tests__/bulk-protect.test.ts` (these exercise null handling through the model layer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored runtime null/undefined short-circuiting so null values are not encrypted as ciphertext
  * Bulk encrypt/decrypt preserve original item positions and return per-item nulls for null inputs
  * Query encryption returns null for null/undefined terms instead of attempting encryption
  * Decrypt operations now gracefully return null for null inputs

* **Tests**
  * Added tests validating null-handling and position-stable results for bulk/batch operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/stack/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
