### PR TITLE
feat(drizzle): EQL v3 adapter (text scalar)

### DIFF
--- a/packages/drizzle/.gitattributes
+++ b/packages/drizzle/.gitattributes
@@ -1,0 +1,4 @@
+# Vendored EQL installer: codegen output from cipherstash/encrypt-query-language,
+# not hand-written. Exclude from language stats and collapse in diffs.
+# Refresh process: scripts/refresh-eql-v3-sql.md
+__tests__/fixtures/cipherstash-encrypt-v3.sql linguist-vendored

--- a/packages/drizzle/__tests__/eql-v3.test.ts
+++ b/packages/drizzle/__tests__/eql-v3.test.ts
@@ -1,0 +1,269 @@
+import 'dotenv/config'
+import { protect } from '@cipherstash/protect'
+import { sql as dsql } from 'drizzle-orm'
+import { pgTable } from 'drizzle-orm/pg-core'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  createProtectOperators,
+  eqlV3Type,
+  extractProtectSchema,
+} from '../src/pg/v3/index'
+import {
+  oracleAscLabels,
+  oracleContains,
+  oracleEq,
+  oracleLt,
+  oracleNe,
+  v3SeedData,
+} from './fixtures/eql-v3-seed-data'
+import { installEqlV3 } from './v3/helpers/install-v3'
+
+// DB-gated suite: skipped (not failed) without DATABASE_URL — see provisioning.test.ts.
+const HAS_DB = !!process.env.DATABASE_URL
+
+const SKIP_ORDER_BY = true // shared CI DB, mirrors drizzle.test.ts:61
+const TABLE = `v3_matrix_${Date.now()}`
+
+const table = pgTable(TABLE, {
+  t_storage: eqlV3Type<string>('t_storage', { dataType: 'text' }),
+  t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+  t_match: eqlV3Type<string>('t_match', {
+    dataType: 'text',
+    index: 'freeTextSearch',
+  }),
+  t_ord: eqlV3Type<string>('t_ord', {
+    dataType: 'text',
+    index: 'orderAndRange',
+  }),
+})
+const schema = extractProtectSchema(table)
+
+let sql: ReturnType<typeof postgres>
+let db: ReturnType<typeof drizzle>
+let pc: Awaited<ReturnType<typeof protect>>
+let ops: ReturnType<typeof createProtectOperators>
+
+// biome-ignore lint/suspicious/noExplicitAny: test unwrap
+function unwrap(r: any) {
+  if (r.failure) {
+    throw new Error(
+      `[protect] ${r.failure.message ?? JSON.stringify(r.failure)}`,
+    )
+  }
+  return r.data
+}
+
+beforeAll(async () => {
+  if (!HAS_DB) return
+  // { prepare: false } is required for the pooled CI DB (PgBouncer transaction
+  // mode) — mirrors packages/protect/__tests__/searchable-json-pg.test.ts:12.
+  sql = postgres(process.env.DATABASE_URL as string, { prepare: false })
+  await installEqlV3(sql)
+  await sql.unsafe(`CREATE TABLE IF NOT EXISTS "${TABLE}" (
+    t_storage eql_v3.text,
+    t_eq eql_v3.text_eq,
+    t_match eql_v3.text_match,
+    t_ord eql_v3.text_ord
+  )`)
+  await sql.unsafe(
+    `CREATE INDEX IF NOT EXISTS "${TABLE}_eq_idx" ON "${TABLE}" (eql_v3.eq_term(t_eq))`,
+  )
+  await sql.unsafe(
+    `CREATE INDEX IF NOT EXISTS "${TABLE}_match_idx" ON "${TABLE}" USING gin (eql_v3.match_term(t_match))`,
+  )
+  await sql.unsafe(
+    `CREATE INDEX IF NOT EXISTS "${TABLE}_ord_idx" ON "${TABLE}" (eql_v3.ord_term(t_ord))`,
+  )
+
+  db = drizzle({ client: sql })
+  pc = await protect({ schemas: [schema] })
+  ops = createProtectOperators(pc)
+
+  const models = v3SeedData.map((r) => ({
+    t_storage: r.label,
+    t_eq: r.label,
+    t_match: r.label,
+    t_ord: r.label,
+  }))
+  const enc = unwrap(await pc.bulkEncryptModels(models, schema))
+  await db.insert(table).values(enc as never[])
+}, 180000)
+
+afterAll(async () => {
+  await sql?.unsafe(`DROP TABLE IF EXISTS "${TABLE}"`)
+  await sql?.end()
+})
+
+async function decryptLabels(
+  rows: unknown[],
+  col: 't_storage' | 't_eq' | 't_match' | 't_ord',
+) {
+  const dec = unwrap(await pc.bulkDecryptModels(rows as never[]))
+  // biome-ignore lint/suspicious/noExplicitAny: dynamic col access
+  return dec.map((d: any) => d[col]).sort()
+}
+
+describe.skipIf(!HAS_DB)('EQL v3 text domain matrix', () => {
+  it('t_storage: insert + decrypt round-trip', async () => {
+    const rows = await db.select().from(table)
+    expect(rows.length).toBe(v3SeedData.length)
+    const labels = await decryptLabels(rows, 't_storage')
+    expect(labels).toEqual(v3SeedData.map((r) => r.label).sort())
+  })
+
+  it('t_storage: NULL round-trips through the adapter codec (not just raw IS NULL)', async () => {
+    await sql.unsafe(`INSERT INTO "${TABLE}" (t_storage) VALUES (NULL)`)
+    // Read the NULL row back THROUGH the Drizzle typed column so v3FromDriver's
+    // null branch is exercised, then decrypt through the codec — proving the
+    // adapter maps a DB NULL to a JS null end-to-end, not just that a NULL exists.
+    const nullRows = await db
+      .select()
+      .from(table)
+      .where(dsql`${table.t_storage} IS NULL`)
+    expect(nullRows.length).toBeGreaterThanOrEqual(1)
+    // biome-ignore lint/suspicious/noExplicitAny: reading the typed column value
+    expect((nullRows[0] as any).t_storage).toBeNull()
+    const dec = unwrap(await pc.bulkDecryptModels(nullRows as never[]))
+    expect(dec[0].t_storage).toBeNull()
+  })
+
+  it('t_eq: = returns exactly the matching row(s)', async () => {
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.eq(table.t_eq, 'banana'))
+    expect(await decryptLabels(rows, 't_eq')).toEqual(
+      oracleEq('banana').map((r) => r.label),
+    )
+  })
+
+  it('t_eq: <> returns the exact complement', async () => {
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.ne(table.t_eq, 'banana'))
+    expect(await decryptLabels(rows, 't_eq')).toEqual(
+      oracleNe('banana')
+        .map((r) => r.label)
+        .sort(),
+    )
+  })
+
+  it('t_eq: HMAC determinism — duplicate plaintext, = returns both', async () => {
+    const enc = unwrap(await pc.bulkEncryptModels([{ t_eq: 'banana' }], schema))
+    await db.insert(table).values(enc[0] as never)
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.eq(table.t_eq, 'banana'))
+    expect(rows.length).toBe(2)
+  })
+
+  it('t_match: containment returns matches and excludes non-matching', async () => {
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.ilike(table.t_match, 'aard'))
+    const got = await decryptLabels(rows, 't_match')
+    expect(got).toEqual(
+      oracleContains('aard')
+        .map((r) => r.label)
+        .sort(),
+    )
+    expect(got).not.toContain('banana')
+  })
+
+  it('t_ord: < returns the lexicographic prefix set', async () => {
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.lt(table.t_ord, 'cherry'))
+    expect(await decryptLabels(rows, 't_ord')).toEqual(
+      oracleLt('cherry')
+        .map((r) => r.label)
+        .sort(),
+    )
+  })
+
+  const ordByIt = SKIP_ORDER_BY ? it.skip : it
+  ordByIt('t_ord: ORDER BY returns the exact decrypted sequence', async () => {
+    const rows = await db.select().from(table).orderBy(ops.asc(table.t_ord))
+    const dec = unwrap(await pc.bulkDecryptModels(rows as never[]))
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic col
+    expect(dec.map((d: any) => d.t_ord)).toEqual(oracleAscLabels())
+  })
+
+  // §7 min/max coverage. Skipped under the same shared-CI ORDER BY constraint
+  // (MIN/MAX over an encrypted ord domain relies on the same ORE ordering the
+  // CI DB declines). Present as a stub so the gap is visible, not omitted.
+  ordByIt('t_ord: MIN()/MAX() return the lexicographic extremes', async () => {
+    const rows = await sql.unsafe(
+      `SELECT eql_v3.min(t_ord) AS lo, eql_v3.max(t_ord) AS hi FROM "${TABLE}"`,
+    )
+    expect(rows.length).toBe(1)
+  })
+})
+
+describe.skipIf(!HAS_DB)('v3 negative assertions', () => {
+  it('CHECK rejects a match payload (bf, no hm) inserted into text_eq', async () => {
+    // A match payload carries {c,i,v,bf} but no hm; text_eq_check requires hm, so
+    // coercing it into text_eq fails with the domain CHECK (SQLSTATE 23514).
+    const matchEnc = unwrap(
+      await pc.bulkEncryptModels([{ t_match: 'banana' }], schema),
+    )
+    const badPayload = JSON.stringify(
+      (matchEnc[0] as Record<string, unknown>).t_match,
+    )
+    await expect(
+      sql.unsafe(
+        `INSERT INTO "${TABLE}" (t_eq) VALUES ('${badPayload}'::jsonb::eql_v3.text_eq)`,
+      ),
+    ).rejects.toThrow(/text_eq_check|23514/i)
+  })
+
+  it('blocker RAISEs for an unsupported ordering operator on text_eq', async () => {
+    // text_eq is equality-only: eql_v3.lt(text_eq, …) is a blocker that RAISEs
+    // 'operator < is not supported for eql_v3.text_eq' — NOT a bare Postgres 42883
+    // "operator does not exist". The operator EXISTS and binds the blocker fn.
+    await expect(
+      sql.unsafe(`SELECT * FROM "${TABLE}" WHERE t_eq < t_eq`),
+    ).rejects.toThrow(/not supported for .*eql_v3\.text_eq/i)
+  })
+
+  it('wrong-domain: an eq-shaped term used as text_ord is rejected, not silently coerced', async () => {
+    // An eq value has {c,i,v,hm} but no ob. The text_ord `=` operator extracts the
+    // ord term via eql_v3.ord_term → eql_v3.ore_block_u64_8_256(jsonb), which RAISEs
+    // 'Expected an ore index (ob) value in json' for the missing ob. (text_ord_check
+    // would also reject it; either is an intentional v3 guard, never silent coercion.)
+    const eqEnc = unwrap(
+      await pc.bulkEncryptModels([{ t_eq: 'banana' }], schema),
+    )
+    const eqTerm = JSON.stringify((eqEnc[0] as Record<string, unknown>).t_eq)
+    await expect(
+      sql.unsafe(
+        `SELECT * FROM "${TABLE}" WHERE t_ord = '${eqTerm}'::jsonb::eql_v3.text_ord`,
+      ),
+    ).rejects.toThrow(/ore index \(ob\)|text_ord_check|23514/i)
+  })
+
+  it('mapping gaps are loud (pure function rejects out-of-scope tuples)', async () => {
+    const { eqlV3Domain } = await import('../src/pg/v3/domain-map')
+    // @ts-expect-error number has no v3 domain in this milestone
+    expect(() => eqlV3Domain('number', 'equality')).toThrow(/unsupported/i)
+  })
+})
+
+describe.skipIf(!HAS_DB)('v3 functional index definitions', () => {
+  it('eq_term / match_term / ord_term functional indexes exist on the table', async () => {
+    const rows = await sql`
+      SELECT indexname, indexdef FROM pg_indexes
+      WHERE tablename = ${TABLE}
+    `
+    const defs = rows.map((r) => r.indexdef as string).join('\n')
+    expect(defs).toContain('eq_term')
+    expect(defs).toContain('match_term')
+    expect(defs).toContain('ord_term')
+  })
+})

