### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships
       # npm 10.x. `changeset publish` shells out to this npm to publish.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: 22
           # No `cache:`, and package-manager-cache disabled. release.yml
-          # publishes to npm (NPM_TOKEN + OIDC) and must not restore the
+          # publishes to npm (OIDC trusted publishing) and must not restore the
           # GitHub Actions cache — a cache-poisoning / supply-chain vector.
           # Enforced by .github/workflows/tests-supply-chain.yml.
           package-manager-cache: false
@@ -45,6 +45,11 @@ jobs:
       # node-gyp on PATH, so install it explicitly.
       - name: Install node-gyp
         run: npm install -g node-gyp
+
+      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships
+      # npm 10.x. `changeset publish` shells out to this npm to publish.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install
@@ -56,5 +61,8 @@ jobs:
           publish: pnpm run release
           commitMode: 'github-api'
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN — publishing authenticates via npm OIDC trusted
+          # publishing (id-token: write above). If NPM_TOKEN is set,
+          # changesets/action writes a token .npmrc that shadows OIDC and
+          # every publish fails with E404 (see npm/cli#8976).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,11 @@
 	"name": "stash",
 	"version": "0.16.0",
 	"description": "CipherStash CLI — the one stash command for auth, init, encryption schema, database setup, and secrets.",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/cli"
+	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",
 	"files": [

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -12,7 +12,7 @@
 		"postgres"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -16,7 +16,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git"
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/drizzle"
 	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/migrate",
   "version": "0.2.0",
   "description": "Plaintext-to-encrypted column migration for CipherStash: resumable backfill, per-column state, and EQL lifecycle orchestration.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/stack.git",
+    "directory": "packages/migrate"
+  },
   "keywords": [
     "cipherstash",
     "encryption",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,7 +13,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git"
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/nextjs"
 	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -9,7 +9,7 @@
 		"nextjs"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/protect-dynamodb/package.json
+++ b/packages/protect-dynamodb/package.json
@@ -15,7 +15,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git"
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/protect-dynamodb"
 	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",

--- a/packages/protect-dynamodb/package.json
+++ b/packages/protect-dynamodb/package.json
@@ -11,7 +11,7 @@
 		"security"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -11,7 +11,7 @@
 		"protect"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/protect/package.json
+++ b/packages/protect/package.json
@@ -15,7 +15,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git"
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/protect"
 	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -9,7 +9,7 @@
 		"builder"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -13,7 +13,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git"
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/schema"
 	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -15,7 +15,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/cipherstash/protectjs.git",
+		"url": "git+https://github.com/cipherstash/stack.git",
 		"directory": "packages/stack"
 	},
 	"license": "MIT",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -11,7 +11,7 @@
 		"stack"
 	],
 	"bugs": {
-		"url": "https://github.com/cipherstash/protectjs/issues"
+		"url": "https://github.com/cipherstash/stack/issues"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/wizard/package.json
+++ b/packages/wizard/package.json
@@ -2,6 +2,11 @@
 	"name": "@cipherstash/wizard",
 	"version": "0.3.0",
 	"description": "AI-powered encryption setup for CipherStash. Reads your codebase, picks columns to encrypt, and wires everything up.",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cipherstash/stack.git",
+		"directory": "packages/wizard"
+	},
 	"license": "MIT",
 	"author": "CipherStash <hello@cipherstash.com>",
 	"files": [


### PR DESCRIPTION
## Problem

The **Release JS** workflow has failed every npm publish since **2026-05-04**. All packages fail identically:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@cipherstash%2fprotect
'@cipherstash/protect@12.0.0' is not in this registry.
```

An `E404` on a `PUT` is npm's signature for a **rejected credential**, not a missing package — a real "missing package" can't 404 an existing package like `@cipherstash/protect`, and a version clash would be `409`. The `NPM_TOKEN` is no longer accepted by the registry (consistent with npm's revocation of legacy publish tokens).

It looked intermittent because the workflow runs on every push to `main` but only exercises the credential when a `changeset-release` PR merges; plain feature merges are no-op publishes that pass.

As a result these versions are bumped and tagged but **never published**: `protect@12.0.0`, `protect-dynamodb@12.0.0`, `schema@3.0.0`, `stack@0.18.0`, `wizard@0.3.0`, `prisma-next@0.3.1`, `stash@0.16.0`.

## Fix

Complete the migration to **npm OIDC trusted publishing** that the workflow was already half-configured for (`id-token: write` was present):

- **Drop `NPM_TOKEN` from the publish env.** `changesets/action` only writes its token `.npmrc` when `NPM_TOKEN` is set (guarded since v1.7.0), so removing it lets `changeset publish` authenticate via OIDC. Leaving it set shadows OIDC and 404s — see [npm/cli#8976](https://github.com/npm/cli/issues/8976).
- **Upgrade npm to ≥ 11.5.1 in CI.** OIDC trusted publishing requires it; Node 22 ships npm 10.x.
- **Fix `repository.url` across all publishable packages.** Most pointed at the old `cipherstash/protectjs`; three were missing. OIDC publishing auto-generates provenance, which requires `repository.url` to match the building repo or the publish fails.

`pnpm run lint:workflow-cache` (the supply-chain cache gate) still passes.

## Required before merge — npmjs.com config

Configure a **Trusted Publisher** for each package: *Settings → Trusted Publisher → GitHub Actions* → org `cipherstash`, repo `stack`, workflow `release.yml`, environment *(blank)*.

Pending versions (must be set before merge): `@cipherstash/protect`, `@cipherstash/protect-dynamodb`, `@cipherstash/schema`, `@cipherstash/stack`, `@cipherstash/wizard`, `@cipherstash/prisma-next`, `stash`.
No pending version this cycle but configure for future releases: `@cipherstash/drizzle`, `@cipherstash/nextjs`, `@cipherstash/migrate`.

## Sequencing

1. Configure the trusted publishers on npmjs.com **first**.
2. Merge this PR — the push to `main` auto-triggers Release, which publishes the pending versions via OIDC.
3. After a green publish, delete the now-unused `NPM_TOKEN` secret (no other workflow references it).

> Note: don't re-run the old failed run — it's pinned to the previous commit with the old workflow and stale `package.json`s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow to use OIDC trusted publishing and removed legacy token-based publishing
  * Added npm upgrade step and tightened npm version requirement (≥ 11.5.1) for publishing compatibility
  * Standardized repository and issue metadata across all packages to reflect the current project location
<!-- end of auto-generated comment: release notes by coderabbit.ai -->