### PR TITLE
chore: migrate biome.json to 2.x schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,13 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "files": {
-    "ignore": ["**/package.json", ".turbo/", "dist", "**/nix/store/**"]
+    "includes": [
+      "**",
+      "!**/package.json",
+      "!**/.turbo/",
+      "!**/dist",
+      "!**/nix/store"
+    ]
   },
   "formatter": {
     "indentStyle": "space",


### PR DESCRIPTION
## Problem

Root `package.json` pins `@biomejs/biome@^2.4.15`, but `biome.json` still declared the **1.8.3** schema. biome 2.x renamed `files.ignore` → `files.includes` (with negated globs), so the installed biome **refuses to parse the config at all**:

```
× Found an unknown key `ignore`.
× Biome exited because the configuration resulted in errors.
```

This breaks every biome entry point locally — `pnpm code:fix` (`biome check --write`) and the per-package `lint` scripts (`biome check .`) all fail before checking a single file. The binary was bumped to 2.x without migrating the config.

## Fix

Ran `biome migrate` to convert the config to the 2.4.15 schema:
- `$schema` → `2.4.15`
- `files.ignore: [...]` → `files.includes: ["**", "!...", ...]` (biome 2.x's negated-glob form)
- Adopted biome's own recommended folder-ignore form (`!**/nix/store` instead of `!**/nix/store/**`)

Faithful, behavior-preserving config migration — **no lint rule changes**. `biome check biome.json` now validates with zero warnings.

## Scope / impact

- **No CI impact.** biome is not invoked in any workflow (CI's `lint:*` steps are custom node scripts, not biome) — this only restores the local dev tooling.
- biome 2.x does surface a backlog of pre-existing findings (it couldn't run before, so they were invisible). Addressing those — `biome check --write` for the auto-fixable formatting/import-sort changes, plus manual review of the rest — is intentionally **out of scope** for this config fix and should be a follow-up.

## Verification

- `biome check biome.json` → valid, 0 warnings
- `biome check` now runs across the repo (previously crashed on config parse)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tool configuration to use the latest schema version and adjusted file inclusion patterns to optimize coverage while excluding specific directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->