--- a/packages/drizzle/__tests__/fixtures/cipherstash-encrypt-v3.sql
+++ b/packages/drizzle/__tests__/fixtures/cipherstash-encrypt-v3.sql
@@ -1,0 +1,16193 @@
+--! @file v3/schema.sql
+--! @brief EQL v3 schema creation
+--!
+--! Creates the eql_v3 schema, which houses the self-contained encrypted-domain
+--! type families (eql_v3.int4, eql_v3.int8, and future scalar domains): their
+--! jsonb-backed domains, the searchable-encrypted-metadata (SEM) index-term
+--! types they use (eql_v3.hmac_256, eql_v3.ore_block_u64_8_256), the index-term
+--! extractors, comparison wrappers, blockers, and aggregates. The v3 surface is
+--! self-contained — it owns every type it needs and has no runtime dependency
+--! on another EQL schema.
+--!
+--! Drops existing schema if present to support clean reinstallation.
+--!
+--! @warning DROP SCHEMA CASCADE will remove all objects in the schema
+--! @note eql_v3 is a new, additional schema for the encrypted-domain families.
+
+--! @brief Drop existing EQL v3 schema
+--! @warning CASCADE will drop all dependent objects
+DROP SCHEMA IF EXISTS eql_v3 CASCADE;
+
+--! @brief Create EQL v3 schema
+--! @note Houses the encrypted-domain type families
+CREATE SCHEMA eql_v3;
+
+--! @file v3/sem/ore_block_u64_8_256/types.sql
+--! @brief ORE block index-term types (eql_v3 SEM).
+--!
+--! Self-contained eql_v3 copies of the Order-Revealing Encryption block types
+--! (design D1/D3). The eql_v2 originals are unchanged.
+
+--! @brief ORE block term type for Order-Revealing Encryption
+--!
+--! Composite type representing a single ORE block term. Stores encrypted data
+--! as bytea that enables range comparisons without decryption.
+CREATE TYPE eql_v3.ore_block_u64_8_256_term AS (
+  bytes bytea
+);
+
+
+--! @brief ORE block index term type for range queries
+--!
+--! Composite type containing an array of ORE block terms. The array is stored
+--! in the 'ob' field of encrypted data payloads.
+--!
+--! @note Transient type used only during query execution.
+CREATE TYPE eql_v3.ore_block_u64_8_256 AS (
+  terms eql_v3.ore_block_u64_8_256_term[]
+);
+
+--! @file v3/crypto.sql
+--! @brief PostgreSQL pgcrypto extension enablement (eql_v3 fork)
+--!
+--! Forked from src/crypto.sql (design D8) so the entire eql_v3 dependency
+--! closure lives under src/v3/. Enables the pgcrypto extension which provides
+--! cryptographic functions used by the eql_v3 ORE comparison path.
+--!
+--! Installs pgcrypto into the `extensions` schema (Supabase convention) to
+--! avoid the `extension_in_public` lint. Every EQL function that uses pgcrypto
+--! has `pg_catalog, extensions, public` on its `search_path`, so a pre-existing
+--! install in `public` keeps working — and a pre-existing install anywhere else
+--! will be rejected at install time. The body is idempotent
+--! (`CREATE SCHEMA IF NOT EXISTS`, `pg_extension` guard), so running it
+--! alongside the eql_v2 copy in a combined install is safe.
+--!
+--! @note pgcrypto provides functions like digest(), hmac(), gen_random_bytes()
+
+--! @brief Create extensions schema (Supabase convention)
+CREATE SCHEMA IF NOT EXISTS extensions;
+
+--! @brief Enable pgcrypto extension and validate its schema
+DO $$
+DECLARE
+  pgcrypto_schema name;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto') THEN
+    CREATE EXTENSION pgcrypto WITH SCHEMA extensions;
+  END IF;
+
+  SELECT n.nspname INTO pgcrypto_schema
+  FROM pg_extension e
+  JOIN pg_namespace n ON n.oid = e.extnamespace
+  WHERE e.extname = 'pgcrypto';
+
+  IF pgcrypto_schema = 'extensions' THEN
+    -- expected location, nothing to say
+    NULL;
+  ELSIF pgcrypto_schema = 'public' THEN
+    RAISE NOTICE
+      'pgcrypto is installed in the `public` schema. EQL works against this layout, '
+      'but Supabase splinter will flag it as `extension_in_public`. Move it with: '
+      'ALTER EXTENSION pgcrypto SET SCHEMA extensions';
+  ELSE
+    RAISE EXCEPTION
+      'pgcrypto is installed in schema `%`, which is not on the EQL function search_path '
+      '(pg_catalog, extensions, public). EQL cryptographic operations would fail at '
+      'runtime. Relocate the extension before installing EQL: '
+      'ALTER EXTENSION pgcrypto SET SCHEMA extensions',
+      pgcrypto_schema;
+  END IF;
+END $$;
+
+--! @file v3/common.sql
+--! @brief Common utility functions for the self-contained eql_v3 surface.
+--!
+--! Forked from src/common.sql (design D7) so the eql_v3 ORE constructor owns the
+--! one transitive helper it needs without reaching into another schema. The
+--! eql_v2 original is unchanged.
+
+--! @brief Convert JSONB hex array to bytea array
+--! @internal
+--!
+--! Converts a JSONB array of hex-encoded strings into a PostgreSQL bytea array.
+--! Used for deserializing binary data (like ORE terms) from JSONB storage.
+--!
+--! @param val jsonb JSONB array of hex-encoded strings
+--! @return bytea[] Array of decoded binary values
+--!
+--! @note Returns NULL if input is JSON null
+--! @note Each array element is hex-decoded to bytea
+--! @note Inlinable `LANGUAGE sql` IMMUTABLE form (no `SET search_path`) so the
+--!   planner can fold this per-encrypted-value helper into the calling query.
+--!   This deliberately diverges from the v2 plpgsql equivalent (intentionally
+--!   left unchanged): the `CASE WHEN jsonb_typeof(val) = 'array'` guard only
+--!   evaluates the set-returning `jsonb_array_elements_text` for an array, so a
+--!   non-array JSON scalar returns NULL here instead of raising "cannot extract
+--!   elements from a scalar". Both callers only ever pass an array or JSON null
+--!   (`val->'ob'`), so the divergence is unreachable in practice; JSON null and
+--!   empty array still return NULL exactly as before.
+CREATE FUNCTION eql_v3.jsonb_array_to_bytea_array(val jsonb)
+RETURNS bytea[]
+  IMMUTABLE
+AS $$
+  SELECT CASE WHEN jsonb_typeof(val) = 'array'
+    THEN (
+      SELECT array_agg(decode(value::text, 'hex')::bytea)
+      FROM jsonb_array_elements_text(val) AS value
+    )
+    ELSE NULL
+  END;
+$$ LANGUAGE sql;
+
+--! @internal Mark this hand-written helper inline-critical so the post-install
+--! pin_search_path pass leaves it unpinned (no `SET search_path`), preserving
+--! SQL-function inlining. It takes a bare `jsonb` arg (not a jsonb-backed
+--! encrypted DOMAIN), so the structural skip in tasks/pin_search_path.sql does
+--! not recognise it; this marker is the documented manual opt-in.
+COMMENT ON FUNCTION eql_v3.jsonb_array_to_bytea_array(jsonb) IS
+  'eql-inline-critical: per-encrypted-value ORE helper; must stay inlinable (unpinned search_path)';
+
+--! @file v3/sem/hmac_256/types.sql
+--! @brief HMAC-SHA256 index term type (eql_v3 SEM)
+--!
+--! Domain type representing HMAC-SHA256 hash values. Used for exact-match
+--! encrypted searches. The hash is stored in the 'hm' field of encrypted data
+--! payloads. Self-contained eql_v3 copy (design D1/D3); the eql_v2 original is
+--! unchanged.
+--!
+--! @note Transient type used only during query execution.
+CREATE DOMAIN eql_v3.hmac_256 AS text;
+
+--! @file v3/sem/bloom_filter/types.sql
+--! @brief Self-contained eql_v3 Bloom-filter SEM index-term type.
+
+--! @brief Bloom-filter index term: a bit array stored as smallint[].
+--!
+--! Backs the `match` capability (`@>` / `<@`) on `eql_v3.text_match`. The
+--! filter is read from the `bf` field of an encrypted jsonb payload. Native
+--! `smallint[]` array-containment (`@>`/`<@`) is inherited through the domain,
+--! so this type needs no custom operators.
+--!
+--! @note Self-contained: references no eql_v2 symbol.
+CREATE DOMAIN eql_v3.bloom_filter AS smallint[];
+
+--! @file v3/scalars/functions.sql
+--! @brief Shared blocker helper for the eql_v3 encrypted-domain families.
+--!
+--! Per-domain wrapper functions live in src/v3/scalars/<T>/.
+--! Blockers in those files delegate to encrypted_domain_unsupported_bool
+--! so every domain raises a uniform domain-specific error rather than
+--! letting an unsupported operator fall through to native jsonb
+--! behaviour.
+
+--! @brief Shared blocker helper. Raises 'operator X is not supported
+--!        for TYPE' so unsupported domain operators surface a clear
+--!        error rather than fall through to native jsonb behaviour.
+--! @param type_name Domain type name (eql_v3.<T>*)
+--! @param operator_name Operator symbol (=, <, @>, ->, etc.)
+--! @return boolean (never returns; always raises)
+CREATE FUNCTION eql_v3.encrypted_domain_unsupported_bool(type_name text, operator_name text)
+RETURNS boolean
+IMMUTABLE PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  RAISE EXCEPTION 'operator % is not supported for %', operator_name, type_name;
+END;
+$$ LANGUAGE plpgsql;
+
+--! @file v3/sem/ore_block_u64_8_256/functions.sql
+--! @brief ORE block construction, extraction, and comparison (eql_v3 SEM).
+--!
+--! jsonb-only subset of src/ore_block_u64_8_256/functions.sql. The
+--! encrypted-column overloads are omitted; the helper jsonb_array_to_bytea_array
+--! and pgcrypto encrypt() are reached via the forked src/v3/common.sql and
+--! src/v3/crypto.sql so the whole closure stays under src/v3. (Doc comments
+--! deliberately avoid naming eql_v2 symbols so the self-containment grep stays
+--! clean.)
+
+--! @brief Convert JSONB array to ORE block composite type
+--! @internal
+--! @param val jsonb Array of hex-encoded ORE block terms
+--! @return eql_v3.ore_block_u64_8_256 ORE block composite, or NULL if input is null
+--! @note Inlinable `LANGUAGE sql` IMMUTABLE form (no `SET search_path`) so the
+--!   planner can fold this per-encrypted-value helper into the calling query.
+--!   This deliberately diverges from the v2 plpgsql equivalent (intentionally
+--!   left unchanged): the `CASE WHEN jsonb_typeof(val) = 'array'` guard only
+--!   evaluates the array path for an array, so a non-array JSON scalar returns
+--!   NULL here instead of raising. The sole caller passes `val->'ob'`, always an
+--!   array or JSON null, so the divergence is unreachable in practice; JSON null
+--!   and empty array still return NULL exactly as before.
+CREATE FUNCTION eql_v3.jsonb_array_to_ore_block_u64_8_256(val jsonb)
+RETURNS eql_v3.ore_block_u64_8_256
+  IMMUTABLE
+AS $$
+  SELECT CASE WHEN jsonb_typeof(val) = 'array'
+    THEN ROW((
+      SELECT array_agg(ROW(b)::eql_v3.ore_block_u64_8_256_term)
+      FROM unnest(eql_v3.jsonb_array_to_bytea_array(val)) AS b
+    ))::eql_v3.ore_block_u64_8_256
+    ELSE NULL
+  END;
+$$ LANGUAGE sql;
+
+--! @internal Mark this hand-written helper inline-critical so the post-install
+--! pin_search_path pass leaves it unpinned (no `SET search_path`), preserving
+--! SQL-function inlining. It takes a bare `jsonb` arg (not a jsonb-backed
+--! encrypted DOMAIN), so the structural skip in tasks/pin_search_path.sql does
+--! not recognise it; this marker is the documented manual opt-in.
+COMMENT ON FUNCTION eql_v3.jsonb_array_to_ore_block_u64_8_256(jsonb) IS
+  'eql-inline-critical: per-encrypted-value ORE helper; must stay inlinable (unpinned search_path)';
+
+
+--! @brief Extract ORE block index term from JSONB payload
+--! @param val jsonb containing encrypted EQL payload
+--! @return eql_v3.ore_block_u64_8_256 ORE block index term
+--! @throws Exception if 'ob' field is missing
+CREATE FUNCTION eql_v3.ore_block_u64_8_256(val jsonb)
+  RETURNS eql_v3.ore_block_u64_8_256
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    -- Declared STRICT: PostgreSQL returns NULL for a NULL argument without
+    -- entering the body, so no explicit `val IS NULL` guard is needed.
+    IF eql_v3.has_ore_block_u64_8_256(val) THEN
+      RETURN eql_v3.jsonb_array_to_ore_block_u64_8_256(val->'ob');
+    END IF;
+    RAISE 'Expected an ore index (ob) value in json: %', val;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+--! @brief Check if JSONB payload contains ORE block index term
+--! @param val jsonb containing encrypted EQL payload
+--! @return boolean True if 'ob' field is present and non-null
+CREATE FUNCTION eql_v3.has_ore_block_u64_8_256(val jsonb)
+  RETURNS boolean
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN val ->> 'ob' IS NOT NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+--! @brief Compare two ORE block terms using cryptographic comparison
+--! @internal
+--! @param a eql_v3.ore_block_u64_8_256_term First ORE term
+--! @param b eql_v3.ore_block_u64_8_256_term Second ORE term
+--! @return integer -1 if a < b, 0 if a = b, 1 if a > b
+--! @throws Exception if ciphertexts are different lengths
+--! @note Marked `IMMUTABLE` (the three `compare_ore_block_u64_8_256_term(s)`
+--!   overloads all are). This deliberately diverges from the v2 originals,
+--!   which carry no volatility marker and so default to `VOLATILE`. The
+--!   comparison is deterministic — its only crypto call, pgcrypto `encrypt()`,
+--!   is itself `IMMUTABLE STRICT PARALLEL SAFE` — so `IMMUTABLE` lets the
+--!   planner fold/cache these in ordering and index contexts. NOT `STRICT`:
+--!   the NULL-handling branches below are load-bearing for the array overload.
+CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_term(a eql_v3.ore_block_u64_8_256_term, b eql_v3.ore_block_u64_8_256_term)
+  RETURNS integer
+  IMMUTABLE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  DECLARE
+    eq boolean := true;
+    unequal_block smallint := 0;
+    hash_key bytea;
+    data_block bytea;
+    encrypt_block bytea;
+    target_block bytea;
+
+    left_block_size CONSTANT smallint := 16;
+    right_block_size CONSTANT smallint := 32;
+    right_offset CONSTANT smallint := 136; -- 8 * 17
+
+    indicator smallint := 0;
+  BEGIN
+    IF a IS NULL AND b IS NULL THEN
+      RETURN 0;
+    END IF;
+
+    IF a IS NULL THEN
+      RETURN -1;
+    END IF;
+
+    IF b IS NULL THEN
+      RETURN 1;
+    END IF;
+
+    IF bit_length(a.bytes) != bit_length(b.bytes) THEN
+      RAISE EXCEPTION 'Ciphertexts are different lengths';
+    END IF;
+
+    FOR block IN 0..7 LOOP
+      IF
+        substr(a.bytes, 1 + block, 1) != substr(b.bytes, 1 + block, 1)
+        OR substr(a.bytes, 9 + left_block_size * block, left_block_size) != substr(b.bytes, 9 + left_block_size * BLOCK, left_block_size)
+      THEN
+        IF eq THEN
+          unequal_block := block;
+        END IF;
+        eq = false;
+      END IF;
+    END LOOP;
+
+    IF eq THEN
+      RETURN 0::integer;
+    END IF;
+
+    hash_key := substr(b.bytes, right_offset + 1, 16);
+
+    target_block := substr(b.bytes, right_offset + 17 + (unequal_block * right_block_size), right_block_size);
+
+    data_block := substr(a.bytes, 9 + (left_block_size * unequal_block), left_block_size);
+
+    encrypt_block := encrypt(data_block::bytea, hash_key::bytea, 'aes-ecb');
+
+    indicator := (
+      get_bit(
+        encrypt_block,
+        0
+      ) + get_bit(target_block, get_byte(a.bytes, unequal_block))) % 2;
+
+    IF indicator = 1 THEN
+      RETURN 1::integer;
+    ELSE
+      RETURN -1::integer;
+    END IF;
+  END;
+$$ LANGUAGE plpgsql;
+
+
+--! @brief Compare arrays of ORE block terms recursively
+--! @internal
+--! @param a eql_v3.ore_block_u64_8_256_term[] First array
+--! @param b eql_v3.ore_block_u64_8_256_term[] Second array
+--! @return integer -1/0/1, or NULL if either array is NULL
+CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_terms(a eql_v3.ore_block_u64_8_256_term[], b eql_v3.ore_block_u64_8_256_term[])
+RETURNS integer
+  IMMUTABLE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  DECLARE
+    cmp_result integer;
+  BEGIN
+    IF a IS NULL OR b IS NULL THEN
+      RETURN NULL;
+    END IF;
+
+    IF cardinality(a) = 0 AND cardinality(b) = 0 THEN
+      RETURN 0;
+    END IF;
+
+    IF (cardinality(a) = 0) AND cardinality(b) > 0 THEN
+      RETURN -1;
+    END IF;
+
+    IF cardinality(a) > 0 AND (cardinality(b) = 0) THEN
+      RETURN 1;
+    END IF;
+
+    cmp_result := eql_v3.compare_ore_block_u64_8_256_term(a[1], b[1]);
+
+    IF cmp_result = 0 THEN
+      RETURN eql_v3.compare_ore_block_u64_8_256_terms(a[2:array_length(a,1)], b[2:array_length(b,1)]);
+    END IF;
+
+    RETURN cmp_result;
+  END
+$$ LANGUAGE plpgsql;
+
+
+--! @brief Compare ORE block composite types
+--! @internal
+--! @param a eql_v3.ore_block_u64_8_256 First ORE block
+--! @param b eql_v3.ore_block_u64_8_256 Second ORE block
+--! @return integer -1/0/1
+CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_terms(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS integer
+  IMMUTABLE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN eql_v3.compare_ore_block_u64_8_256_terms(a.terms, b.terms);
+  END
+$$ LANGUAGE plpgsql;
+
+--! @file v3/sem/ore_block_u64_8_256/operators.sql
+--! @brief Comparison operators on eql_v3.ore_block_u64_8_256.
+--!
+--! The six backing functions are inlinable single-statement SQL so the planner
+--! can fold the eql_v3 comparison wrappers through to functional-index matching.
+
+--! @brief Equality backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the ORE blocks are equal
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_eq(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) = 0
+$$;
+
+--! @brief Not-equal backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the ORE blocks are not equal
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_neq(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) <> 0
+$$;
+
+--! @brief Less-than backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the left operand is less than the right operand
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_lt(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) = -1
+$$;
+
+--! @brief Less-than-or-equal backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the left operand is less than or equal to the right operand
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_lte(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) != 1
+$$;
+
+--! @brief Greater-than backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the left operand is greater than the right operand
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_gt(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) = 1
+$$;
+
+--! @brief Greater-than-or-equal backing function for ORE block types
+--! @internal
+--!
+--! @param a eql_v3.ore_block_u64_8_256 Left operand
+--! @param b eql_v3.ore_block_u64_8_256 Right operand
+--! @return boolean True if the left operand is greater than or equal to the right operand
+--!
+--! @see eql_v3.compare_ore_block_u64_8_256_terms
+CREATE FUNCTION eql_v3.ore_block_u64_8_256_gte(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
+RETURNS boolean
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT eql_v3.compare_ore_block_u64_8_256_terms(a, b) != -1
+$$;
+
+
+--! @brief = operator for ORE block types
+--!
+--! COMMUTATOR is the operator itself: equality is symmetric. Required for the
+--! MERGES flag — without it the planner raises "could not find commutator" the
+--! first time an ore_block equality is used as a join qual (e.g. via the inlined
+--! eql_v3.<T>_ord_ore equality wrappers).
+CREATE OPERATOR = (
+  FUNCTION=eql_v3.ore_block_u64_8_256_eq,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = =,
+  NEGATOR = <>,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+--! @brief <> operator for ORE block types
+CREATE OPERATOR <> (
+  FUNCTION=eql_v3.ore_block_u64_8_256_neq,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = <>,
+  NEGATOR = =,
+  RESTRICT = eqsel,
+  JOIN = eqjoinsel,
+  HASHES,
+  MERGES
+);
+
+--! @brief > operator for ORE block types
+CREATE OPERATOR > (
+  FUNCTION=eql_v3.ore_block_u64_8_256_gt,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = <,
+  NEGATOR = <=,
+  RESTRICT = scalargtsel,
+  JOIN = scalargtjoinsel
+);
+
+--! @brief < operator for ORE block types
+CREATE OPERATOR < (
+  FUNCTION=eql_v3.ore_block_u64_8_256_lt,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = >,
+  NEGATOR = >=,
+  RESTRICT = scalarltsel,
+  JOIN = scalarltjoinsel
+);
+
+--! @brief <= operator for ORE block types
+CREATE OPERATOR <= (
+  FUNCTION=eql_v3.ore_block_u64_8_256_lte,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = >=,
+  NEGATOR = >,
+  RESTRICT = scalarlesel,
+  JOIN = scalarlejoinsel
+);
+
+--! @brief >= operator for ORE block types
+CREATE OPERATOR >= (
+  FUNCTION=eql_v3.ore_block_u64_8_256_gte,
+  LEFTARG=eql_v3.ore_block_u64_8_256,
+  RIGHTARG=eql_v3.ore_block_u64_8_256,
+  COMMUTATOR = <=,
+  NEGATOR = <,
+  RESTRICT = scalargesel,
+  JOIN = scalargejoinsel
+);
+
+--! @file v3/sem/hmac_256/functions.sql
+--! @brief HMAC-SHA256 index-term extraction from a jsonb payload (eql_v3 SEM).
+--!
+--! jsonb-only subset of src/hmac_256/functions.sql. The encrypted-column and
+--! ste_vec-entry overloads are intentionally omitted — the eql_v3 scalar
+--! domains extract from the jsonb payload directly via a cast to the domain.
+--! (Doc comments deliberately avoid naming eql_v2 symbols so the
+--! self-containment grep stays clean.)
+
+--! @brief Extract HMAC-SHA256 index term from JSONB payload
+--!
+--! Inlinable single-statement SQL — the planner can fold this into the calling
+--! query so functional hash/btree indexes built on `eql_v3.eq_term(col)`
+--! (which calls this) engage structurally.
+--!
+--! @param val jsonb containing encrypted EQL payload
+--! @return eql_v3.hmac_256 HMAC-SHA256 hash value, or NULL when `hm` is absent
+CREATE FUNCTION eql_v3.hmac_256(val jsonb)
+  RETURNS eql_v3.hmac_256
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT (val ->> 'hm')::eql_v3.hmac_256
+$$;
+
+
+--! @brief Check if JSONB payload contains HMAC-SHA256 index term
+--!
+--! @param val jsonb containing encrypted EQL payload
+--! @return boolean True if 'hm' field is present and non-null
+CREATE FUNCTION eql_v3.has_hmac_256(val jsonb)
+  RETURNS boolean
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN val ->> 'hm' IS NOT NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+--! @file v3/sem/bloom_filter/functions.sql
+--! @brief Extractor for the eql_v3 Bloom-filter SEM index term.
+--!
+--! jsonb-only subset of src/bloom_filter/functions.sql. The encrypted-column
+--! overloads are intentionally omitted — the eql_v3 scalar domains extract from
+--! the jsonb payload directly via a cast to the domain. (Doc comments
+--! deliberately avoid naming eql_v2 symbols so the self-containment grep stays
+--! clean.)
+
+--! @brief Test whether a jsonb payload carries a Bloom-filter (`bf`) term.
+--!
+--! @param val jsonb The encrypted payload.
+--! @return boolean True when the `bf` key is present and non-null.
+--!
+--! @internal Defined for parity with the eql_v3 SEM index-term predicates
+--! (`has_hmac_256` / `has_ore_block_u64_8_256`); it is not currently called by
+--! the extractor below, which gates on value-shape inline, nor by the generated
+--! domain CHECK, which tests `bf` presence via the envelope-key skeleton. Kept
+--! as the canonical presence test for callers that need one.
+CREATE FUNCTION eql_v3.has_bloom_filter(val jsonb)
+  RETURNS boolean
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN val ? 'bf' AND val ->> 'bf' IS NOT NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+--! @brief Extract the Bloom-filter index term from a jsonb payload.
+--!
+--! Inlinable single-statement SQL — the planner can fold this into the calling
+--! query so the functional GIN index built on `eql_v3.match_term(col)` (which
+--! calls this) engages structurally. Mirrors `eql_v3.hmac_256(jsonb)`: no RAISE
+--! and no pinned `search_path`. Returns NULL when `bf` is absent or present but
+--! not a json array, rather than raising. The `text_match` domain CHECK
+--! guarantees the `bf` *key* is present but not that it is an array, so a
+--! non-array `bf` (e.g. `{"bf": null}`) can reach here even on a typed value;
+--! gating on `jsonb_typeof(...) = 'array'` returns NULL for that case — and for
+--! raw jsonb outside the domain — instead of erroring inside
+--! `jsonb_array_elements`. NULL, like the HMAC extractor, is the right answer. An
+--! empty `bf` array yields an empty filter (contains nothing, contained by
+--! everything), matching set-containment semantics.
+--!
+--! @param val jsonb The encrypted payload.
+--! @return eql_v3.bloom_filter The `bf` array as a smallint[] domain value, or
+--!   NULL when `bf` is absent or not a json array.
+CREATE FUNCTION eql_v3.bloom_filter(val jsonb)
+  RETURNS eql_v3.bloom_filter
+  LANGUAGE sql
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT CASE WHEN jsonb_typeof(val -> 'bf') = 'array'
+    THEN ARRAY(SELECT jsonb_array_elements(val -> 'bf'))::eql_v3.bloom_filter
+  END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/int4/int4_types.sql
+--! @brief Encrypted-domain types for int4.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.int4.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int4' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int4 AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int4_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int4_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int4_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int4_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int4_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int4_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int4_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int4_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int4_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_functions.sql
+--! @brief Functions for eql_v3.int4_ord.
+
+--! @brief Index extractor for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int4_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int4_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int4_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param selector text
+--! @return eql_v3.int4_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_ord, selector text)
+RETURNS eql_v3.int4_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param selector integer
+--! @return eql_v3.int4_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_ord, selector integer)
+RETURNS eql_v3.int4_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int4_ord
+--! @return eql_v3.int4_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int4_ord)
+RETURNS eql_v3.int4_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int4_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int4_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int4_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int4_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int4_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int4_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int4_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int4_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int4_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int4_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b eql_v3.int4_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_ord, b eql_v3.int4_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a eql_v3.int4_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int4_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_operators.sql
+--! @brief Operators for eql_v3.int4_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = eql_v3.int4_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_eq_functions.sql
+--! @brief Functions for eql_v3.int4_eq.
+
+--! @brief Index extractor for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.int4_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.int4_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int4_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.int4_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int4_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int4_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param selector text
+--! @return eql_v3.int4_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_eq, selector text)
+RETURNS eql_v3.int4_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param selector integer
+--! @return eql_v3.int4_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_eq, selector integer)
+RETURNS eql_v3.int4_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int4_eq
+--! @return eql_v3.int4_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int4_eq)
+RETURNS eql_v3.int4_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int4_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int4_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int4_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int4_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int4_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int4_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int4_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int4_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int4_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int4_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b eql_v3.int4_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_eq, b eql_v3.int4_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a eql_v3.int4_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_eq.
+--! @param a jsonb
+--! @param b eql_v3.int4_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int4_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/timestamptz/timestamptz_types.sql
+--! @brief Encrypted-domain types for timestamptz.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.timestamptz.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamptz' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamptz AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.timestamptz_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamptz_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamptz_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamptz/timestamptz_eq_functions.sql
+--! @brief Functions for eql_v3.timestamptz_eq.
+
+--! @brief Index extractor for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.timestamptz_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector text
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector text)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector integer
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector integer)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz_eq
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz_eq)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/int2/int2_types.sql
+--! @brief Encrypted-domain types for int2.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.int2.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2 AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_ore_functions.sql
+--! @brief Functions for eql_v3.int2_ord_ore.
+
+--! @brief Index extractor for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int2_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector text
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord_ore, selector text)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector integer
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord_ore, selector integer)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_functions.sql
+--! @brief Functions for eql_v3.int2_ord.
+
+--! @brief Index extractor for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int2_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector text
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord, selector text)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector integer
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord, selector integer)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_operators.sql
+--! @brief Operators for eql_v3.int2_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_functions.sql
+--! @brief Functions for eql_v3.int2.
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector text
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2, selector text)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector integer
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2, selector integer)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param selector eql_v3.int2
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param selector eql_v3.int2
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2, b eql_v3.int2)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_ore_operators.sql
+--! @brief Operators for eql_v3.int2_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/date/date_types.sql
+--! @brief Encrypted-domain types for date.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.date.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_ore_functions.sql
+--! @brief Functions for eql_v3.date_ord_ore.
+
+--! @brief Index extractor for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.date_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector text
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord_ore, selector text)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector integer
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord_ore, selector integer)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_eq_functions.sql
+--! @brief Functions for eql_v3.date_eq.
+
+--! @brief Index extractor for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.date_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.date_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.date_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.date_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.date_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector text
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_eq, selector text)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector integer
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_eq, selector integer)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param selector eql_v3.date_eq
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_eq)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param selector eql_v3.date_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_functions.sql
+--! @brief Functions for eql_v3.date.
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector text
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a eql_v3.date, selector text)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector integer
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a eql_v3.date, selector integer)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param selector eql_v3.date
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param selector eql_v3.date
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date, b eql_v3.date)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_ore_operators.sql
+--! @brief Operators for eql_v3.date_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/int8/int8_types.sql
+--! @brief Encrypted-domain types for int8.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.int8.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8 AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_functions.sql
+--! @brief Functions for eql_v3.int8.
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector text
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8, selector text)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector integer
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8, selector integer)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param selector eql_v3.int8
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param selector eql_v3.int8
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8, b eql_v3.int8)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_functions.sql
+--! @brief Functions for eql_v3.int8_ord.
+
+--! @brief Index extractor for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int8_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector text
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord, selector text)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector integer
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord, selector integer)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/text/text_types.sql
+--! @brief Encrypted-domain types for text.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.text.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_match.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_match' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_match AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'bf'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_functions.sql
+--! @brief Functions for eql_v3.text_ord.
+
+--! @brief Index extractor for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.text_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector text
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord, selector text)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector integer
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord, selector integer)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_ord)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_ore_functions.sql
+--! @brief Functions for eql_v3.text_ord_ore.
+
+--! @brief Index extractor for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.text_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector text
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord_ore, selector text)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector integer
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord_ore, selector integer)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_match_functions.sql
+--! @brief Functions for eql_v3.text_match.
+
+--! @brief Index extractor for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @return eql_v3.bloom_filter
+CREATE FUNCTION eql_v3.match_term(a eql_v3.text_match)
+RETURNS eql_v3.bloom_filter
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.bloom_filter(a::jsonb) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) @> eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_match, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) @> eql_v3.match_term(b::eql_v3.text_match) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a::eql_v3.text_match) @> eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) <@ eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_match, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) <@ eql_v3.match_term(b::eql_v3.text_match) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a::eql_v3.text_match) <@ eql_v3.match_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector text
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_match, selector text)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector integer
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_match, selector integer)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param selector eql_v3.text_match
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_match)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_match, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_match, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param selector eql_v3.text_match
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_match)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_match, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_match, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_match, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_match, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_match, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_match, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_match, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_match)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_eq_functions.sql
+--! @brief Functions for eql_v3.text_eq.
+
+--! @brief Index extractor for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.text_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.text_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.text_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.text_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.text_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector text
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_eq, selector text)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector integer
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_eq, selector integer)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param selector eql_v3.text_eq
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_eq)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param selector eql_v3.text_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_ore_operators.sql
+--! @brief Operators for eql_v3.text_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_operators.sql
+--! @brief Operators for eql_v3.text_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.int4_ord.
+
+--! @brief State function for min on eql_v3.int4_ord.
+--! @param state eql_v3.int4_ord
+--! @param value eql_v3.int4_ord
+--! @return eql_v3.int4_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int4_ord, value eql_v3.int4_ord)
+RETURNS eql_v3.int4_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int4_ord.
+--! @param input eql_v3.int4_ord
+--! @return eql_v3.int4_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.int4_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int4_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int4_ord.
+--! @param state eql_v3.int4_ord
+--! @param value eql_v3.int4_ord
+--! @return eql_v3.int4_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int4_ord, value eql_v3.int4_ord)
+RETURNS eql_v3.int4_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int4_ord.
+--! @param input eql_v3.int4_ord
+--! @return eql_v3.int4_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.int4_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int4_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_functions.sql
+--! @brief Functions for eql_v3.int4.
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int4)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param selector text
+--! @return eql_v3.int4
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4, selector text)
+RETURNS eql_v3.int4 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param selector integer
+--! @return eql_v3.int4
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4, selector integer)
+RETURNS eql_v3.int4 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param selector eql_v3.int4
+--! @return eql_v3.int4
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int4)
+RETURNS eql_v3.int4 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param selector eql_v3.int4
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int4)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int4, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int4, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int4, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int4, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int4, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int4, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int4, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int4, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b eql_v3.int4
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4, b eql_v3.int4)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a eql_v3.int4
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4.
+--! @param a jsonb
+--! @param b eql_v3.int4
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int4)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_eq_operators.sql
+--! @brief Operators for eql_v3.int4_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = eql_v3.int4_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_ore_functions.sql
+--! @brief Functions for eql_v3.int4_ord_ore.
+
+--! @brief Index extractor for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int4_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int4_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int4_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param selector text
+--! @return eql_v3.int4_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_ord_ore, selector text)
+RETURNS eql_v3.int4_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param selector integer
+--! @return eql_v3.int4_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int4_ord_ore, selector integer)
+RETURNS eql_v3.int4_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int4_ord_ore
+--! @return eql_v3.int4_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int4_ord_ore)
+RETURNS eql_v3.int4_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int4_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int4_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int4_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int4_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int4_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int4_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int4_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int4_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int4_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int4_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int4_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int4_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b eql_v3.int4_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_ord_ore, b eql_v3.int4_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a eql_v3.int4_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int4_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int4_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int4_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int4_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_ore_operators.sql
+--! @brief Operators for eql_v3.int4_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = eql_v3.int4_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4_ord_ore
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_operators.sql
+--! @brief Operators for eql_v3.int4.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int4, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int4, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int4, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int4, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4, RIGHTARG = eql_v3.int4
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int4, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int4
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int4/int4_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.int4_ord_ore.
+
+--! @brief State function for min on eql_v3.int4_ord_ore.
+--! @param state eql_v3.int4_ord_ore
+--! @param value eql_v3.int4_ord_ore
+--! @return eql_v3.int4_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int4_ord_ore, value eql_v3.int4_ord_ore)
+RETURNS eql_v3.int4_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int4_ord_ore.
+--! @param input eql_v3.int4_ord_ore
+--! @return eql_v3.int4_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.int4_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int4_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int4_ord_ore.
+--! @param state eql_v3.int4_ord_ore
+--! @param value eql_v3.int4_ord_ore
+--! @return eql_v3.int4_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int4_ord_ore, value eql_v3.int4_ord_ore)
+RETURNS eql_v3.int4_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int4_ord_ore.
+--! @param input eql_v3.int4_ord_ore
+--! @return eql_v3.int4_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.int4_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int4_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamptz/timestamptz_functions.sql
+--! @brief Functions for eql_v3.timestamptz.
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector text
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector text)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector integer
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector integer)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamptz/timestamptz_eq_operators.sql
+--! @brief Operators for eql_v3.timestamptz_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamptz/timestamptz_operators.sql
+--! @brief Operators for eql_v3.timestamptz.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_eq_functions.sql
+--! @brief Functions for eql_v3.int2_eq.
+
+--! @brief Index extractor for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.int2_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.int2_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int2_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.int2_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int2_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector text
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_eq, selector text)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector integer
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_eq, selector integer)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int2_eq
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_eq)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int2_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.int2_ord.
+
+--! @brief State function for min on eql_v3.int2_ord.
+--! @param state eql_v3.int2_ord
+--! @param value eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int2_ord, value eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int2_ord.
+--! @param input eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.int2_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int2_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int2_ord.
+--! @param state eql_v3.int2_ord
+--! @param value eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int2_ord, value eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int2_ord.
+--! @param input eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.int2_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int2_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_operators.sql
+--! @brief Operators for eql_v3.int2.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_eq_operators.sql
+--! @brief Operators for eql_v3.int2_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int2/int2_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.int2_ord_ore.
+
+--! @brief State function for min on eql_v3.int2_ord_ore.
+--! @param state eql_v3.int2_ord_ore
+--! @param value eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int2_ord_ore, value eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int2_ord_ore.
+--! @param input eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.int2_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int2_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int2_ord_ore.
+--! @param state eql_v3.int2_ord_ore
+--! @param value eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int2_ord_ore, value eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int2_ord_ore.
+--! @param input eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.int2_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int2_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_functions.sql
+--! @brief Functions for eql_v3.date_ord.
+
+--! @brief Index extractor for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.date_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector text
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord, selector text)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector integer
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord, selector integer)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_ord)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_eq_operators.sql
+--! @brief Operators for eql_v3.date_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_operators.sql
+--! @brief Operators for eql_v3.date.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.date_ord_ore.
+
+--! @brief State function for min on eql_v3.date_ord_ore.
+--! @param state eql_v3.date_ord_ore
+--! @param value eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.date_ord_ore, value eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.date_ord_ore.
+--! @param input eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.date_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.date_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.date_ord_ore.
+--! @param state eql_v3.date_ord_ore
+--! @param value eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.date_ord_ore, value eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.date_ord_ore.
+--! @param input eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.date_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.date_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_operators.sql
+--! @brief Operators for eql_v3.date_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/date/date_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.date_ord.
+
+--! @brief State function for min on eql_v3.date_ord.
+--! @param state eql_v3.date_ord
+--! @param value eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.date_ord, value eql_v3.date_ord)
+RETURNS eql_v3.date_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.date_ord.
+--! @param input eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.date_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.date_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.date_ord.
+--! @param state eql_v3.date_ord
+--! @param value eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.date_ord, value eql_v3.date_ord)
+RETURNS eql_v3.date_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.date_ord.
+--! @param input eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.date_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.date_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_operators.sql
+--! @brief Operators for eql_v3.int8.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_eq_functions.sql
+--! @brief Functions for eql_v3.int8_eq.
+
+--! @brief Index extractor for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.int8_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.int8_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int8_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.int8_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int8_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector text
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_eq, selector text)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector integer
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_eq, selector integer)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int8_eq
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_eq)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int8_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_ore_functions.sql
+--! @brief Functions for eql_v3.int8_ord_ore.
+
+--! @brief Index extractor for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int8_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector text
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord_ore, selector text)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector integer
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord_ore, selector integer)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_operators.sql
+--! @brief Operators for eql_v3.int8_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_ore_operators.sql
+--! @brief Operators for eql_v3.int8_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.int8_ord_ore.
+
+--! @brief State function for min on eql_v3.int8_ord_ore.
+--! @param state eql_v3.int8_ord_ore
+--! @param value eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int8_ord_ore, value eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int8_ord_ore.
+--! @param input eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.int8_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int8_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int8_ord_ore.
+--! @param state eql_v3.int8_ord_ore
+--! @param value eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int8_ord_ore, value eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int8_ord_ore.
+--! @param input eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.int8_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int8_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.int8_ord.
+
+--! @brief State function for min on eql_v3.int8_ord.
+--! @param state eql_v3.int8_ord
+--! @param value eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int8_ord, value eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int8_ord.
+--! @param input eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.int8_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int8_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int8_ord.
+--! @param state eql_v3.int8_ord
+--! @param value eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int8_ord, value eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int8_ord.
+--! @param input eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.int8_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int8_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/int8/int8_eq_operators.sql
+--! @brief Operators for eql_v3.int8_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_functions.sql
+--! @brief Functions for eql_v3.text.
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector text
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a eql_v3.text, selector text)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector integer
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a eql_v3.text, selector integer)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param selector eql_v3.text
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param selector eql_v3.text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text, b eql_v3.text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_match_operators.sql
+--! @brief Operators for eql_v3.text_match.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_eq_operators.sql
+--! @brief Operators for eql_v3.text_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.text_ord_ore.
+
+--! @brief State function for min on eql_v3.text_ord_ore.
+--! @param state eql_v3.text_ord_ore
+--! @param value eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.text_ord_ore, value eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.text_ord_ore.
+--! @param input eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.text_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.text_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.text_ord_ore.
+--! @param state eql_v3.text_ord_ore
+--! @param value eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.text_ord_ore, value eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.text_ord_ore.
+--! @param input eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.text_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.text_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.text_ord.
+
+--! @brief State function for min on eql_v3.text_ord.
+--! @param state eql_v3.text_ord
+--! @param value eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.text_ord, value eql_v3.text_ord)
+RETURNS eql_v3.text_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.text_ord.
+--! @param input eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.text_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.text_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.text_ord.
+--! @param state eql_v3.text_ord
+--! @param value eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.text_ord, value eql_v3.text_ord)
+RETURNS eql_v3.text_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.text_ord.
+--! @param input eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.text_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.text_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/text/text_operators.sql
+--! @brief Operators for eql_v3.text.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+--! @file v3/sem/ore_block_u64_8_256/operator_class.sql
+--! @brief B-tree operator family + default class on eql_v3.ore_block_u64_8_256.
+--!
+--! Gives the composite type its DEFAULT btree opclass so the recommended
+--! functional index `CREATE INDEX ON t (eql_v3.ord_term(col))` engages without
+--! an explicit opclass annotation (design D4). Excluded from the Supabase build
+--! variant by the `**/*operator_class.sql` glob.
+
+--! @brief B-tree operator family for ORE block types
+CREATE OPERATOR FAMILY eql_v3.ore_block_u64_8_256_operator_family USING btree;
+
+--! @brief B-tree operator class for ORE block encrypted values
+--!
+--! Supports operators: <, <=, =, >=, >. Uses comparison function
+--! compare_ore_block_u64_8_256_terms.
+CREATE OPERATOR CLASS eql_v3.ore_block_u64_8_256_operator_class DEFAULT FOR TYPE eql_v3.ore_block_u64_8_256 USING btree FAMILY eql_v3.ore_block_u64_8_256_operator_family  AS
+        OPERATOR 1 <,
+        OPERATOR 2 <=,
+        OPERATOR 3 =,
+        OPERATOR 4 >=,
+        OPERATOR 5 >,
+        FUNCTION 1 eql_v3.compare_ore_block_u64_8_256_terms(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256);

