### PR TITLE
ci: run release on github-hosted runner for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted (not Blacksmith): npm provenance attestations, which are
+    # generated automatically by OIDC trusted publishing, are only accepted
+    # from github-hosted runners — self-hosted runners are rejected with E422.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why

Follow-up to #503. After that merged, OIDC trusted publishing authenticated correctly (`No NPM_TOKEN found, but OIDC is available - using npm trusted publishing`), but the publish then failed:

```
E422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Unsupported GitHub Actions runner environment: "self-hosted".
Only "github-hosted" runners are supported when publishing with provenance.
```

OIDC trusted publishing **auto-generates provenance attestations**, and npm only accepts those from **github-hosted** runners. The release job runs on Blacksmith (`blacksmith-4vcpu-ubuntu-2404`), which npm classifies as self-hosted → every package is rejected with E422.

## Fix

Move the `release` job to `ubuntu-latest`. OIDC auth + provenance both work there, and `repository.url` (set on every package in #503) satisfies provenance validation. Release runs are infrequent, so losing Blacksmith build speed for this job is an acceptable trade for signed provenance.

## Still required on npmjs.com

Two packages failed with `ENEEDAUTH` in the post-#503 run because their trusted publishers point at the old `cipherstash/protectjs` repo, so the OIDC claim from `cipherstash/stack` doesn't match: **`@cipherstash/protect-dynamodb`** and **`@cipherstash/schema`**. Repoint those two trusted publishers to `cipherstash/stack` (workflow `release.yml`). The other five are already correct.

Once this is merged and those two are repointed, the stuck versions (`protect@12.0.0`, `stack@0.18.0`, `schema@3.0.0`, etc.) publish on the next push to `main`.