--- a/packages/drizzle/__tests__/fixtures/eql-v3-seed-data.ts
+++ b/packages/drizzle/__tests__/fixtures/eql-v3-seed-data.ts
@@ -1,0 +1,28 @@
+export type V3SeedRow = { label: string }
+
+/** Lexicographic spread for ord; shared-trigram pair (aardvark/aard) for match. */
+export const v3SeedData: V3SeedRow[] = [
+  { label: 'aardvark' },
+  { label: 'aard' },
+  { label: 'banana' },
+  { label: 'cherry' },
+  { label: 'date' },
+]
+
+export function oracleEq(target: string): V3SeedRow[] {
+  return v3SeedData.filter((r) => r.label === target)
+}
+export function oracleNe(target: string): V3SeedRow[] {
+  return v3SeedData.filter((r) => r.label !== target)
+}
+export function oracleContains(sub: string): V3SeedRow[] {
+  return v3SeedData.filter((r) => r.label.includes(sub))
+}
+export function oracleLt(target: string): V3SeedRow[] {
+  return v3SeedData.filter((r) => r.label < target)
+}
+export function oracleAscLabels(): string[] {
+  return [...v3SeedData]
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .map((r) => r.label)
+}

--- a/packages/drizzle/__tests__/test-utils.ts
+++ b/packages/drizzle/__tests__/test-utils.ts
@@ -2,6 +2,13 @@ import { createProtectOperators } from '@cipherstash/drizzle/pg'
 import type { ProtectClient } from '@cipherstash/protect/client'
 import { PgDialect } from 'drizzle-orm/pg-core'
 import { vi } from 'vitest'
+// NOTE: import from SOURCE, not the built @cipherstash/drizzle/pg — the v3 builder
+// (eqlV3Type) registers config in the SOURCE module-instance columnConfigMap, and the
+// SOURCE createProtectOperators is the one that accepts the dialect param. Keeping the
+// v3 path on the source tree avoids module-identity mismatches (a different
+// columnConfigMap, or a stale single-arg createProtectOperators in the built output).
+import { createProtectOperators as createProtectOperatorsSrc } from '../src/pg/operators'
+import { v3Dialect } from '../src/pg/sql-dialect'
 
 export const ENCRYPTED_VALUE = '{"v":"encrypted-value"}'
 
@@ -22,6 +29,13 @@ export function createMockProtectClient() {
 export function setup() {
   const { client, encryptQuery } = createMockProtectClient()
   const protectOps = createProtectOperators(client)
+  const dialect = new PgDialect()
+  return { client, encryptQuery, protectOps, dialect }
+}
+
+export function setupV3() {
+  const { client, encryptQuery } = createMockProtectClient()
+  const protectOps = createProtectOperatorsSrc(client, v3Dialect)
   const dialect = new PgDialect()
   return { client, encryptQuery, protectOps, dialect }
 }

--- a/packages/drizzle/__tests__/v3/codec.test.ts
+++ b/packages/drizzle/__tests__/v3/codec.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { v3FromDriver, v3ToDriver } from '../../src/pg/v3/codec'
+
+describe('v3 plain-jsonb codec', () => {
+  it('toDriver serialises the payload as plain JSON (no composite wrapper)', () => {
+    const payload = {
+      v: '2',
+      i: { t: 'users', c: 't_eq' },
+      c: 'ct',
+      hm: 'hmac',
+    }
+    const wire = v3ToDriver(payload)
+    expect(wire).toBe(JSON.stringify(payload))
+    // not v2's ("…") composite (typeof guard: v3ToDriver returns string | null)
+    expect(typeof wire === 'string' && wire.startsWith('(')).toBe(false)
+  })
+
+  it('fromDriver round-trips a plain-jsonb object', () => {
+    const payload = {
+      v: '2',
+      i: { t: 'users', c: 't_eq' },
+      c: 'ct',
+      hm: 'hmac',
+    }
+    expect(v3FromDriver(JSON.stringify(payload))).toEqual(payload)
+  })
+
+  it('fromDriver accepts an already-parsed object (postgres jsonb auto-parse)', () => {
+    const payload = { v: '2', c: 'ct' }
+    // No cast needed now: v3FromDriver's param is string | object | null.
+    expect(v3FromDriver(payload)).toEqual(payload)
+  })
+
+  it('fromDriver maps NULL to null', () => {
+    expect(v3FromDriver(null)).toBeNull()
+  })
+
+  it('fromDriver maps undefined (absent column) to undefined', () => {
+    expect(v3FromDriver(undefined)).toBeUndefined()
+  })
+
+  it('fromDriver throws on malformed jsonb (surfaces the parse error)', () => {
+    expect(() => v3FromDriver('{not valid json')).toThrow()
+  })
+
+  it('toDriver maps null/undefined to SQL NULL (JS null), not the JSONB null literal', () => {
+    // Returning 'null' would bind JSONB null and fail the v3 domain CHECK
+    // (jsonb_typeof = 'object'); JS null binds SQL NULL, which the domain accepts.
+    expect(v3ToDriver(null)).toBeNull()
+    expect(v3ToDriver(undefined)).toBeNull()
+  })
+})

--- a/packages/drizzle/__tests__/v3/detection.test.ts
+++ b/packages/drizzle/__tests__/v3/detection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isEncryptedSqlName } from '../../src/pg/index'
+
+describe('isEncryptedSqlName', () => {
+  it('recognises the v2 composite type', () => {
+    expect(isEncryptedSqlName('eql_v2_encrypted')).toBe(true)
+  })
+
+  it('recognises every v3 capability + storage domain', () => {
+    expect(isEncryptedSqlName('eql_v3.text')).toBe(true)
+    expect(isEncryptedSqlName('eql_v3.text_eq')).toBe(true)
+    expect(isEncryptedSqlName('eql_v3.text_match')).toBe(true)
+    expect(isEncryptedSqlName('eql_v3.text_ord')).toBe(true)
+  })
+
+  it('rejects unrelated sql names', () => {
+    expect(isEncryptedSqlName('text')).toBe(false)
+    expect(isEncryptedSqlName('jsonb')).toBe(false)
+    expect(isEncryptedSqlName(undefined)).toBe(false)
+  })
+})

--- a/packages/drizzle/__tests__/v3/dialect.test.ts
+++ b/packages/drizzle/__tests__/v3/dialect.test.ts
@@ -1,0 +1,89 @@
+import { sql } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import { v2Dialect, v3Dialect } from '../../src/pg/sql-dialect'
+
+const render = (s: ReturnType<typeof sql>) => new PgDialect().sqlToQuery(s).sql
+
+describe('v2Dialect', () => {
+  it('comparison(gt) emits eql_v2.gt(...)', () => {
+    const out = v2Dialect.comparison('gt', sql`"col"`, sql`'enc'`)
+    expect(render(out)).toContain('eql_v2.gt(')
+  })
+
+  it('range emits eql_v2.gte AND eql_v2.lte', () => {
+    const out = v2Dialect.range(sql`"col"`, sql`'lo'`, sql`'hi'`)
+    const rendered = render(out)
+    expect(rendered).toContain('eql_v2.gte(')
+    expect(rendered).toContain('eql_v2.lte(')
+  })
+
+  it('match(like) emits eql_v2.like(...)', () => {
+    const out = v2Dialect.match('like', sql`"col"`, sql`'enc'`)
+    expect(render(out)).toContain('eql_v2.like(')
+  })
+
+  it('orderBy emits eql_v2.order_by(...)', () => {
+    const out = v2Dialect.orderBy(sql`"col"`)
+    expect(render(out)).toContain('eql_v2.order_by(')
+  })
+})
+
+describe('v3Dialect', () => {
+  // Reconciled against the real eql_v3 SQL (EQL 035952e): v3 compares EXTRACTED
+  // index terms — eq_term/ord_term/match_term on the column, and the jsonb helper
+  // extractors hmac_256/ore_block_u64_8_256/bloom_filter on the search term — so the
+  // search term is never coerced into a domain whose CHECK requires ciphertext.
+  it('equality(eq) compares eq_term to hmac_256 of the jsonb term', () => {
+    const rendered = render(v3Dialect.equality('eq', sql`"col"`, sql`'enc'`))
+    expect(rendered).toContain('eql_v3.eq_term(')
+    expect(rendered).toContain('=')
+    expect(rendered).toContain('eql_v3.hmac_256(')
+    expect(rendered).toContain('::jsonb')
+  })
+
+  it('equality(ne) emits <> between eq_term and hmac_256', () => {
+    const rendered = render(v3Dialect.equality('ne', sql`"col"`, sql`'enc'`))
+    expect(rendered).toContain('eql_v3.eq_term(')
+    expect(rendered).toContain('<>')
+    expect(rendered).toContain('eql_v3.hmac_256(')
+  })
+
+  // All four comparison ops, not just lt: guards ORD_SYMBOL against a copy-paste
+  // (e.g. gte→'>'). The exact symbol must sit between the two extractor calls —
+  // `) <sym> eql_v3.ore_block_u64_8_256(` — which disambiguates `>` from `>=`.
+  it.each([
+    ['gt', '>'],
+    ['gte', '>='],
+    ['lt', '<'],
+    ['lte', '<='],
+  ] as const)(
+    'comparison(%s) emits ord_term %s ore_block_u64_8_256 of the term',
+    (op, symbol) => {
+      const rendered = render(v3Dialect.comparison(op, sql`"col"`, sql`'enc'`))
+      expect(rendered).toContain('eql_v3.ord_term(')
+      expect(rendered).toContain('eql_v3.ore_block_u64_8_256(')
+      expect(rendered).toContain(`) ${symbol} eql_v3.ore_block_u64_8_256(`)
+      expect(rendered).not.toContain('eql_v3.lt(')
+    },
+  )
+
+  it('range emits ord_term >= … AND ord_term <= … over ore blocks', () => {
+    const rendered = render(v3Dialect.range(sql`"col"`, sql`'lo'`, sql`'hi'`))
+    expect(rendered).toContain('eql_v3.ord_term(')
+    expect(rendered).toContain('>=')
+    expect(rendered).toContain('<=')
+    expect(rendered).toContain('eql_v3.ore_block_u64_8_256(')
+  })
+
+  it('match emits match_term @> bloom_filter of the jsonb term', () => {
+    const rendered = render(v3Dialect.match('like', sql`"col"`, sql`'enc'`))
+    expect(rendered).toContain('eql_v3.match_term(')
+    expect(rendered).toContain('@>')
+    expect(rendered).toContain('eql_v3.bloom_filter(')
+  })
+
+  it('orderBy emits eql_v3.ord_term(...)', () => {
+    expect(render(v3Dialect.orderBy(sql`"col"`))).toContain('eql_v3.ord_term(')
+  })
+})

--- a/packages/drizzle/__tests__/v3/domain-map.test.ts
+++ b/packages/drizzle/__tests__/v3/domain-map.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { type V3Index, eqlV3Domain, v3CastAs } from '../../src/pg/v3/domain-map'
+
+describe('eqlV3Domain', () => {
+  it('maps text + each index to its capability domain', () => {
+    expect(eqlV3Domain('text', undefined)).toBe('eql_v3.text')
+    expect(eqlV3Domain('text', 'equality')).toBe('eql_v3.text_eq')
+    expect(eqlV3Domain('text', 'freeTextSearch')).toBe('eql_v3.text_match')
+    expect(eqlV3Domain('text', 'orderAndRange')).toBe('eql_v3.text_ord')
+  })
+
+  it('rejects out-of-scope dataTypes loudly', () => {
+    // @ts-expect-error 'number' is not a v3 scalar in this milestone
+    expect(() => eqlV3Domain('number', 'equality')).toThrow(
+      /unsupported.*dataType.*number/i,
+    )
+    // @ts-expect-error 'boolean' has no v3 domain
+    expect(() => eqlV3Domain('boolean', 'equality')).toThrow(/unsupported/i)
+    // @ts-expect-error searchableJson is not a v3 index in this milestone
+    expect(() => eqlV3Domain('text', 'searchableJson')).toThrow(/unsupported/i)
+  })
+
+  it('translates the text scalar to its internal CastAs', () => {
+    expect(v3CastAs('text')).toBe('string')
+  })
+})

--- a/packages/drizzle/__tests__/v3/eql-v3-type.test.ts
+++ b/packages/drizzle/__tests__/v3/eql-v3-type.test.ts
@@ -1,0 +1,77 @@
+import { pgTable } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import { getEncryptedColumnConfig } from '../../src/pg/index'
+import { eqlV3Type } from '../../src/pg/v3/eql-v3-type'
+
+describe('eqlV3Type', () => {
+  it('dataType() returns the capability domain for each index', () => {
+    const storage = eqlV3Type<string>('t_storage', { dataType: 'text' })
+    const eqCol = eqlV3Type<string>('t_eq', {
+      dataType: 'text',
+      index: 'equality',
+    })
+    const matchCol = eqlV3Type<string>('t_match', {
+      dataType: 'text',
+      index: 'freeTextSearch',
+    })
+    const ordCol = eqlV3Type<string>('t_ord', {
+      dataType: 'text',
+      index: 'orderAndRange',
+    })
+
+    // The customType dataType() callback lives at config.customTypeParams on the
+    // raw Drizzle column builder (before pgTable); getSQLType() exposes the same
+    // value post-pgTable. Reading the internal path keeps the four-builder shape.
+    // biome-ignore lint/suspicious/noExplicitAny: reading Drizzle internals in test
+    expect((storage as any).config.customTypeParams.dataType()).toBe(
+      'eql_v3.text',
+    )
+    // biome-ignore lint/suspicious/noExplicitAny: reading Drizzle internals in test
+    expect((eqCol as any).config.customTypeParams.dataType()).toBe(
+      'eql_v3.text_eq',
+    )
+    // biome-ignore lint/suspicious/noExplicitAny: reading Drizzle internals in test
+    expect((matchCol as any).config.customTypeParams.dataType()).toBe(
+      'eql_v3.text_match',
+    )
+    // biome-ignore lint/suspicious/noExplicitAny: reading Drizzle internals in test
+    expect((ordCol as any).config.customTypeParams.dataType()).toBe(
+      'eql_v3.text_ord',
+    )
+  })
+
+  it('registers an EncryptedColumnConfig discoverable by extraction', () => {
+    const table = pgTable('v3_users', {
+      t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+    })
+    const config = getEncryptedColumnConfig('t_eq', table.t_eq)
+    expect(config).toBeDefined()
+    // text → equality index flag set; internal CastAs is 'string'
+    expect(config?.equality).toBe(true)
+    expect(config?.dataType).toBe('string')
+  })
+
+  it('maps freeTextSearch index to the freeTextSearch config flag', () => {
+    const table = pgTable('v3_b', {
+      t_match: eqlV3Type<string>('t_match', {
+        dataType: 'text',
+        index: 'freeTextSearch',
+      }),
+    })
+    expect(
+      getEncryptedColumnConfig('t_match', table.t_match)?.freeTextSearch,
+    ).toBe(true)
+  })
+
+  it('maps orderAndRange index to the orderAndRange config flag', () => {
+    const table = pgTable('v3_c', {
+      t_ord: eqlV3Type<string>('t_ord', {
+        dataType: 'text',
+        index: 'orderAndRange',
+      }),
+    })
+    expect(getEncryptedColumnConfig('t_ord', table.t_ord)?.orderAndRange).toBe(
+      true,
+    )
+  })
+})

--- a/packages/drizzle/__tests__/v3/exports.test.ts
+++ b/packages/drizzle/__tests__/v3/exports.test.ts
@@ -1,0 +1,36 @@
+import { PgDialect, pgTable } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import * as v3 from '../../src/pg/v3/index'
+import { createMockProtectClient } from '../test-utils'
+
+describe('./pg/v3 export surface', () => {
+  it('exposes the v3 builder, dialect, and shared helpers', () => {
+    expect(typeof v3.eqlV3Type).toBe('function')
+    expect(typeof v3.createProtectOperators).toBe('function')
+    expect(typeof v3.createProtectOperatorsV3).toBe('function')
+    expect(typeof v3.extractProtectSchema).toBe('function')
+    expect(v3.v3Dialect).toBeDefined()
+  })
+
+  // On the v3 subpath, BOTH the bare `createProtectOperators` and the explicit
+  // `createProtectOperatorsV3` alias must be v3-bound — the v2-defaulted factory must
+  // not be reachable here, or a v3 consumer would silently emit failing v2 SQL.
+  it.each(['createProtectOperators', 'createProtectOperatorsV3'] as const)(
+    '%s on the v3 subpath pre-binds the v3 dialect (emits eq_term, not native =)',
+    async (factory) => {
+      const table = pgTable(`v3_wrap_${factory}`, {
+        t_eq: v3.eqlV3Type<string>('t_eq', {
+          dataType: 'text',
+          index: 'equality',
+        }),
+      })
+      const { client } = createMockProtectClient()
+      const ops = v3[factory](client)
+      const query = new PgDialect().sqlToQuery(
+        await ops.eq(table.t_eq, 'alice'),
+      )
+      expect(query.sql).toContain('eql_v3.eq_term(')
+      expect(query.sql).not.toContain('"t_eq" = $')
+    },
+  )
+})

--- a/packages/drizzle/__tests__/v3/extraction.test.ts
+++ b/packages/drizzle/__tests__/v3/extraction.test.ts
@@ -1,0 +1,58 @@
+import { pgTable } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import {
+  extractProtectSchema,
+  getEncryptedColumnConfig,
+} from '../../src/pg/index'
+import { eqlV3Type } from '../../src/pg/v3/eql-v3-type'
+
+describe('extractProtectSchema with v3 columns', () => {
+  it('does not throw "No encrypted columns found" for a v3-only table', () => {
+    const table = pgTable('v3_only', {
+      t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+      t_ord: eqlV3Type<string>('t_ord', {
+        dataType: 'text',
+        index: 'orderAndRange',
+      }),
+    })
+    expect(() => extractProtectSchema(table)).not.toThrow()
+  })
+
+  it('builds a ProtectTable whose t_eq column carries the equality index + string cast', () => {
+    const table = pgTable('v3_only2', {
+      t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+    })
+    const schema = extractProtectSchema(table)
+    const built = schema.build()
+    // Structural check, not a substring of the serialized blob: the built table
+    // actually contains the t_eq column, cast as 'string', with the equality
+    // (unique) index enabled — equality() sets indexes.unique (schema/src/index.ts:198).
+    expect(built.columns).toHaveProperty('t_eq')
+    expect(built.columns.t_eq.cast_as).toBe('string')
+    expect(built.columns.t_eq.indexes.unique).toBeDefined()
+  })
+
+  // The column config map is the only source once pgTable strips _protectConfig.
+  // It's anchored on a global-registry Symbol so the ./pg and ./pg/v3 CJS bundles
+  // (built without code splitting) share ONE map instead of registering into
+  // separate private copies — otherwise mixed-import CJS consumers would see no
+  // encrypted columns.
+  it('registers v3 column config on the shared global map (cross-bundle safe)', () => {
+    const table = pgTable('v3_shared', {
+      t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+    })
+    const mapKey = Symbol.for('@cipherstash/drizzle/pg:columnConfigMap')
+    const sharedMap = (globalThis as Record<symbol, unknown>)[mapKey] as Map<
+      string,
+      { name: string }
+    >
+    expect(sharedMap).toBeInstanceOf(Map)
+    expect(sharedMap.get('t_eq')?.name).toBe('t_eq')
+
+    // Simulate pgTable having stripped _protectConfig: resolution must still
+    // succeed via the shared map, not the per-column property.
+    const column = table.t_eq as unknown as { _protectConfig?: unknown }
+    column._protectConfig = undefined
+    expect(getEncryptedColumnConfig('t_eq', table.t_eq)?.name).toBe('t_eq')
+  })
+})

--- a/packages/drizzle/__tests__/v3/extraction.test.ts
+++ b/packages/drizzle/__tests__/v3/extraction.test.ts
@@ -38,21 +38,31 @@ describe('extractProtectSchema with v3 columns', () => {
   // separate private copies — otherwise mixed-import CJS consumers would see no
   // encrypted columns.
   it('registers v3 column config on the shared global map (cross-bundle safe)', () => {
-    const table = pgTable('v3_shared', {
-      t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
-    })
     const mapKey = Symbol.for('@cipherstash/drizzle/pg:columnConfigMap')
     const sharedMap = (globalThis as Record<symbol, unknown>)[mapKey] as Map<
       string,
       { name: string }
     >
+    // Use a column name unique to this test so the global, name-keyed registry
+    // can't yield a false positive from another test's prior registration.
+    sharedMap.delete('v3_shared_t_eq')
+    const table = pgTable('v3_shared', {
+      v3_shared_t_eq: eqlV3Type<string>('v3_shared_t_eq', {
+        dataType: 'text',
+        index: 'equality',
+      }),
+    })
     expect(sharedMap).toBeInstanceOf(Map)
-    expect(sharedMap.get('t_eq')?.name).toBe('t_eq')
+    expect(sharedMap.get('v3_shared_t_eq')?.name).toBe('v3_shared_t_eq')
 
     // Simulate pgTable having stripped _protectConfig: resolution must still
     // succeed via the shared map, not the per-column property.
-    const column = table.t_eq as unknown as { _protectConfig?: unknown }
+    const column = table.v3_shared_t_eq as unknown as {
+      _protectConfig?: unknown
+    }
     column._protectConfig = undefined
-    expect(getEncryptedColumnConfig('t_eq', table.t_eq)?.name).toBe('t_eq')
+    expect(
+      getEncryptedColumnConfig('v3_shared_t_eq', table.v3_shared_t_eq)?.name,
+    ).toBe('v3_shared_t_eq')
   })
 })

--- a/packages/drizzle/__tests__/v3/helpers/install-v3.ts
+++ b/packages/drizzle/__tests__/v3/helpers/install-v3.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type postgres from 'postgres'
+
+const SQL_PATH = fileURLToPath(
+  new URL('../../fixtures/cipherstash-encrypt-v3.sql', import.meta.url),
+)
+
+/**
+ * Installs the v3 SQL. Multi-statement DDL requires sql.unsafe (tagged-template
+ * sql`` runs a single statement).
+ *
+ * Idempotency is GUARDED, not via CREATE OR REPLACE: the EQL v3 SQL hardcodes the
+ * `eql_v3` schema and its `CREATE DOMAIN`/`CREATE OPERATOR` have no OR REPLACE, so a
+ * blind re-install errors on the second run. We therefore probe for `eql_v3.text_eq`
+ * and skip the install if it already exists.
+ *
+ * The probe-then-install runs inside ONE transaction holding a transaction-scoped
+ * advisory lock, so it is also concurrency-safe: the `eql_v3` schema is global and
+ * shared across the protect/stack/drizzle suites Turbo runs, and without the lock
+ * two suites could both pass the probe before either installs, then race on
+ * `CREATE DOMAIN` (which has no OR REPLACE). A `pg_advisory_xact_lock` serialises
+ * that window — the first holder installs, the rest see `text_eq` present and
+ * no-op (§9b). It MUST be a transaction (not a bare session lock): `sql` is a
+ * connection pool, so a session lock and its unlock could land on different pooled
+ * connections (and would not survive PgBouncer transaction mode). A single
+ * `sql.begin` keeps the lock, probe, and install on one connection and auto-releases
+ * the lock at commit.
+ */
+const INSTALL_LOCK_KEY = 'eql_v3_install'
+
+export async function installEqlV3(sql: postgres.Sql): Promise<void> {
+  const ddl = readFileSync(SQL_PATH, 'utf-8')
+  await sql.begin(async (tx) => {
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${INSTALL_LOCK_KEY}))`
+    const [present] = await tx`
+      SELECT 1 FROM pg_type t
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'eql_v3' AND t.typname = 'text_eq'
+    `
+    if (present) return // already installed by an earlier run / sibling suite
+    await tx.unsafe(ddl)
+  })
+}

--- a/packages/drizzle/__tests__/v3/operators-v3.test.ts
+++ b/packages/drizzle/__tests__/v3/operators-v3.test.ts
@@ -1,0 +1,185 @@
+import { and } from 'drizzle-orm'
+import { integer, pgTable, text } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import { eqlV3Type } from '../../src/pg/v3/eql-v3-type'
+import { setupV3 } from '../test-utils'
+
+const table = pgTable('v3_ops', {
+  t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+  t_ord: eqlV3Type<string>('t_ord', {
+    dataType: 'text',
+    index: 'orderAndRange',
+  }),
+  t_match: eqlV3Type<string>('t_match', {
+    dataType: 'text',
+    index: 'freeTextSearch',
+  }),
+})
+
+// Plain (non-encrypted) columns — exercise the native fallback branches.
+const plainTable = pgTable('plain_ops', {
+  age: integer('age'),
+  name: text('name'),
+})
+
+describe('v3 operators encrypt params (not plaintext)', () => {
+  it('eq on text_eq compares eq_term to hmac_256 with an encrypted param', async () => {
+    const { protectOps, dialect, encryptQuery } = setupV3()
+    const condition = await protectOps.eq(table.t_eq, 'alice')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('eql_v3.eq_term(')
+    expect(query.sql).toContain('eql_v3.hmac_256(')
+    expect(query.params[0]).toContain('encrypted-value')
+    expect(encryptQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('lt on text_ord compares ord_term to ore_block with an encrypted param', async () => {
+    const { protectOps, dialect } = setupV3()
+    const condition = await protectOps.lt(table.t_ord, 'm')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('eql_v3.ord_term(')
+    expect(query.sql).toContain('<')
+    expect(query.sql).toContain('eql_v3.ore_block_u64_8_256(')
+    expect(query.params[0]).toContain('encrypted-value')
+  })
+
+  it('ilike on text_match emits match_term @> bloom_filter with an encrypted param', async () => {
+    const { protectOps, dialect } = setupV3()
+    const condition = await protectOps.ilike(table.t_match, 'aard')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('eql_v3.match_term(')
+    expect(query.sql).toContain('@>')
+    expect(query.sql).toContain('eql_v3.bloom_filter(')
+    expect(query.params[0]).toContain('encrypted-value')
+  })
+
+  // All four ordering ops at the operator level (not just lt): confirms each routes
+  // through dialect.comparison with the right symbol and an encrypted param.
+  it.each([
+    ['gt', '>'],
+    ['gte', '>='],
+    ['lt', '<'],
+    ['lte', '<='],
+  ] as const)(
+    '%s on text_ord emits ord_term %s ore_block with an encrypted param',
+    async (op, symbol) => {
+      const { protectOps, dialect } = setupV3()
+      const condition = await protectOps[op](table.t_ord, 'm')
+      const query = dialect.sqlToQuery(condition)
+      expect(query.sql).toContain('eql_v3.ord_term(')
+      expect(query.sql).toContain(`) ${symbol} eql_v3.ore_block_u64_8_256(`)
+      expect(query.params[0]).toContain('encrypted-value')
+    },
+  )
+
+  it('between on text_ord emits ord_term >= … AND ord_term <= … with two encrypted params', async () => {
+    const { protectOps, dialect } = setupV3()
+    const condition = await protectOps.between(table.t_ord, 'a', 'z')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('eql_v3.ord_term(')
+    expect(query.sql).toContain('>=')
+    expect(query.sql).toContain('<=')
+    expect(query.sql).toContain('eql_v3.ore_block_u64_8_256(')
+    expect(query.sql).not.toContain('NOT (')
+    expect(query.params).toHaveLength(2)
+    expect(query.params[0]).toContain('encrypted-value')
+    expect(query.params[1]).toContain('encrypted-value')
+  })
+
+  it('notBetween on text_ord wraps the range in NOT (...) with two encrypted params', async () => {
+    const { protectOps, dialect } = setupV3()
+    const condition = await protectOps.notBetween(table.t_ord, 'a', 'z')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('NOT (')
+    expect(query.sql).toContain('eql_v3.ord_term(')
+    expect(query.sql).toContain('eql_v3.ore_block_u64_8_256(')
+    expect(query.params).toHaveLength(2)
+  })
+})
+
+describe('v3 set membership routes through the dialect seam', () => {
+  it('inArray on text_eq emits eq_term/hmac_256 per value (not native =), OR-combined', async () => {
+    const { protectOps, dialect, encryptQuery } = setupV3()
+    const condition = await protectOps.inArray(table.t_eq, ['alice', 'bob'])
+    const query = dialect.sqlToQuery(condition)
+    // Must go through the v3 seam, not Drizzle's bare `eq` (native `=`), which would
+    // coerce the term into text_eq and fail the domain CHECK (SQLSTATE 23514).
+    expect(query.sql).toContain('eql_v3.eq_term(')
+    expect(query.sql).toContain('eql_v3.hmac_256(')
+    expect(query.sql.toLowerCase()).toContain(' or ')
+    expect(query.params).toHaveLength(2)
+    expect(query.params[0]).toContain('encrypted-value')
+    expect(query.params[1]).toContain('encrypted-value')
+    expect(encryptQuery).toHaveBeenCalledTimes(1) // single batch
+  })
+
+  it('notInArray on text_eq emits eq_term <> hmac_256 per value, AND-combined', async () => {
+    const { protectOps, dialect } = setupV3()
+    const condition = await protectOps.notInArray(table.t_eq, ['alice', 'bob'])
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('eql_v3.eq_term(')
+    expect(query.sql).toContain('eql_v3.hmac_256(')
+    expect(query.sql).toContain('<>')
+    expect(query.sql.toLowerCase()).toContain(' and ')
+    expect(query.params).toHaveLength(2)
+  })
+})
+
+describe('v3 ordering helpers route through the dialect seam', () => {
+  it.each(['asc', 'desc'] as const)(
+    '%s on text_ord sorts by ord_term(column)',
+    (dir) => {
+      const { protectOps, dialect } = setupV3()
+      const condition = protectOps[dir](table.t_ord)
+      const query = dialect.sqlToQuery(condition)
+      expect(query.sql).toContain('eql_v3.ord_term(')
+      expect(query.sql.toLowerCase()).toContain(dir)
+    },
+  )
+})
+
+describe('v3 lazy operators combine under and()', () => {
+  it('and(eq, lt) emits both eq_term and ord_term with one param each', async () => {
+    const { protectOps, dialect } = setupV3()
+    const [eqCond, ltCond] = await Promise.all([
+      protectOps.eq(table.t_eq, 'alice'),
+      protectOps.lt(table.t_ord, 'm'),
+    ])
+    const combined = and(eqCond, ltCond)
+    if (!combined) throw new Error('expected a combined condition')
+    const query = dialect.sqlToQuery(combined)
+    expect(query.sql).toContain('eql_v3.eq_term(')
+    expect(query.sql).toContain('eql_v3.ord_term(')
+    expect(query.sql.toLowerCase()).toContain(' and ')
+    expect(query.params).toHaveLength(2)
+  })
+})
+
+describe('v3 dialect leaves non-encrypted columns on the native path', () => {
+  it('gt on a plain column emits native > and does not encrypt', async () => {
+    const { protectOps, dialect, encryptQuery } = setupV3()
+    const condition = await protectOps.gt(plainTable.age, 5)
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('>')
+    expect(query.sql).not.toContain('eql_v3')
+    expect(encryptQuery).not.toHaveBeenCalled()
+  })
+
+  it('like on a plain column emits native like and does not encrypt', async () => {
+    const { protectOps, dialect, encryptQuery } = setupV3()
+    const condition = await protectOps.like(plainTable.name, 'a%')
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('like')
+    expect(query.sql).not.toContain('eql_v3')
+    expect(encryptQuery).not.toHaveBeenCalled()
+  })
+
+  it('between on a plain column emits native between and does not encrypt', async () => {
+    const { protectOps, dialect, encryptQuery } = setupV3()
+    const condition = await protectOps.between(plainTable.age, 1, 5)
+    const query = dialect.sqlToQuery(condition)
+    expect(query.sql).toContain('between')
+    expect(query.sql).not.toContain('eql_v3')
+    expect(encryptQuery).not.toHaveBeenCalled()
+  })
+})

--- a/packages/drizzle/__tests__/v3/provisioning.test.ts
+++ b/packages/drizzle/__tests__/v3/provisioning.test.ts
@@ -1,0 +1,45 @@
+import 'dotenv/config'
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { installEqlV3 } from './helpers/install-v3'
+
+// DB-gated suite: without DATABASE_URL the whole describe is skipped (not failed),
+// so a bare `pnpm test` reports skips rather than a hard import-time throw.
+const HAS_DB = !!process.env.DATABASE_URL
+
+let sql: ReturnType<typeof postgres>
+
+beforeAll(async () => {
+  if (!HAS_DB) return
+  // { prepare: false } is required for the pooled CI DB (PgBouncer transaction
+  // mode) — mirrors packages/protect/__tests__/searchable-json-pg.test.ts:12.
+  sql = postgres(process.env.DATABASE_URL as string, { prepare: false })
+  await installEqlV3(sql)
+}, 120000)
+
+afterAll(async () => {
+  await sql?.end()
+})
+
+describe.skipIf(!HAS_DB)('v3 DB provisioning', () => {
+  it('installs the eql_v3 schema and its text_eq domain', async () => {
+    const rows = await sql`
+      SELECT 1 FROM pg_type t
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+      WHERE n.nspname = 'eql_v3' AND t.typname = 'text_eq'
+    `
+    expect(rows.length).toBe(1)
+  })
+
+  it('the v3 extractor functions were installed (eq_term, ord_term, match_term)', async () => {
+    const fns = await sql`
+      SELECT proname FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'eql_v3' AND p.proname IN ('eq_term','ord_term','match_term')
+    `
+    // >= 3, not == 3: each extractor is overloaded per scalar (text/int2/int4/int8/
+    // date/timestamptz/…), so there are many rows. At least one per name proves the
+    // DDL executed rather than silently no-op'ing.
+    expect(fns.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/packages/drizzle/__tests__/v3/provisioning.test.ts
+++ b/packages/drizzle/__tests__/v3/provisioning.test.ts
@@ -33,13 +33,14 @@ describe.skipIf(!HAS_DB)('v3 DB provisioning', () => {
 
   it('the v3 extractor functions were installed (eq_term, ord_term, match_term)', async () => {
     const fns = await sql`
-      SELECT proname FROM pg_proc p
+      SELECT DISTINCT proname FROM pg_proc p
       JOIN pg_namespace n ON n.oid = p.pronamespace
       WHERE n.nspname = 'eql_v3' AND p.proname IN ('eq_term','ord_term','match_term')
     `
-    // >= 3, not == 3: each extractor is overloaded per scalar (text/int2/int4/int8/
-    // date/timestamptz/…), so there are many rows. At least one per name proves the
-    // DDL executed rather than silently no-op'ing.
-    expect(fns.length).toBeGreaterThanOrEqual(3)
+    // Assert the exact set of distinct names: overloads-per-scalar mean a single
+    // name could otherwise satisfy a bare count, hiding a missing extractor.
+    expect(new Set(fns.map((r) => r.proname))).toEqual(
+      new Set(['eq_term', 'ord_term', 'match_term']),
+    )
   })
 })

--- a/packages/drizzle/__tests__/v3/roundtrip-eq.test.ts
+++ b/packages/drizzle/__tests__/v3/roundtrip-eq.test.ts
@@ -1,0 +1,73 @@
+import 'dotenv/config'
+import { protect } from '@cipherstash/protect'
+import { pgTable } from 'drizzle-orm/pg-core'
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  createProtectOperators,
+  eqlV3Type,
+  extractProtectSchema,
+} from '../../src/pg/v3/index'
+import { installEqlV3 } from './helpers/install-v3'
+
+// DB-gated suite: skipped (not failed) without DATABASE_URL — see provisioning.test.ts.
+const HAS_DB = !!process.env.DATABASE_URL
+
+const TABLE = `v3_eq_${Date.now()}`
+const table = pgTable(TABLE, {
+  t_eq: eqlV3Type<string>('t_eq', { dataType: 'text', index: 'equality' }),
+})
+const schema = extractProtectSchema(table)
+
+let sql: ReturnType<typeof postgres>
+let db: ReturnType<typeof drizzle>
+let protectClient: Awaited<ReturnType<typeof protect>>
+let ops: ReturnType<typeof createProtectOperators>
+
+beforeAll(async () => {
+  if (!HAS_DB) return
+  // { prepare: false } is required for the pooled CI DB (PgBouncer transaction
+  // mode) — mirrors packages/protect/__tests__/searchable-json-pg.test.ts:12.
+  sql = postgres(process.env.DATABASE_URL as string, { prepare: false })
+  await installEqlV3(sql)
+  await sql.unsafe(
+    `CREATE TABLE IF NOT EXISTS "${TABLE}" (t_eq eql_v3.text_eq)`,
+  )
+  db = drizzle({ client: sql })
+  protectClient = await protect({ schemas: [schema] })
+  ops = createProtectOperators(protectClient)
+}, 120000)
+
+afterAll(async () => {
+  await sql?.unsafe(`DROP TABLE IF EXISTS "${TABLE}"`)
+  await sql?.end()
+})
+
+describe.skipIf(!HAS_DB)('v3 text_eq round-trip', () => {
+  it('encrypts, inserts, queries with =, and decrypts back to plaintext', async () => {
+    const enc = unwrap(
+      await protectClient.bulkEncryptModels([{ t_eq: 'alice' }], schema),
+    )
+    await db.insert(table).values(enc[0] as never)
+
+    const rows = await db
+      .select()
+      .from(table)
+      .where(await ops.eq(table.t_eq, 'alice'))
+    expect(rows).toHaveLength(1)
+
+    const dec = unwrap(await protectClient.bulkDecryptModels(rows as never[]))
+    expect(dec[0].t_eq).toBe('alice')
+  })
+})
+
+// biome-ignore lint/suspicious/noExplicitAny: test unwrap
+function unwrap(r: any) {
+  if (r.failure) {
+    throw new Error(
+      `[protect] ${r.failure.message ?? JSON.stringify(r.failure)}`,
+    )
+  }
+  return r.data
+}

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -29,6 +29,11 @@
 			"types": "./dist/pg/index.d.ts",
 			"import": "./dist/pg/index.js",
 			"require": "./dist/pg/index.cjs"
+		},
+		"./pg/v3": {
+			"types": "./dist/pg/v3/index.d.ts",
+			"import": "./dist/pg/v3/index.js",
+			"require": "./dist/pg/v3/index.cjs"
 		}
 	},
 	"files": [

--- a/packages/drizzle/scripts/refresh-eql-v3-sql.md
+++ b/packages/drizzle/scripts/refresh-eql-v3-sql.md
@@ -1,0 +1,61 @@
+<!-- packages/drizzle/scripts/refresh-eql-v3-sql.md -->
+# Refreshing cipherstash-encrypt-v3.sql
+
+Source: cipherstash/encrypt-query-language @ `035952e13fafc87c8a3c89fc7a7ff5447597bdd4`
+(branch `dan/eql-types-crate`)
+
+The fixture `__tests__/fixtures/cipherstash-encrypt-v3.sql` is the self-contained
+`eql_v3` installer (zero non-comment `eql_v2` references). It defines the four
+`text` scalar domains the adapter targets — `eql_v3.text`, `eql_v3.text_eq`,
+`eql_v3.text_match`, `eql_v3.text_ord` — plus an additional ORE-variant domain
+`eql_v3.text_ord_ore` that the adapter does not target directly. The verification
+in step 4 counts only the four primary domains (the `_ord_ore` variant is excluded
+by the regex on purpose).
+
+## Steps
+
+1. Clone/checkout the EQL repo at the pinned commit above.
+2. Build the release artifacts:
+   ```sh
+   # sccache must be disabled when building inside a restricted sandbox:
+   RUSTC_WRAPPER="" CARGO_BUILD_RUSTC_WRAPPER="" mise run build
+   ```
+   This regenerates `release/cipherstash-encrypt-v3.sql`. The `text` scalar is a
+   hand-written non-integer scalar emitted by the Rust codegen toolchain, so a
+   rebuild is required after any EQL update that touches it.
+3. Copy the v3 artifact (NOT `cipherstash-encrypt.sql`, which is the v2 installer):
+   ```sh
+   cp <eql-repo>/release/cipherstash-encrypt-v3.sql \
+      packages/drizzle/__tests__/fixtures/cipherstash-encrypt-v3.sql
+   ```
+4. Verify:
+   ```sh
+   F=packages/drizzle/__tests__/fixtures/cipherstash-encrypt-v3.sql
+   grep -vE '^\s*--' $F | grep -c 'eql_v2'                         # expect 0
+   grep -cE 'CREATE DOMAIN eql_v3\.text(_eq|_match|_ord)?\b' $F    # expect 4
+   grep -cE 'eq_term|ord_term|match_term' $F                       # > 0
+   ```
+5. Update the commit SHA above and commit.
+
+## Operator forms (resolves spec §10 — reconciled against the fixture)
+
+The v3 domains DO expose native Postgres operators, but their `(domain, jsonb)`
+operator functions coerce the right operand into the domain (e.g.
+`eq_term(a) = eq_term(b::text_eq)`). Every domain CHECK requires ciphertext `c`,
+which a Protect SEARCH term lacks (`{i,v,hm}` / `…ob` / `…bf`), so the native
+form fails `*_check` (SQLSTATE 23514). `v3Dialect` therefore compares **extracted
+index terms** — column-side extractors take the column domain, jsonb-side helpers
+read the index field straight out of the search term with no coercion:
+
+- `text_eq`    — `eql_v3.eq_term(col) = eql_v3.hmac_256(term::jsonb)`
+- `text_ord`   — `eql_v3.ord_term(col) <sym> eql_v3.ore_block_u64_8_256(term::jsonb)`
+- `text_match` — `eql_v3.match_term(col) @> eql_v3.bloom_filter(term::jsonb)`
+
+Equality/inequality on `text_eq` go **through the dialect seam** too (the
+`dialect.equality` branch in `operators.ts`), not the native `eq()`/`ne()` path —
+native `=` would coerce the term into `text_eq` and fail the CHECK.
+
+> Confirmed: equality/inequality go through the dialect seam — plan Task 12
+> validated this against the fixture, superseding the earlier Task 6 draft that
+> kept `eq`/`ne` on the native path. See `text_eq`, `dialect.equality`, and the
+> native `eq()`/`ne()` fallback in `operators.ts`.

--- a/packages/drizzle/src/pg/index.ts
+++ b/packages/drizzle/src/pg/index.ts
@@ -1,5 +1,6 @@
 import type { CastAs, MatchIndexOpts, TokenFilter } from '@cipherstash/schema'
 import { customType } from 'drizzle-orm/pg-core'
+import { ALL_V3_DOMAINS } from './v3/domain-map.js'
 
 export type { CastAs, MatchIndexOpts, TokenFilter }
 
@@ -31,13 +32,44 @@ export type EncryptedColumnConfig = {
 }
 
 /**
- * Map to store configuration for encrypted columns
- * Keyed by column name (the name passed to encryptedType)
+ * Map to store configuration for encrypted columns, keyed by column name (the
+ * name passed to encryptedType / eqlV3Type).
+ *
+ * Anchored on a global-registry Symbol so every copy of this module shares ONE
+ * map. The CJS build emits separate bundles for ./pg and ./pg/v3 (no code
+ * splitting), so a CJS consumer importing eqlV3Type from ./pg/v3 but
+ * extractProtectSchema/operators from ./pg would otherwise register into one
+ * bundle's private map and read the other's — schema extraction would then find
+ * no encrypted columns and operators could emit unencrypted SQL.
  */
-const columnConfigMap = new Map<
-  string,
-  EncryptedColumnConfig & { name: string }
->()
+const COLUMN_CONFIG_MAP_KEY = Symbol.for(
+  '@cipherstash/drizzle/pg:columnConfigMap',
+)
+type ColumnConfigMap = Map<string, EncryptedColumnConfig & { name: string }>
+const globalStore = globalThis as unknown as {
+  [COLUMN_CONFIG_MAP_KEY]?: ColumnConfigMap
+}
+const columnConfigMap: ColumnConfigMap =
+  globalStore[COLUMN_CONFIG_MAP_KEY] ?? new Map()
+// Idempotent write-back: stores the new map on first load, no-ops thereafter.
+globalStore[COLUMN_CONFIG_MAP_KEY] = columnConfigMap
+
+/**
+ * Returns true if a Drizzle column's sql-name is an encrypted type we manage —
+ * either the v2 composite or a v3 domain. Shared by the builder and extraction.
+ * The v3 domain set is owned by domain-map.ts (no second hand-maintained list).
+ */
+export function isEncryptedSqlName(name: unknown): boolean {
+  if (typeof name !== 'string') return false
+  return name === 'eql_v2_encrypted' || ALL_V3_DOMAINS.has(name)
+}
+
+/** @internal Register a column config for later extraction lookup. */
+export function registerColumnConfig(
+  config: EncryptedColumnConfig & { name: string },
+): void {
+  columnConfigMap.set(config.name, config)
+}
 
 /**
  * Creates an encrypted column type for Drizzle ORM with configurable searchable encryption options.
@@ -168,11 +200,10 @@ export function getEncryptedColumnConfig(
     // Check if it's an encrypted column by checking sqlName or dataType
     // After pgTable processes it, sqlName will be 'eql_v2_encrypted'
     const isEncrypted =
-      columnAny.sqlName === 'eql_v2_encrypted' ||
-      columnAny.dataType === 'eql_v2_encrypted' ||
-      (columnAny.dataType &&
-        typeof columnAny.dataType === 'function' &&
-        columnAny.dataType() === 'eql_v2_encrypted')
+      isEncryptedSqlName(columnAny.sqlName) ||
+      isEncryptedSqlName(columnAny.dataType) ||
+      (typeof columnAny.dataType === 'function' &&
+        isEncryptedSqlName(columnAny.dataType()))
 
     if (isEncrypted) {
       // Try to get config from property (if still there)

--- a/packages/drizzle/src/pg/operators.ts
+++ b/packages/drizzle/src/pg/operators.ts
@@ -39,6 +39,13 @@ import type { PgTable } from 'drizzle-orm/pg-core'
 import type { EncryptedColumnConfig } from './index.js'
 import { getEncryptedColumnConfig } from './index.js'
 import { extractProtectSchema } from './schema-extraction.js'
+import {
+  type ComparisonOp,
+  type EqualityOp,
+  type MatchOp,
+  type SqlDialect,
+  v2Dialect,
+} from './sql-dialect.js'
 
 // ============================================================================
 // Type Definitions and Type Guards
@@ -661,6 +668,7 @@ function createComparisonOperator(
   protectClient: ProtectClient,
   defaultProtectTable: ProtectTable<ProtectTableColumn> | undefined,
   protectTableCache: Map<string, ProtectTable<ProtectTableColumn>>,
+  dialect: SqlDialect,
 ): Promise<SQL> | SQL {
   const { config } = columnInfo
 
@@ -694,7 +702,11 @@ function createComparisonOperator(
           },
         )
       }
-      return sql`eql_v2.${sql.raw(operator)}(${left}, ${bindIfParam(encrypted, left)})`
+      return dialect.comparison(
+        operator as ComparisonOp,
+        sql`${left}`,
+        sql`${bindIfParam(encrypted, left)}`,
+      )
     }
 
     return createLazyOperator(
@@ -728,7 +740,11 @@ function createComparisonOperator(
           },
         )
       }
-      return operator === 'eq' ? eq(left, encrypted) : ne(left, encrypted)
+      return dialect.equality(
+        operator as EqualityOp,
+        sql`${left}`,
+        sql`${bindIfParam(encrypted, left)}`,
+      )
     }
 
     return createLazyOperator(
@@ -763,6 +779,7 @@ function createRangeOperator(
   protectClient: ProtectClient,
   defaultProtectTable: ProtectTable<ProtectTableColumn> | undefined,
   protectTableCache: Map<string, ProtectTable<ProtectTableColumn>>,
+  dialect: SqlDialect,
 ): Promise<SQL> | SQL {
   const { config } = columnInfo
 
@@ -788,7 +805,11 @@ function createRangeOperator(
       )
     }
 
-    const rangeCondition = sql`eql_v2.gte(${left}, ${bindIfParam(encryptedMin, left)}) AND eql_v2.lte(${left}, ${bindIfParam(encryptedMax, left)})`
+    const rangeCondition = dialect.range(
+      sql`${left}`,
+      sql`${bindIfParam(encryptedMin, left)}`,
+      sql`${bindIfParam(encryptedMax, left)}`,
+    )
 
     return operator === 'between'
       ? rangeCondition
@@ -822,6 +843,7 @@ function createTextSearchOperator(
   protectClient: ProtectClient,
   defaultProtectTable: ProtectTable<ProtectTableColumn> | undefined,
   protectTableCache: Map<string, ProtectTable<ProtectTableColumn>>,
+  dialect: SqlDialect,
 ): Promise<SQL> | SQL {
   const { config } = columnInfo
 
@@ -850,7 +872,11 @@ function createTextSearchOperator(
       )
     }
 
-    const sqlFn = sql`eql_v2.${sql.raw(operator === 'notIlike' ? 'ilike' : operator)}(${left}, ${bindIfParam(encrypted, left)})`
+    const sqlFn = dialect.match(
+      (operator === 'notIlike' ? 'ilike' : operator) as MatchOp,
+      sql`${left}`,
+      sql`${bindIfParam(encrypted, left)}`,
+    )
     return operator === 'notIlike' ? sql`NOT (${sqlFn})` : sqlFn
   }
 
@@ -985,7 +1011,10 @@ function createJsonbOperator(
  *   .where(await protectOps.gte(usersTable.age, 25))
  * ```
  */
-export function createProtectOperators(protectClient: ProtectClient): {
+export function createProtectOperators(
+  protectClient: ProtectClient,
+  dialect: SqlDialect = v2Dialect,
+): {
   // Comparison operators
   /**
    * Equality operator - encrypts value for encrypted columns.
@@ -1228,6 +1257,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1248,6 +1278,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1268,6 +1299,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1288,6 +1320,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1308,6 +1341,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1328,6 +1362,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1353,6 +1388,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1378,6 +1414,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1401,6 +1438,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1424,6 +1462,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1447,6 +1486,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectClient,
       defaultProtectTable,
       protectTableCache,
+      dialect,
     )
   }
 
@@ -1559,10 +1599,19 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectTableCache,
     )
 
-    // Use regular eq for each encrypted value - PostgreSQL operators handle it
+    // Route each value through the dialect seam (not Drizzle's bare `eq`): under v3
+    // equality compares eql_v3.eq_term(col) to eql_v3.hmac_256(term), since a native
+    // `=` would coerce the term into text_eq and fail the domain CHECK (SQLSTATE
+    // 23514). v2Dialect emits the identical native `=`, so v2 is unaffected.
     const conditions = encryptedValues
       .filter((encrypted) => encrypted !== undefined)
-      .map((encrypted) => eq(left, encrypted))
+      .map((encrypted) =>
+        dialect.equality(
+          'eq',
+          sql`${left}`,
+          sql`${bindIfParam(encrypted, left)}`,
+        ),
+      )
 
     if (conditions.length === 0) {
       return sql`false`
@@ -1609,10 +1658,17 @@ export function createProtectOperators(protectClient: ProtectClient): {
       protectTableCache,
     )
 
-    // Use regular ne for each encrypted value - PostgreSQL operators handle it
+    // Route each value through the dialect seam (not Drizzle's bare `ne`) — same
+    // reason as protectInArray: v3 inequality is eql_v3.eq_term(col) <> hmac_256(term).
     const conditions = encryptedValues
       .filter((encrypted) => encrypted !== undefined)
-      .map((encrypted) => ne(left, encrypted))
+      .map((encrypted) =>
+        dialect.equality(
+          'ne',
+          sql`${left}`,
+          sql`${bindIfParam(encrypted, left)}`,
+        ),
+      )
 
     if (conditions.length === 0) {
       return sql`true`
@@ -1633,7 +1689,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
     )
 
     if (columnInfo.config?.orderAndRange) {
-      return asc(sql`eql_v2.order_by(${column})`)
+      return asc(dialect.orderBy(sql`${column}`))
     }
 
     return asc(column)
@@ -1650,7 +1706,7 @@ export function createProtectOperators(protectClient: ProtectClient): {
     )
 
     if (columnInfo.config?.orderAndRange) {
-      return desc(sql`eql_v2.order_by(${column})`)
+      return desc(dialect.orderBy(sql`${column}`))
     }
 
     return desc(column)

--- a/packages/drizzle/src/pg/sql-dialect.ts
+++ b/packages/drizzle/src/pg/sql-dialect.ts
@@ -1,0 +1,99 @@
+import { type SQL, sql } from 'drizzle-orm'
+
+export type EqualityOp = 'eq' | 'ne'
+export type ComparisonOp = 'gt' | 'gte' | 'lt' | 'lte'
+export type MatchOp = 'like' | 'ilike'
+
+/**
+ * The SQL-dialect seam (spec §5.2). The operator factories in operators.ts read
+ * their templates from here, so v2 and v3 share all lazy/batch plumbing and differ
+ * only in this object.
+ *
+ * `left` is the column SQL; `enc`/`min`/`max` are bound encrypted-param SQL
+ * fragments (already wrapped via bindIfParam by the caller).
+ *
+ * `equality` is in the seam (unlike the original plan, which kept eq/ne on the
+ * native Drizzle eq/ne path): v3's `text_eq` domain CHECK requires {v,i,c,hm}, but
+ * an equality SEARCH term carries only {i,v,hm} (no ciphertext). Letting Postgres
+ * coerce the param to `text_eq` therefore fails `text_eq_check` (SQLSTATE 23514).
+ * Casting the param to `jsonb` binds the `= (text_eq, jsonb)` operator (function
+ * eql_v3.eq) instead, which compares hmacs without coercing the param. Confirmed
+ * by the Task 12 round-trip.
+ */
+export type SqlDialect = {
+  equality(op: EqualityOp, left: SQL, enc: SQL): SQL
+  comparison(op: ComparisonOp, left: SQL, enc: SQL): SQL
+  range(left: SQL, min: SQL, max: SQL): SQL
+  match(op: MatchOp, left: SQL, enc: SQL): SQL
+  orderBy(column: SQL): SQL
+}
+
+export const v2Dialect: SqlDialect = {
+  equality(op, left, enc) {
+    return op === 'eq' ? sql`${left} = ${enc}` : sql`${left} <> ${enc}`
+  },
+  comparison(op, left, enc) {
+    return sql`eql_v2.${sql.raw(op)}(${left}, ${enc})`
+  },
+  range(left, min, max) {
+    return sql`eql_v2.gte(${left}, ${min}) AND eql_v2.lte(${left}, ${max})`
+  },
+  match(op, left, enc) {
+    return sql`eql_v2.${sql.raw(op)}(${left}, ${enc})`
+  },
+  orderBy(column) {
+    return sql`eql_v2.order_by(${column})`
+  },
+}
+
+const ORD_SYMBOL: Record<ComparisonOp, string> = {
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+}
+
+/**
+ * v3 emission (spec §5.2), reconciled against release/cipherstash-encrypt-v3.sql
+ * (EQL 035952e) in plan Task 12.
+ *
+ * v3 queries compare EXTRACTED INDEX TERMS, not the encrypted payloads directly.
+ * Why: the v3 domains (`text_eq`, `text_ord`, `text_match`) have CHECK constraints
+ * requiring a full payload `{v,i,c,…}` INCLUDING ciphertext `c`. A protect SEARCH
+ * term is index-only (`{i,v,hm}` / `…ob` / `…bf}`, no `c`), so casting it to the
+ * domain — which every native `(domain, jsonb)` operator function does internally
+ * (`eq_term(a) = eq_term(b::text_eq)`) — fails `*_check` (SQLSTATE 23514).
+ *
+ * Instead we extract on both sides and compare the index terms:
+ *   - column side: `eq_term`/`ord_term`/`match_term` take the column DOMAIN (the
+ *     stored value has `c`, so it passes the CHECK);
+ *   - search side: the jsonb helper extractors `hmac_256(jsonb)` /
+ *     `ore_block_u64_8_256(jsonb)` / `bloom_filter(jsonb)` pull the index field
+ *     straight out of the search-term jsonb with NO domain coercion (no CHECK).
+ * The extracted types carry the real comparison operators: hmac_256 `=`/`<>`,
+ * ore_block_u64_8_256 `<`/`<=`/`>`/`>=`, bloom_filter `@>` containment.
+ *
+ * This form is scalar-AGNOSTIC: the column-side extractors are overloaded per
+ * domain (Postgres resolves by the column's type) and the jsonb-side helpers are
+ * shared across scalars. So no scalar name is hardcoded here — adding scalar #2 is
+ * a domain-map row, not a new dialect (resolves the plan Task 7 limitation note).
+ */
+export const v3Dialect: SqlDialect = {
+  equality(op, left, enc) {
+    const cmp = op === 'eq' ? sql.raw('=') : sql.raw('<>')
+    return sql`eql_v3.eq_term(${left}) ${cmp} eql_v3.hmac_256(${enc}::jsonb)`
+  },
+  comparison(op, left, enc) {
+    return sql`eql_v3.ord_term(${left}) ${sql.raw(ORD_SYMBOL[op])} eql_v3.ore_block_u64_8_256(${enc}::jsonb)`
+  },
+  range(left, min, max) {
+    return sql`eql_v3.ord_term(${left}) >= eql_v3.ore_block_u64_8_256(${min}::jsonb) AND eql_v3.ord_term(${left}) <= eql_v3.ore_block_u64_8_256(${max}::jsonb)`
+  },
+  match(_op, left, enc) {
+    // containment match: column bloom filter @> search-term bloom filter
+    return sql`eql_v3.match_term(${left}) @> eql_v3.bloom_filter(${enc}::jsonb)`
+  },
+  orderBy(column) {
+    return sql`eql_v3.ord_term(${column})`
+  },
+}

--- a/packages/drizzle/src/pg/v3/codec.ts
+++ b/packages/drizzle/src/pg/v3/codec.ts
@@ -1,0 +1,37 @@
+/**
+ * v3 columns are CREATE DOMAIN … AS jsonb, so they serialise as plain jsonb.
+ * This is a DISTINCT codec from v2's composite-literal parser (the `encryptedType`
+ * customType in index.ts), not a parameterization of it (spec §5.1, §10).
+ *
+ * Note: TData is a phantom type — fromDriver returns the parsed value with no
+ * runtime validation, mirroring v2. Do not over-trust the generic.
+ */
+
+export function v3ToDriver<TData>(value: TData): string | null {
+  // Bind null/undefined as SQL NULL (return JS null), NOT the JSON null literal
+  // 'null': the v3 domains CHECK jsonb_typeof(VALUE) = 'object', so a JSONB null
+  // would fail the domain. SQL NULL is accepted and round-trips via v3FromDriver.
+  // Drizzle's mapToDriverValue calls this hook even for null (no null guard).
+  if (value === null || value === undefined) {
+    return null
+  }
+  return JSON.stringify(value)
+}
+
+// The param type is honestly `string | object | null | undefined`: the postgres
+// driver hands back a raw jsonb string OR an already-parsed object, NULL for SQL
+// NULL, and Drizzle may pass `undefined` for an absent column. Typing it as `string`
+// forced `as unknown as` self-casts on every runtime branch — widening the param
+// removes them.
+export function v3FromDriver<TData>(
+  value: string | object | null | undefined,
+): TData {
+  if (value === null || value === undefined) {
+    return value as TData
+  }
+  // The postgres driver may hand back an already-parsed object for jsonb.
+  if (typeof value === 'object') {
+    return value as TData
+  }
+  return JSON.parse(value) as TData
+}

--- a/packages/drizzle/src/pg/v3/domain-map.ts
+++ b/packages/drizzle/src/pg/v3/domain-map.ts
@@ -1,0 +1,74 @@
+import type { CastAs } from '@cipherstash/schema'
+
+/** v3 scalar names (column-facing API). NOT the same as CastAs. */
+export type V3DataType = 'text'
+
+/** v3 single-capability index choices for the text scalar. */
+export type V3Index = 'equality' | 'freeTextSearch' | 'orderAndRange'
+
+/**
+ * Per-scalar capability table. Keyed by scalar so adding int/date/timestamptz
+ * is a type-shape extension (new key + its valid index subset), not a row append
+ * that lets invalid (scalar, capability) tuples type-check (spec §5.1, §11 item 5).
+ */
+const DOMAINS: Record<
+  V3DataType,
+  { storage: string; byIndex: Record<V3Index, string> }
+> = {
+  text: {
+    storage: 'eql_v3.text',
+    byIndex: {
+      equality: 'eql_v3.text_eq',
+      freeTextSearch: 'eql_v3.text_match',
+      orderAndRange: 'eql_v3.text_ord',
+    },
+  },
+}
+
+/**
+ * Single source of truth for the v3 domain sql-names, derived from DOMAINS by
+ * flattening the storage + per-index values. The encrypted-column detection
+ * predicate in index.ts imports this instead of re-listing the strings, so the
+ * domain set has exactly one definition (no "keep in sync" hazard).
+ */
+export const ALL_V3_DOMAINS: ReadonlySet<string> = new Set(
+  Object.values(DOMAINS).flatMap((scalar) => [
+    scalar.storage,
+    ...Object.values(scalar.byIndex),
+  ]),
+)
+
+/** Translate a v3 scalar name to the internal Protect CastAs (spec §5.1). */
+const CAST_AS: Record<V3DataType, CastAs> = {
+  text: 'string',
+}
+
+export function eqlV3Domain(
+  dataType: V3DataType,
+  index: V3Index | undefined,
+): string {
+  const scalar = DOMAINS[dataType]
+  if (!scalar) {
+    throw new Error(
+      `Unsupported v3 dataType "${dataType}". Only "text" is supported in this milestone.`,
+    )
+  }
+  if (index === undefined) {
+    return scalar.storage
+  }
+  const domain = scalar.byIndex[index]
+  if (!domain) {
+    throw new Error(
+      `Unsupported v3 index "${index}" for dataType "${dataType}".`,
+    )
+  }
+  return domain
+}
+
+export function v3CastAs(dataType: V3DataType): CastAs {
+  const castAs = CAST_AS[dataType]
+  if (!castAs) {
+    throw new Error(`Unsupported v3 dataType "${dataType}".`)
+  }
+  return castAs
+}

--- a/packages/drizzle/src/pg/v3/eql-v3-type.ts
+++ b/packages/drizzle/src/pg/v3/eql-v3-type.ts
@@ -1,0 +1,62 @@
+import { customType } from 'drizzle-orm/pg-core'
+import { type EncryptedColumnConfig, registerColumnConfig } from '../index.js'
+import { v3FromDriver, v3ToDriver } from './codec.js'
+import {
+  type V3DataType,
+  type V3Index,
+  eqlV3Domain,
+  v3CastAs,
+} from './domain-map.js'
+
+export type EqlV3Config = {
+  /** Only 'text' in this milestone. */
+  dataType: V3DataType
+  /** Omit for a storage-only column. One capability per column. */
+  index?: V3Index
+}
+
+/**
+ * Single-capability EQL v3 encrypted column. dataType() returns the v3 domain
+ * string; values are plain-jsonb encoded (spec §5.1).
+ */
+export const eqlV3Type = <TData>(name: string, config: EqlV3Config) => {
+  const domain = eqlV3Domain(config.dataType, config.index)
+
+  const customColumnType = customType<{
+    data: TData
+    driverData: string | null
+  }>({
+    dataType() {
+      return domain
+    },
+    // null/undefined bind as SQL NULL (see v3ToDriver) — never the JSONB null literal.
+    toDriver(value: TData): string | null {
+      return v3ToDriver(value)
+    },
+    fromDriver(value: string | null): TData {
+      return v3FromDriver<TData>(value)
+    },
+  })
+
+  const column = customColumnType(name)
+
+  // Translate to the EncryptedColumnConfig flag shape the encrypt half consumes.
+  // dataType is the INTERNAL CastAs ('string'), not the v3 scalar name (spec §5.1).
+  const fullConfig: EncryptedColumnConfig & { name: string } = {
+    name,
+    dataType: v3CastAs(config.dataType),
+    equality: config.index === 'equality' ? true : undefined,
+    freeTextSearch: config.index === 'freeTextSearch' ? true : undefined,
+    orderAndRange: config.index === 'orderAndRange' ? true : undefined,
+  }
+
+  // Registered in BOTH places (mirrors the v2 encryptedType builder): the
+  // module-global map is the lookup keyed by column name during extraction, while
+  // `_protectConfig` rides on the column object itself so detection can read the
+  // config directly before pgTable processing strips custom props / loses identity.
+  registerColumnConfig(fullConfig)
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle columns don't expose custom props
+  ;(column as any)._protectConfig = fullConfig
+
+  return column
+}

--- a/packages/drizzle/src/pg/v3/index.ts
+++ b/packages/drizzle/src/pg/v3/index.ts
@@ -1,0 +1,27 @@
+export { eqlV3Type, type EqlV3Config } from './eql-v3-type.js'
+export {
+  eqlV3Domain,
+  v3CastAs,
+  type V3DataType,
+  type V3Index,
+} from './domain-map.js'
+export { v3FromDriver, v3ToDriver } from './codec.js'
+export { v3Dialect, type SqlDialect } from '../sql-dialect.js'
+// Shared with v2 — re-exported for a single v3 import site:
+export { extractProtectSchema } from '../schema-extraction.js'
+import type { ProtectClient } from '@cipherstash/protect/client'
+import { createProtectOperators as createProtectOperatorsBase } from '../operators.js'
+import { v3Dialect } from '../sql-dialect.js'
+export { ProtectOperatorError, ProtectConfigError } from '../operators.js'
+
+/**
+ * Operators with the v3 dialect pre-bound. On the ./pg/v3 import path this IS
+ * `createProtectOperators` (and the explicit `createProtectOperatorsV3` alias), so
+ * a v3 consumer can't accidentally reach the v2-defaulted factory — which would
+ * emit eql_v2/native SQL that fails the v3 domain CHECKs at runtime. The
+ * dialect-parameterised factory is still available from '@cipherstash/drizzle/pg'.
+ */
+export function createProtectOperators(client: ProtectClient) {
+  return createProtectOperatorsBase(client, v3Dialect)
+}
+export const createProtectOperatorsV3 = createProtectOperators

--- a/packages/drizzle/tsup.config.ts
+++ b/packages/drizzle/tsup.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig([
   {
-    entry: ['src/pg/index.ts'],
+    // Keyed entry-object form: a flat array of two `index.ts` basenames would
+    // collide both onto dist/pg/index.js. The keyed form pins the output paths so
+    // src/pg/v3/index.ts lands at dist/pg/v3/index.js (not dist/pg/index.js).
+    entry: {
+      index: 'src/pg/index.ts',
+      'v3/index': 'src/pg/v3/index.ts',
+    },
     outDir: 'dist/pg',
     format: ['cjs', 'esm'],
     sourcemap: true,


### PR DESCRIPTION
## Summary

Adds an EQL **v3** adapter to the Drizzle Postgres integration, alongside the existing v2 support. v3 columns are `CREATE DOMAIN … AS jsonb` types (`eql_v3.text{,_eq,_match,_ord}`); queries compare **extracted index terms** (`eq_term`/`ord_term`/`match_term` vs the `hmac_256`/`ore_block_u64_8_256`/`bloom_filter` jsonb helpers) rather than coercing search terms into the domain — which would fail the domain CHECK (SQLSTATE 23514). This milestone covers the **text** scalar.

The change is structured as 7 cohesive, layered commits (each builds + tests green):

1. `refactor: SQL-dialect seam with v2 + v3 emitters` — extracts a `SqlDialect` seam so operator factories share all lazy/batch plumbing and differ only by dialect. v2 behaviour unchanged.
2. `feat: eql_v3 domain mapping + jsonb wire codec` — pure `(dataType, index) -> domain` mapping; plain-jsonb codec (null/undefined bind as SQL NULL).
3. `feat: eqlV3Type column builder + encrypted-column detection` — single-capability column builder; shared `isEncryptedSqlName`; column-config registry anchored on a global `Symbol` so the `./pg` and `./pg/v3` bundles share one map.
4. `feat: ./pg/v3 export subpath + v3-bound operators` — keyed tsup entry + exports map; `createProtectOperators` on the v3 subpath pre-binds the v3 dialect (no v2-default footgun).
5. `test: v3 operator param-emission unit tests` — eq/ne, gt/gte/lt/lte, between/notBetween, match, inArray/notInArray, asc/desc, lazy `and()` combine, native fallback.
6. `chore: vendor eql_v3 SQL fixture + refresh doc` — checked-in `eql_v3` installer (EQL `035952e`) + refresh process.
7. `test: v3 DB integration suite` — provisioning, text_eq round-trip, text domain matrix with an in-memory oracle and negative assertions.

## Testing

- `tsc --noEmit` clean · biome clean on all touched files.
- **84 unit tests pass**; 17 DB-gated tests `describe.skipIf` when `DATABASE_URL` is unset (run them against a Postgres with the v3 SQL installed).
- v2 `operators.test.ts` (31 tests) unchanged — no regression.

## Notes for reviewers

- `packages/drizzle/__tests__/fixtures/cipherstash-encrypt-v3.sql` (~16k lines) is a **vendored, codegen-produced** EQL artifact, not hand-written — see `scripts/refresh-eql-v3-sql.md`. It dominates the diff line count.
- Design/walkthrough docs are intentionally **not** committed to this branch.
- The CJS cross-bundle registry fix (commit 3) is verified at source/test level; an end-to-end bundled-CJS smoke test against `dist/` is a possible follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EQL v3 encrypted text columns with support for equality, free-text search, and order/range queries.
  * Added a new `./pg/v3` package subpath for v3-specific helpers.
  * Added v3 JSONB codec behavior: converts `null`/`undefined` to SQL `NULL` and round-trips plain JSON strings/objects.
* **Improvements**
  * Improved detection of encrypted column names to support both v2 and v3 domains, and ensured operators switch to native SQL for non-encrypted columns.
* **Documentation**
  * Added instructions to refresh and verify the v3 SQL fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->