### PR TITLE
chore(stack): upgrade EQL v3 bundle (timestamptz → timestamp) + cast_as fix

### DIFF
--- a/.changeset/eql-v3-typed-client.md
+++ b/.changeset/eql-v3-typed-client.md
@@ -11,7 +11,7 @@ Every method derives its types from the concrete `table` / `column` builder
 arguments:
 
 - `encrypt` / `encryptQuery` pin the plaintext to the column's domain type
-  (`text → string`, `int8 → bigint`, `timestamptz → Date`, …).
+  (`text → string`, `int8 → bigint`, `timestamp → Date`, …).
 - `encryptQuery` constrains `queryType` to the column's capabilities and rejects
   storage-only columns at compile time.
 - `encryptModel` / `bulkEncryptModels` validate schema-column fields against their

--- a/.changeset/eql-v3-typed-schema.md
+++ b/.changeset/eql-v3-typed-schema.md
@@ -2,6 +2,6 @@
 '@cipherstash/stack': minor
 ---
 
-Add EQL v3 schema builders for all generated SQL domains under `@cipherstash/stack/eql/v3`, exposed as the `types` namespace (one member per EQL v3 domain, e.g. `types.TextEq` / `types.Int4Ord` / `types.Timestamptz`), including explicit query capability metadata (`getQueryCapabilities()` / `isQueryable()`) and v3 table support in model encryption helpers (`encryptModel` / `bulkEncryptModels`).
+Add EQL v3 schema builders for all generated SQL domains under `@cipherstash/stack/eql/v3`, exposed as the `types` namespace (one member per EQL v3 domain, e.g. `types.TextEq` / `types.Int4Ord` / `types.Timestamp`), including explicit query capability metadata (`getQueryCapabilities()` / `isQueryable()`) and v3 table support in model encryption helpers (`encryptModel` / `bulkEncryptModels`).
 
-Also widen the accepted plaintext input type for `encrypt` / `encryptQuery` to include `Date` and `bigint` (via the new `Plaintext` type), so v3 `date` / `timestamptz` / `int8` domains can be encrypted and queried with their natural JavaScript values.
+Also widen the accepted plaintext input type for `encrypt` / `encryptQuery` to include `Date` and `bigint` (via the new `Plaintext` type), so v3 `date` / `timestamp` / `int8` domains can be encrypted and queried with their natural JavaScript values.

--- a/docs/superpowers/specs/2026-07-06-eql-v3-drizzle-concrete-types-design.md
+++ b/docs/superpowers/specs/2026-07-06-eql-v3-drizzle-concrete-types-design.md
@@ -1,0 +1,286 @@
+# EQL v3 Drizzle support — concrete-type authoring — design
+
+Status: proposed
+Date: 2026-07-06
+Branch: `feat/eql-v3-text-search-schema`
+
+## 1. Goal
+
+Add EQL v3 support to the Drizzle integration inside `@cipherstash/stack`, mirroring
+the existing v2 Drizzle integration (`@cipherstash/stack/drizzle`) but re-shaped
+around the v3 **concrete-type** model.
+
+The defining change of v3: **the concrete type defines the search capabilities.**
+A column declared `eql_v3.int4_eq` supports equality; `eql_v3.int4_ord` supports
+order/range (and equality via ORE); `eql_v3.text_search` supports equality, order,
+and free-text match. There is no separate `.equality()` / `.orderAndRange()` /
+`.freeTextSearch()` index configuration as in v2 — everything the adapter needs
+(SQL column domain, `cast_as`, and which operators are legal) is **derived from the
+concrete type**, which already carries that metadata in
+`@cipherstash/stack/eql/v3`.
+
+Success = a developer can declare a Drizzle `pgTable` with encrypted v3 columns,
+feed the same schema to `EncryptionV3`, and run equality / range / free-text /
+ordering queries through Drizzle using capability-checked operators that emit the
+correct `eql_v3` term-function SQL.
+
+## 2. Background: why v3 is different from v2
+
+Confirmed against this branch's SQL bundle
+(`packages/stack/__tests__/fixtures/eql-v3/cipherstash-encrypt-v3.sql`) and the live
+pg tests (`packages/stack/__tests__/schema-v3-pg.test.ts`).
+
+**Column type.** v2 uses a single composite type `eql_v2_encrypted` for every
+encrypted column. v3 uses **one `CREATE DOMAIN … AS jsonb` per concrete type** —
+`eql_v3.int4_ord`, `eql_v3.text_eq`, `eql_v3.text_search`, `eql_v3.bool`, … There is
+no single catch-all `eql_v3_encrypted`.
+
+**Wire form.** v2 writes a composite literal `("…")`. v3 domains are plain jsonb, so
+the value is inserted as plain JSON cast to the domain (`$1::eql_v3.int4_ord`).
+
+**Query form.** v2 compares encrypted payloads directly (native `=` on
+`eql_v2_encrypted`, or `eql_v2.gt/lt/like/order_by(...)` convenience functions). v3
+has **no convenience operators**; it compares **extracted index terms** on both
+sides:
+
+| Capability | v3 SQL |
+| --- | --- |
+| equality (HMAC) | `eql_v3.eq_term(col) = eql_v3.hmac_256($::jsonb)` |
+| equality (ORE, numeric/date order domains) | `eql_v3.ord_term(col) = eql_v3.ore_block_256($::jsonb)` |
+| order/range | `eql_v3.ord_term(col) </<=/>/>= eql_v3.ore_block_256($::jsonb)` |
+| free-text match | `eql_v3.match_term(col) @> eql_v3.bloom_filter($::jsonb)` |
+| order by | `ORDER BY eql_v3.ord_term(col)` |
+
+The column-side extractor (`eq_term`/`ord_term`/`match_term`) takes the column
+domain (its stored value has ciphertext `c`, so it passes the domain CHECK). The
+search-side constructor (`hmac_256`/`ore_block_256`/`bloom_filter`) pulls the index
+field straight out of the query-term jsonb with no domain coercion — this is why a
+query term (which has no ciphertext) must be cast to `::jsonb`, never to the domain.
+
+**Concrete types already exist.** `@cipherstash/stack/eql/v3` ships the full
+concrete-type system (`packages/stack/src/eql/v3/{columns,types,table,index}.ts`):
+- `types.<Domain>(name)` factories for all 35 shipped domains.
+- Each `EncryptedV3Column` carries `getEqlType()` (`eql_v3.int4_ord`), `castAs`
+  (`'string' | 'number' | 'boolean' | 'date'`), `getQueryCapabilities()`
+  (`{ equality, orderAndRange, freeTextSearch }`), and `build()` →
+  `{ cast_as, indexes: { unique?, ore?, match? } }`.
+- `encryptedTable(name, columns)` builds the schema `EncryptionV3` consumes.
+- `EncryptionV3(...).encryptQuery(value, { table, column, queryType })` produces the
+  query term; the FFI's `resolveIndexType` picks the index (including equality-via-ORE
+  for numeric/date order domains).
+
+This adapter **reuses** that system verbatim — it never re-declares domain or
+capability data.
+
+## 3. Scope
+
+### In scope
+- A new Drizzle v3 module in `@cipherstash/stack`, exported at
+  `@cipherstash/stack/eql/v3/drizzle` (nested under the existing `eql/v3` namespace).
+- A Drizzle-native `types` namespace with the **identical PascalCase factory names**
+  as `@cipherstash/stack/eql/v3` (`types.TextSearch`, `types.Int4Ord`, `types.Bool`,
+  … all 35 shipped domains), each returning a Drizzle `customType` column.
+- Plain-jsonb codec (`toDriver` / `fromDriver`).
+- Schema extraction: Drizzle table → v3 `encryptedTable` for `EncryptionV3`.
+- `createEncryptionOperatorsV3(client)` — capability-checked async operators:
+  `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between`, `notBetween`, `like`, `ilike`,
+  `notIlike`, `inArray`, `notInArray`, `asc`, `desc`, `and`, `or`, plus the
+  pass-through non-encrypting operators (`isNull`, `isNotNull`, `not`, `exists`,
+  `notExists`).
+- Detection: recover the concrete builder from a processed Drizzle column.
+- A `.changeset/` entry (minor `@cipherstash/stack`).
+
+### Out of scope (explicit gaps, not silent omissions)
+- **JSON / `ste_vec`** operators (`jsonbPathQueryFirst`, `jsonbGet`,
+  `jsonbPathExists`). No v3 JSON column builder ships yet (`eql_v3.json` /
+  `ste_vec` have no `types.*` factory), so these are simply absent from the v3
+  operator surface — there is no v3 column they could target. Deferred until a v3
+  JSON builder exists.
+- **int8 / bigint** domains — intentionally absent from `eql/v3` pending lossless
+  FFI round-tripping. This adapter mirrors that: no int8 factory.
+- **`like`/`ilike` pattern semantics.** v3's only text-match SQL is bloom-filter
+  containment (`match_term @> bloom_filter`), which is **token/substring matching,
+  not SQL `LIKE` patterns**. `like`/`ilike`/`notIlike` all map to containment
+  (`notIlike` = `NOT (…)`); wildcards in the argument are not interpreted. Documented
+  on each operator.
+- **No changes to the v2 Drizzle module** (`@cipherstash/stack/drizzle`) or the
+  standalone `@cipherstash/drizzle` package. Zero v2 regression surface.
+- **No dialect-seam refactor of the v2 `operators.ts`.** The v3 operators are a
+  self-contained module; the SQL-dialect seam (below) lives only inside v3.
+
+## 4. Architecture & location
+
+```
+packages/stack/src/eql/v3/drizzle/
+  index.ts             // barrel: types, createEncryptionOperatorsV3, extractEncryptionSchemaV3, errors
+  types.ts             // Drizzle `types` namespace (PascalCase factories → customType columns)
+  column.ts            // customType wrapper + detection + config stash
+  codec.ts             // plain-jsonb toDriver / fromDriver
+  sql-dialect.ts       // v3 term-function SQL emission (local seam)
+  operators.ts         // createEncryptionOperatorsV3
+  schema-extraction.ts // Drizzle table → eql/v3 encryptedTable
+```
+
+Package wiring: add `"./eql/v3/drizzle"` to `packages/stack/package.json` `exports`
+and to the tsup entry list, following the existing `./eql/v3` and `./drizzle`
+entries.
+
+The v3 module depends inward on `@/eql/v3` (concrete types + `encryptedTable`) and
+the base `EncryptionClient` (`@/encryption`) — the same client the v2 Drizzle
+operators use. It does **not** depend on the v2 Drizzle module.
+
+## 5. Components
+
+### 5.1 `types` namespace + column wrapper (`types.ts`, `column.ts`, `codec.ts`)
+
+`types.TextSearch(name)` (and the 34 siblings) returns a Drizzle column built via
+`customType`. Each factory:
+
+1. Constructs the corresponding `eql/v3` builder — `v3.types.TextSearch(name)` — the
+   **single source of truth** for domain / `cast_as` / capabilities. No metadata is
+   re-declared here; this file is a name→delegate map.
+2. Builds a `customType<{ data: Plaintext; driverData: string | null }>` whose
+   `dataType()` returns `builder.getEqlType()` (e.g. `eql_v3.int4_ord`), and whose
+   `toDriver`/`fromDriver` are the plain-jsonb codec.
+3. Stashes the `eql/v3` builder on the column (`_eqlv3Column`) **and** in a
+   module-global map keyed by column name — mirroring v2's dual registration — so
+   detection and schema-extraction can recover it after `pgTable` strips custom
+   props.
+
+The decrypted TypeScript type is `PlaintextForColumn<typeof builder>` (string /
+number / boolean / Date), so `users.age` decrypts to `number`, `users.createdAt` to
+`Date`, etc.
+
+**Codec** (`codec.ts`), proven by the `eql-v3-drizzle-adapter` branch:
+- `toDriver`: `null`/`undefined` → SQL `NULL` (JS `null`). The v3 domains
+  `CHECK jsonb_typeof(VALUE) = 'object'`, so a JSONB `null` literal would fail the
+  domain; SQL NULL is accepted. Otherwise `JSON.stringify(value)`.
+- `fromDriver`: pass `null` through; return already-parsed objects as-is (the
+  postgres driver may hand back a parsed jsonb object); else `JSON.parse`.
+
+**Detection** (`column.ts`): `isEqlV3Column(column)` / `getEqlV3Column(name, column)`
+check `_eqlv3Column`, falling back to the name-keyed map, and validate the
+`dataType()` string is one of the known `eql_v3.*` domains (source: iterate the
+`eql/v3` `types` factories once at module load to build the domain set — no
+hand-maintained string list).
+
+### 5.2 SQL dialect (`sql-dialect.ts`)
+
+A small object that emits the v3 term-function SQL, keyed off which index the column
+exposes. Gating and dialect both read `builder.build().indexes` — the authoritative
+index set:
+
+- `indexes.unique` present → equality via `eql_v3.eq_term(col) = eql_v3.hmac_256($::jsonb)`.
+- `indexes.ore` present → order/range via `eql_v3.ord_term(col) <op> eql_v3.ore_block_256($::jsonb)`;
+  order-by via `eql_v3.ord_term(col)`; **and** equality via ORE when `unique` is
+  absent (`eql_v3.ord_term(col) = eql_v3.ore_block_256($::jsonb)`).
+- `indexes.match` present → free-text via `eql_v3.match_term(col) @> eql_v3.bloom_filter($::jsonb)`.
+
+Query terms are bound params already wrapped with `bindIfParam` by the caller, then
+cast `::jsonb` inside the constructor call. Constructor names are pinned to this
+branch's bundle: `hmac_256`, `ore_block_256`, `bloom_filter` (note: **not** the
+`ore_block_u64_8_256` spelling from the older adapter branch — that predates this
+bundle).
+
+### 5.3 Operators (`operators.ts`)
+
+`createEncryptionOperatorsV3(client: EncryptionClient)` returns the async-operator
+object, same ergonomics as v2 (`await ops.eq(users.email, 'x')`, `ops.and(...)` /
+`ops.or(...)` batch encryption, `ops.asc(...)` / `ops.desc(...)`,
+`ops.inArray(...)`). Per operator:
+
+| Operator | Requires index | `queryType` sent to `encryptQuery` | Emitted SQL |
+| --- | --- | --- | --- |
+| `eq` / `ne` | `unique` or `ore` | `equality` | `unique` → `eq_term = hmac_256`; else `ord_term =/<> ore_block_256` |
+| `gt`/`gte`/`lt`/`lte` | `ore` | `orderAndRange` | `ord_term </<=/>/>= ore_block_256` |
+| `between` / `notBetween` | `ore` | `orderAndRange` | `ord_term >= ore_block_256($min) AND ord_term <= ore_block_256($max)`, NOT-wrapped for `notBetween` |
+| `like`/`ilike`/`notIlike` | `match` | `freeTextSearch` | `match_term @> bloom_filter`, NOT-wrapped for `notIlike` |
+| `inArray`/`notInArray` | `unique` or `ore` | `equality` | OR of `eq` terms / AND of `ne` terms |
+| `asc` / `desc` | `ore` | — | `ORDER BY eql_v3.ord_term(col)` |
+| `isNull`/`isNotNull`/`not`/`exists`/`notExists` | — | — | pass-through Drizzle operators |
+
+Term encryption reuses the column's recovered `eql/v3` builder + its owning
+`encryptedTable` (rebuilt via schema-extraction and cached per table, exactly as v2
+caches the ProtectTable): `client.encryptQuery(value, { table, column, queryType })`.
+
+**Error handling — no silent fallback.** In v2, an operator on a non-encrypted
+column falls through to the plain Drizzle operator. In v3 that is impossible: a v3
+domain column has no plaintext form, and using the wrong operator emits SQL the
+domain CHECK rejects at runtime. So the operators **throw `EncryptionOperatorError`**
+(reusing the v2 error class name) when a column lacks the required index — e.g.
+`ops.gt` on a `types.TextEq` column (equality-only, no `ore`), or `ops.ilike` on a
+column without `match`. The message names the column, operator, and the missing
+capability. A non-v3 column passed to a v3 operator also throws (it can't be a v3
+domain), rather than silently degrading.
+
+### 5.4 Schema extraction (`schema-extraction.ts`)
+
+`extractEncryptionSchemaV3(drizzleTable)` iterates the Drizzle columns, recovers each
+stashed `eql/v3` builder via detection, and returns
+`encryptedTable(tableName, { <property>: builder, … })` — ready for
+`EncryptionV3({ schemas: [users] })`. Throws if the table has no v3 columns (mirrors
+v2's `extractEncryptionSchema`). Operators call this internally to resolve the
+`encryptedTable` for a column's parent table, caching per table name.
+
+## 6. Data flow (per query)
+
+```
+types.Int4Ord('age')                      // authoring
+  → customType dataType() = 'eql_v3.int4_ord', stash eql/v3 builder
+pgTable('users', { age })                  // Drizzle table
+
+extractEncryptionSchemaV3(users)           // → encryptedTable('users', { age: <builder> })
+EncryptionV3({ schemas: [users-schema] })  // typed client
+
+await ops.gte(users.age, 30)
+  → recover builder (ore index present ✓)
+  → client.encryptQuery(30, { table, column, queryType: 'orderAndRange' })  // term
+  → sql`eql_v3.ord_term(${users.age}) >= eql_v3.ore_block_256(${term}::jsonb)`
+```
+
+## 7. Testing
+
+Mirror `packages/drizzle/__tests__` structure, plus the v3 live-pg pattern from
+`packages/stack/__tests__/schema-v3-pg.test.ts`. Location:
+`packages/stack/__tests__/drizzle-v3/` (or alongside the existing
+`packages/stack/__tests__/drizzle-*.test.ts` files, matching whatever the v2 drizzle
+tests in stack already use).
+
+**Unit (no DB):**
+- `types.*` produce the correct `dataType()` domain string for a representative set
+  across every scalar family and capability tier.
+- Codec round-trip (object ⇄ jsonb string; null ⇄ SQL NULL).
+- `extractEncryptionSchemaV3` rebuilds the expected `encryptedTable` (`build()`
+  output equals the directly-authored `eql/v3` table's).
+- Operator SQL emission via a mock client + `PgDialect`: assert exact
+  `eql_v3.eq_term/ord_term/match_term` + `hmac_256/ore_block_256/bloom_filter`
+  strings and the equality-via-ORE branch on an order-only numeric column.
+- Gating errors: `gt` on equality-only, `ilike` on non-match column, and a non-v3
+  column passed into a v3 operator.
+
+**Live pg** (gated by `LIVE_EQL_V3_PG_ENABLED`, install via `installEqlV3IfNeeded`):
+- One `pgTable` with a representative column per tier: `types.TextSearch('email')`,
+  `types.Int4Ord('age')`, `types.TextEq('nickname')`, `types.Bool('active')`.
+- Seed with `EncryptionV3(...).bulkEncryptModels` (or raw insert with
+  `$::eql_v3.<domain>` casts), then real Drizzle `select().where(await ops.eq(...))`,
+  `ops.gte(...)`, `ops.between(...)`, `ops.ilike(...)`, `orderBy(ops.asc(...))`;
+  decrypt; assert the selected rows. Use `test_run_id` isolation like the v2 suite.
+
+## 8. Open implementation details (resolved during build, not blocking)
+
+- Exact test directory name / whether to gate live tests behind the same env var the
+  stack v3 pg tests use (`LIVE_EQL_V3_PG_ENABLED`) — adopt the existing helper.
+- Whether `between` on a text order domain (which has both `unique` and `ore`) needs
+  any special handling — it uses `ore`, same as numeric; verify against a live row.
+- Confirm the postgres driver path Drizzle uses binds `$::jsonb` correctly for the
+  term param (the pg tests use `sql.json(...)`; Drizzle's `bindIfParam` + `::jsonb`
+  cast is the equivalent — assert in a live round-trip).
+
+## 9. Non-goals / follow-ups (tracked, not in this milestone)
+
+- v3 JSON / `ste_vec` operators once a v3 JSON column builder ships.
+- int8 / bigint once the FFI round-trips losslessly.
+- Mirroring into the standalone `@cipherstash/drizzle` package (only if it must ship
+  v3 independently of `@cipherstash/stack`).
+- drizzle-kit migration generation for v3 domains (the v2 `generate-eql-migration`
+  path emits `eql_v2_encrypted`; a v3 equivalent is a separate effort).

--- a/packages/stack/__tests__/cjs-require.test.ts
+++ b/packages/stack/__tests__/cjs-require.test.ts
@@ -93,7 +93,7 @@ describe('CJS consumers can require the built bundles', () => {
       `if (typeof v3.encryptedTable !== 'function') { throw new Error('missing v3 CJS export: encryptedTable') }`,
       `if (typeof v3.buildEncryptConfig !== 'function') { throw new Error('missing v3 CJS export: buildEncryptConfig') }`,
       `if (typeof v3.types !== 'object' || v3.types === null) { throw new Error('missing v3 CJS export: types namespace') }`,
-      `const requiredTypes = ['TextSearch', 'TextEq', 'Int4Ord', 'Bool', 'Timestamptz']`,
+      `const requiredTypes = ['TextSearch', 'TextEq', 'Int4Ord', 'Bool', 'Timestamp']`,
       `const missing = requiredTypes.filter((k) => typeof v3.types[k] !== 'function')`,
       `if (missing.length > 0) { throw new Error('missing v3 types.* CJS members: ' + missing.join(', ')) }`,
     ].join('\n')

--- a/packages/stack/__tests__/fixtures/eql-v3/cipherstash-encrypt-v3.sql
+++ b/packages/stack/__tests__/fixtures/eql-v3/cipherstash-encrypt-v3.sql
@@ -142,7 +142,7 @@ $$ LANGUAGE sql;
 --! @internal Mark this hand-written helper inline-critical so the post-install
 --! pin_search_path pass leaves it unpinned (no `SET search_path`), preserving
 --! SQL-function inlining. It takes a bare `jsonb` arg (not a jsonb-backed
---! encrypted DOMAIN), so the structural skip in tasks/pin_search_path.sql does
+--! encrypted DOMAIN), so the structural skip in tasks/pin_search_path_v3.sql does
 --! not recognise it; this marker is the documented manual opt-in.
 COMMENT ON FUNCTION eql_v3.jsonb_array_to_bytea_array(jsonb) IS
   'eql-inline-critical: per-encrypted-value ORE helper; must stay inlinable (unpinned search_path)';
@@ -278,7 +278,7 @@ $$ LANGUAGE sql;
 --! @internal Mark this hand-written helper inline-critical so the post-install
 --! pin_search_path pass leaves it unpinned (no `SET search_path`), preserving
 --! SQL-function inlining. It takes a bare `jsonb` arg (not a jsonb-backed
---! encrypted DOMAIN), so the structural skip in tasks/pin_search_path.sql does
+--! encrypted DOMAIN), so the structural skip in tasks/pin_search_path_v3.sql does
 --! not recognise it; this marker is the documented manual opt-in.
 COMMENT ON FUNCTION eql_v3.jsonb_array_to_ore_block_256(jsonb) IS
   'eql-inline-critical: per-encrypted-value ORE helper; must stay inlinable (unpinned search_path)';
@@ -762,6 +762,81 @@ AS $$
   SELECT CASE WHEN jsonb_typeof(val -> 'bf') = 'array'
     THEN ARRAY(SELECT jsonb_array_elements(val -> 'bf'))::eql_v3.bloom_filter
   END
+$$;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file v3/scalars/timestamp/timestamp_types.sql
+--! @brief Encrypted-domain types for timestamp.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.timestamp.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamp' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamp AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.timestamp_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamp_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamp_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.timestamp_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamp_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamp_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND jsonb_typeof(VALUE -> 'ob') = 'array'
+        AND jsonb_array_length(VALUE -> 'ob') > 0
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.timestamp_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamp_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamp_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND jsonb_typeof(VALUE -> 'ob') = 'array'
+        AND jsonb_array_length(VALUE -> 'ob') > 0
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
 $$;
 -- AUTOMATICALLY GENERATED FILE.
 
@@ -1872,1747 +1947,6 @@ CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int4_eq)
 RETURNS jsonb IMMUTABLE PARALLEL SAFE
 AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int4_eq'; END; $$
 LANGUAGE plpgsql;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file v3/scalars/timestamptz/timestamptz_types.sql
---! @brief Encrypted-domain types for timestamptz.
-
-DO $$
-BEGIN
-  --! @brief Encrypted domain eql_v3.timestamptz.
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_type
-    WHERE typname = 'timestamptz' AND typnamespace = 'eql_v3'::regnamespace
-  ) THEN
-    CREATE DOMAIN eql_v3.timestamptz AS jsonb
-      CHECK (
-        jsonb_typeof(VALUE) = 'object'
-        AND VALUE ? 'v'
-        AND VALUE ? 'i'
-        AND VALUE ? 'c'
-        AND VALUE->>'v' = '2'
-      );
-  END IF;
-
-  --! @brief Encrypted domain eql_v3.timestamptz_eq.
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_type
-    WHERE typname = 'timestamptz_eq' AND typnamespace = 'eql_v3'::regnamespace
-  ) THEN
-    CREATE DOMAIN eql_v3.timestamptz_eq AS jsonb
-      CHECK (
-        jsonb_typeof(VALUE) = 'object'
-        AND VALUE ? 'v'
-        AND VALUE ? 'i'
-        AND VALUE ? 'c'
-        AND VALUE ? 'hm'
-        AND VALUE->>'v' = '2'
-      );
-  END IF;
-
-  --! @brief Encrypted domain eql_v3.timestamptz_ord_ore.
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_type
-    WHERE typname = 'timestamptz_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
-  ) THEN
-    CREATE DOMAIN eql_v3.timestamptz_ord_ore AS jsonb
-      CHECK (
-        jsonb_typeof(VALUE) = 'object'
-        AND VALUE ? 'v'
-        AND VALUE ? 'i'
-        AND VALUE ? 'c'
-        AND VALUE ? 'ob'
-        AND jsonb_typeof(VALUE -> 'ob') = 'array'
-        AND jsonb_array_length(VALUE -> 'ob') > 0
-        AND VALUE->>'v' = '2'
-      );
-  END IF;
-
-  --! @brief Encrypted domain eql_v3.timestamptz_ord.
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_type
-    WHERE typname = 'timestamptz_ord' AND typnamespace = 'eql_v3'::regnamespace
-  ) THEN
-    CREATE DOMAIN eql_v3.timestamptz_ord AS jsonb
-      CHECK (
-        jsonb_typeof(VALUE) = 'object'
-        AND VALUE ? 'v'
-        AND VALUE ? 'i'
-        AND VALUE ? 'c'
-        AND VALUE ? 'ob'
-        AND jsonb_typeof(VALUE -> 'ob') = 'array'
-        AND jsonb_array_length(VALUE -> 'ob') > 0
-        AND VALUE->>'v' = '2'
-      );
-  END IF;
-END
-$$;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_ore_functions.sql
---! @brief Functions for eql_v3.timestamptz_ord_ore.
-
---! @brief Index extractor for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @return eql_v3.ore_block_256
-CREATE FUNCTION eql_v3.ord_term(a eql_v3.timestamptz_ord_ore)
-RETURNS eql_v3.ore_block_256
-LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ore_block_256(a::jsonb) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) = eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) <> eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) < eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) <= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) > eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.timestamptz_ord_ore) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord_ore) >= eql_v3.ord_term(b) $$;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param selector text
---! @return eql_v3.timestamptz_ord_ore
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_ord_ore, selector text)
-RETURNS eql_v3.timestamptz_ord_ore IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param selector integer
---! @return eql_v3.timestamptz_ord_ore
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_ord_ore, selector integer)
-RETURNS eql_v3.timestamptz_ord_ore IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_ord_ore
---! @return eql_v3.timestamptz_ord_ore
-CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz_ord_ore)
-RETURNS eql_v3.timestamptz_ord_ore IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param selector text
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_ord_ore, selector text)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param selector integer
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_ord_ore, selector integer)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_ord_ore
---! @return text
-CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz_ord_ore)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text
---! @return boolean
-CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz_ord_ore, b text)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz_ord_ore, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz_ord_ore, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return text
-CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord_ore, b text)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b integer
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord_ore, b integer)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz_ord_ore, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b eql_v3.timestamptz_ord_ore
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_ord_ore, b eql_v3.timestamptz_ord_ore)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a eql_v3.timestamptz_ord_ore
---! @param b jsonb
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_ord_ore, b jsonb)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord_ore.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord_ore
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz_ord_ore)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord_ore'; END; $$
-LANGUAGE plpgsql;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_ore_operators.sql
---! @brief Operators for eql_v3.timestamptz_ord_ore.
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = integer
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = integer
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR ? (
-  FUNCTION = eql_v3."?",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text
-);
-
-CREATE OPERATOR ?| (
-  FUNCTION = eql_v3."?|",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR ?& (
-  FUNCTION = eql_v3."?&",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR @? (
-  FUNCTION = eql_v3."@?",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR @@ (
-  FUNCTION = eql_v3."@@",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR #> (
-  FUNCTION = eql_v3."#>",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #>> (
-  FUNCTION = eql_v3."#>>",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = integer
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #- (
-  FUNCTION = eql_v3."#-",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = text[]
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_ord_ore, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord_ore
-);
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_eq_functions.sql
---! @brief Functions for eql_v3.timestamptz_eq.
-
---! @brief Index extractor for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @return eql_v3.hmac_256
-CREATE FUNCTION eql_v3.eq_term(a eql_v3.timestamptz_eq)
-RETURNS eql_v3.hmac_256
-LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) = eql_v3.eq_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) <> eql_v3.eq_term(b) $$;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param selector text
---! @return eql_v3.timestamptz_eq
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector text)
-RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param selector integer
---! @return eql_v3.timestamptz_eq
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector integer)
-RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_eq
---! @return eql_v3.timestamptz_eq
-CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz_eq)
-RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param selector text
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector text)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param selector integer
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector integer)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_eq
---! @return text
-CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz_eq)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text
---! @return boolean
-CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz_eq, b text)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz_eq, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz_eq, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz_eq, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz_eq, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz_eq, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return text
-CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz_eq, b text[])
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b integer
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b integer)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz_eq, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b eql_v3.timestamptz_eq
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a eql_v3.timestamptz_eq
---! @param b jsonb
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b jsonb)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
---! @param a jsonb
---! @param b eql_v3.timestamptz_eq
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz_eq)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
-LANGUAGE plpgsql;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_functions.sql
---! @brief Functions for eql_v3.timestamptz_ord.
-
---! @brief Index extractor for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @return eql_v3.ore_block_256
-CREATE FUNCTION eql_v3.ord_term(a eql_v3.timestamptz_ord)
-RETURNS eql_v3.ore_block_256
-LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ore_block_256(a::jsonb) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) = eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) <> eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) < eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) <= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) > eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.timestamptz_ord) $$;
-
---! @brief Operator wrapper for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
-AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamptz_ord) >= eql_v3.ord_term(b) $$;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param selector text
---! @return eql_v3.timestamptz_ord
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_ord, selector text)
-RETURNS eql_v3.timestamptz_ord IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param selector integer
---! @return eql_v3.timestamptz_ord
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_ord, selector integer)
-RETURNS eql_v3.timestamptz_ord IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_ord
---! @return eql_v3.timestamptz_ord
-CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz_ord)
-RETURNS eql_v3.timestamptz_ord IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param selector text
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_ord, selector text)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param selector integer
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_ord, selector integer)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param selector eql_v3.timestamptz_ord
---! @return text
-CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz_ord)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text
---! @return boolean
-CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz_ord, b text)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz_ord, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz_ord, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz_ord, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz_ord, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz_ord, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return text
-CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz_ord, b text[])
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord, b text)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b integer
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord, b integer)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_ord, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz_ord, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b eql_v3.timestamptz_ord
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_ord, b eql_v3.timestamptz_ord)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a eql_v3.timestamptz_ord
---! @param b jsonb
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_ord, b jsonb)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz_ord.
---! @param a jsonb
---! @param b eql_v3.timestamptz_ord
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz_ord)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_ord'; END; $$
-LANGUAGE plpgsql;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_operators.sql
---! @brief Operators for eql_v3.timestamptz_ord.
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord,
-  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = integer
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = integer
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR ? (
-  FUNCTION = eql_v3."?",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text
-);
-
-CREATE OPERATOR ?| (
-  FUNCTION = eql_v3."?|",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR ?& (
-  FUNCTION = eql_v3."?&",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR @? (
-  FUNCTION = eql_v3."@?",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR @@ (
-  FUNCTION = eql_v3."@@",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR #> (
-  FUNCTION = eql_v3."#>",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #>> (
-  FUNCTION = eql_v3."#>>",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = integer
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #- (
-  FUNCTION = eql_v3."#-",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = text[]
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = eql_v3.timestamptz_ord
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_ord, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_ord
-);
 -- AUTOMATICALLY GENERATED FILE.
 
 --! @file v3/scalars/int2/int2_types.sql
@@ -15093,6 +13427,1672 @@ CREATE OPERATOR || (
   FUNCTION = eql_v3."||",
   LEFTARG = jsonb, RIGHTARG = eql_v3.float4_ord
 );
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_ore_functions.sql
+--! @brief Functions for eql_v3.timestamp_ord_ore.
+
+--! @brief Index extractor for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @return eql_v3.ore_block_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.timestamp_ord_ore)
+RETURNS eql_v3.ore_block_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.timestamp_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param selector text
+--! @return eql_v3.timestamp_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_ord_ore, selector text)
+RETURNS eql_v3.timestamp_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param selector integer
+--! @return eql_v3.timestamp_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_ord_ore, selector integer)
+RETURNS eql_v3.timestamp_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_ord_ore
+--! @return eql_v3.timestamp_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamp_ord_ore)
+RETURNS eql_v3.timestamp_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamp_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamp_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamp_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamp_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamp_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b eql_v3.timestamp_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_ord_ore, b eql_v3.timestamp_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a eql_v3.timestamp_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamp_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord_ore'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_functions.sql
+--! @brief Functions for eql_v3.timestamp_ord.
+
+--! @brief Index extractor for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @return eql_v3.ore_block_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.timestamp_ord)
+RETURNS eql_v3.ore_block_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.timestamp_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.timestamp_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamp_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param selector text
+--! @return eql_v3.timestamp_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_ord, selector text)
+RETURNS eql_v3.timestamp_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param selector integer
+--! @return eql_v3.timestamp_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_ord, selector integer)
+RETURNS eql_v3.timestamp_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_ord
+--! @return eql_v3.timestamp_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamp_ord)
+RETURNS eql_v3.timestamp_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamp_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamp_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamp_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamp_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamp_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamp_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamp_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamp_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamp_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b eql_v3.timestamp_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_ord, b eql_v3.timestamp_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a eql_v3.timestamp_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_ord.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamp_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_ord'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_operators.sql
+--! @brief Operators for eql_v3.timestamp_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = eql_v3.timestamp_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_eq_functions.sql
+--! @brief Functions for eql_v3.timestamp_eq.
+
+--! @brief Index extractor for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.timestamp_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.timestamp_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamp_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.timestamp_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamp_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamp_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param selector text
+--! @return eql_v3.timestamp_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_eq, selector text)
+RETURNS eql_v3.timestamp_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param selector integer
+--! @return eql_v3.timestamp_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp_eq, selector integer)
+RETURNS eql_v3.timestamp_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_eq
+--! @return eql_v3.timestamp_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamp_eq)
+RETURNS eql_v3.timestamp_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamp_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamp_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamp_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamp_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamp_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamp_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamp_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamp_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamp_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b eql_v3.timestamp_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_eq, b eql_v3.timestamp_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a eql_v3.timestamp_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamp_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamp_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp_eq'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_ore_operators.sql
+--! @brief Operators for eql_v3.timestamp_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = eql_v3.timestamp_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_ord_ore
+);
 
 --! @file v3/sem/ore_cllw/types.sql
 --! @brief CLLW ORE index term type for STE-vec range queries (eql_v3 SEM)
@@ -15298,8 +15298,8 @@ $$ LANGUAGE plpgsql;
 --! against the ultimate base type jsonb, so the native-jsonb firewall in
 --! blockers.sql can attach):
 --!   - eql_v3.json     — storage/root: an EQL envelope object ({i, v, ...}).
---!   - eql_v3.ste_vec_entry — a single sv element (returned by `->`).
---!   - eql_v3.ste_vec_query  — a containment needle (sv elements, no ciphertext).
+--!   - eql_v3.jsonb_entry — a single sv element (returned by `->`).
+--!   - eql_v3.jsonb_query  — a containment needle (sv elements, no ciphertext).
 
 --! @brief Validate a single SteVec entry payload.
 --! @internal
@@ -15410,7 +15410,7 @@ CREATE DOMAIN eql_v3.json AS jsonb
 --! `i`/`v` merged in by `->`) are allowed.
 --!
 --! @see src/v3/jsonb/operators.sql
-CREATE DOMAIN eql_v3.ste_vec_entry AS jsonb
+CREATE DOMAIN eql_v3.jsonb_entry AS jsonb
   CHECK (
     eql_v3.is_valid_ste_vec_entry_payload(VALUE)
   );
@@ -15424,14 +15424,14 @@ CREATE DOMAIN eql_v3.ste_vec_entry AS jsonb
 --! `jsonb @>`.
 --!
 --! @note Construct from inline JSON via the DOMAIN cast:
---!       `'{"sv":[{"s":"<sel>","hm":"<hm>"}]}'::eql_v3.ste_vec_query`.
+--!       `'{"sv":[{"s":"<sel>","hm":"<hm>"}]}'::eql_v3.jsonb_query`.
 --! @see eql_v3.to_ste_vec_query
-CREATE DOMAIN eql_v3.ste_vec_query AS jsonb
+CREATE DOMAIN eql_v3.jsonb_query AS jsonb
   CHECK (
     eql_v3.is_valid_ste_vec_query_payload(VALUE)
   );
 
---! @brief Convert an eql_v3.json to a ste_vec_query needle.
+--! @brief Convert an eql_v3.json to a jsonb_query needle.
 --!
 --! Normalises each sv element down to the matching-relevant fields: `s` plus
 --! exactly one of `hm` / `oc`. Other fields (`c`, `a`, `i`/`v`, anything else)
@@ -15440,10 +15440,10 @@ CREATE DOMAIN eql_v3.ste_vec_query AS jsonb
 --!   `GIN (eql_v3.to_ste_vec_query(col)::jsonb jsonb_path_ops)`.
 --!
 --! @param e eql_v3.json Source encrypted payload
---! @return eql_v3.ste_vec_query Query-shaped needle, sv elements normalised.
---! @see eql_v3.ste_vec_query
+--! @return eql_v3.jsonb_query Query-shaped needle, sv elements normalised.
+--! @see eql_v3.jsonb_query
 CREATE FUNCTION eql_v3.to_ste_vec_query(e eql_v3.json)
-  RETURNS eql_v3.ste_vec_query
+  RETURNS eql_v3.jsonb_query
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
   SELECT jsonb_build_object(
@@ -15461,10 +15461,10 @@ AS $$
        FROM jsonb_array_elements(e::jsonb -> 'sv') AS elem),
       '[]'::jsonb
     )
-  )::eql_v3.ste_vec_query
+  )::eql_v3.jsonb_query
 $$;
 
-CREATE CAST (eql_v3.json AS eql_v3.ste_vec_query)
+CREATE CAST (eql_v3.json AS eql_v3.jsonb_query)
   WITH FUNCTION eql_v3.to_ste_vec_query
   AS ASSIGNMENT;
 
@@ -15534,9 +15534,9 @@ $$ LANGUAGE plpgsql;
 
 --! @brief Extract selector (s) from a ste_vec entry. The DOMAIN CHECK
 --!        guarantees `s` is present, so this is a simple field access.
---! @param entry eql_v3.ste_vec_entry
+--! @param entry eql_v3.jsonb_entry
 --! @return text The selector value.
-CREATE FUNCTION eql_v3.selector(entry eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.selector(entry eql_v3.jsonb_entry)
   RETURNS text
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -15547,16 +15547,16 @@ $$;
 -- Equality-term extractor (XOR-aware: coalesce(hm, oc))
 ------------------------------------------------------------------------------
 
---! @brief XOR-aware equality term extractor for eql_v3.ste_vec_entry.
+--! @brief XOR-aware equality term extractor for eql_v3.jsonb_entry.
 --!
 --! Returns the bytea of whichever deterministic term the sv entry carries —
 --! `hm` (HMAC-256) or `oc` (CLLW ORE). The two byte distributions are disjoint
 --! by construction, so byte equality on the coalesce is unambiguous. Canonical
---! equality extractor used by `=` / `<>` on ste_vec_entry.
+--! equality extractor used by `=` / `<>` on jsonb_entry.
 --!
---! @param entry eql_v3.ste_vec_entry
+--! @param entry eql_v3.jsonb_entry
 --! @return bytea Decoded `hm` or `oc` bytes (NULL if entry is NULL).
-CREATE FUNCTION eql_v3.eq_term(entry eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.eq_term(entry eql_v3.jsonb_entry)
   RETURNS bytea
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -15570,13 +15570,13 @@ $$;
 --! @brief Extract CLLW ORE index term from a ste_vec entry.
 --!
 --! `oc` is only ever present on an sv element, never at a root encrypted value,
---! so the typed overload accepts eql_v3.ste_vec_entry. Returns SQL NULL when
+--! so the typed overload accepts eql_v3.jsonb_entry. Returns SQL NULL when
 --! `oc` is absent (btree NULL-filters such rows from range queries).
 --!
---! @param entry eql_v3.ste_vec_entry
+--! @param entry eql_v3.jsonb_entry
 --! @return eql_v3.ore_cllw Composite carrying the CLLW ciphertext, or NULL.
 --! @see eql_v3.has_ore_cllw
-CREATE FUNCTION eql_v3.ore_cllw(entry eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.ore_cllw(entry eql_v3.jsonb_entry)
   RETURNS eql_v3.ore_cllw
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -15586,9 +15586,9 @@ AS $$
 $$;
 
 --! @brief Check if a ste_vec entry contains a CLLW ORE index term.
---! @param entry eql_v3.ste_vec_entry
+--! @param entry eql_v3.jsonb_entry
 --! @return boolean True if `oc` is present and non-null.
-CREATE FUNCTION eql_v3.has_ore_cllw(entry eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.has_ore_cllw(entry eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -15683,6 +15683,11 @@ COMMENT ON FUNCTION eql_v3.jsonb_array(jsonb) IS
 --! @param a jsonb Container payload.
 --! @param b jsonb Search payload.
 --! @return boolean True if a contains all deterministic elements of b.
+--! @note Convenience helper for hand-rolled GIN index expressions over the
+--!       raw extracted `jsonb[]` array (see database-indexes.md). The typed
+--!       `eql_v3.json` `@>`/`<@` operators do NOT call this function — they
+--!       bind to `eql_v3.ste_vec_contains` instead. Public API, reachable
+--!       only from caller-authored SQL.
 CREATE FUNCTION eql_v3.jsonb_contains(a jsonb, b jsonb)
 RETURNS boolean
 IMMUTABLE STRICT PARALLEL SAFE
@@ -15698,6 +15703,11 @@ COMMENT ON FUNCTION eql_v3.jsonb_contains(jsonb, jsonb) IS
 --! @param a jsonb Payload to check.
 --! @param b jsonb Container payload.
 --! @return boolean True if all elements of a are contained in b.
+--! @note Convenience helper for hand-rolled GIN index expressions over the
+--!       raw extracted `jsonb[]` array (see database-indexes.md). The typed
+--!       `eql_v3.json` `@>`/`<@` operators do NOT call this function — they
+--!       bind to `eql_v3.ste_vec_contains` instead. Public API, reachable
+--!       only from caller-authored SQL.
 CREATE FUNCTION eql_v3.jsonb_contained_by(a jsonb, b jsonb)
 RETURNS boolean
 IMMUTABLE STRICT PARALLEL SAFE
@@ -15743,7 +15753,7 @@ AS $$
       _a := a[idx];
       result := result OR (
         eql_v3.selector(_a) = eql_v3.selector(b)
-        AND eql_v3.eq_term(_a::eql_v3.ste_vec_entry) = eql_v3.eq_term(b::eql_v3.ste_vec_entry)
+        AND eql_v3.eq_term(_a::eql_v3.jsonb_entry) = eql_v3.eq_term(b::eql_v3.jsonb_entry)
       );
       EXIT WHEN result;
     END LOOP;
@@ -15800,20 +15810,20 @@ $$ LANGUAGE plpgsql;
 
 --! @brief Query encrypted JSONB for sv elements matching `selector`.
 --!
---! Returns one ste_vec_entry row per matching encrypted element. Returns empty
+--! Returns one jsonb_entry row per matching encrypted element. Returns empty
 --! set on no match. It deliberately does not wrap multiple matches as an
 --! eql_v3.json document, because the root document domain requires an `sv`
---! array and single leaves belong to eql_v3.ste_vec_entry.
+--! array and single leaves belong to eql_v3.jsonb_entry.
 --!
 --! @param val jsonb encrypted EQL payload with `sv`.
 --! @param selector text Selector hash (`s` value).
---! @return SETOF eql_v3.ste_vec_entry Matching encrypted entries.
+--! @return SETOF eql_v3.jsonb_entry Matching encrypted entries.
 --! @see eql_v3.jsonb_path_query_first
 CREATE FUNCTION eql_v3.jsonb_path_query(val jsonb, selector text)
-  RETURNS SETOF eql_v3.ste_vec_entry
+  RETURNS SETOF eql_v3.jsonb_entry
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
-  SELECT (eql_v3.meta_data(val) || elem)::eql_v3.ste_vec_entry
+  SELECT (eql_v3.meta_data(val) || elem)::eql_v3.jsonb_entry
   FROM jsonb_array_elements(val -> 'sv') elem
   WHERE elem ->> 's' = selector
 $$;
@@ -15841,12 +15851,12 @@ COMMENT ON FUNCTION eql_v3.jsonb_path_exists(jsonb, text) IS
 --! @brief Get the first sv element matching `selector`, or NULL.
 --! @param val jsonb encrypted EQL payload.
 --! @param selector text Selector hash to match.
---! @return eql_v3.ste_vec_entry First matching element or NULL.
+--! @return eql_v3.jsonb_entry First matching element or NULL.
 CREATE FUNCTION eql_v3.jsonb_path_query_first(val jsonb, selector text)
-  RETURNS eql_v3.ste_vec_entry
+  RETURNS eql_v3.jsonb_entry
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
-  SELECT (eql_v3.meta_data(val) || elem)::eql_v3.ste_vec_entry
+  SELECT (eql_v3.meta_data(val) || elem)::eql_v3.jsonb_entry
   FROM jsonb_array_elements(val -> 'sv') elem
   WHERE elem ->> 's' = selector
   LIMIT 1
@@ -15882,10 +15892,10 @@ $$ LANGUAGE plpgsql;
 
 --! @brief Extract elements of an encrypted JSONB array as rows.
 --! @param val jsonb encrypted EQL payload (must have `a` flag true).
---! @return SETOF eql_v3.ste_vec_entry One row per element (metadata preserved).
+--! @return SETOF eql_v3.jsonb_entry One row per element (metadata preserved).
 --! @throws Exception 'cannot extract elements from non-array' if not an array.
 CREATE FUNCTION eql_v3.jsonb_array_elements(val jsonb)
-  RETURNS SETOF eql_v3.ste_vec_entry
+  RETURNS SETOF eql_v3.jsonb_entry
   IMMUTABLE STRICT PARALLEL SAFE
   SET search_path = pg_catalog, extensions, public
 AS $$
@@ -15903,7 +15913,7 @@ AS $$
 
     FOR idx IN 1..array_length(sv, 1) LOOP
       item = sv[idx];
-      RETURN NEXT (meta || item)::eql_v3.ste_vec_entry;
+      RETURN NEXT (meta || item)::eql_v3.jsonb_entry;
     END LOOP;
 
     RETURN;
@@ -15973,6 +15983,360 @@ $$ LANGUAGE SQL;
 --! Mirrors eql_v3.version() as a comment on the schema so the installed
 --! version can also be read via obj_description('eql_v3'::regnamespace).
 COMMENT ON SCHEMA eql_v3 IS 'DEV';
+
+--! @brief EQL lint: detect non-inlinable operator implementation functions
+--!
+--! Returns one row per violation found in the installed `eql_v3` surface. The
+--! Postgres planner can only inline a function during index matching when:
+--!
+--!   * `LANGUAGE sql` (plpgsql / C / etc. cannot be inlined)
+--!   * `IMMUTABLE` or `STABLE` volatility (VOLATILE cannot be inlined into
+--!     index expressions)
+--!   * No `SET` clauses (e.g. `SET search_path = ...`)
+--!   * Not `SECURITY DEFINER`
+--!   * Single-statement SELECT body
+--!
+--! @note The single-statement SELECT body condition is **not yet checked** by
+--! this lint. A `LANGUAGE sql` function with a multi-statement body, a CTE,
+--! or any pre-SELECT statement will pass all four implemented checks while
+--! remaining non-inlinable. Implementing the check requires walking `prosrc`
+--! (or `pg_get_functiondef`); tracked as a follow-up.
+--!
+--! Operators on `eql_v3` types (the jsonb-backed encrypted-domain families and
+--! the SEM index-term types `eql_v3.ore_block_256`, `eql_v3.ore_cllw`) whose
+--! implementation functions fail any of these rules silently fall back to seq
+--! scan when the documented functional indexes (`eql_v3.eq_term(col)`,
+--! `eql_v3.ord_term(col)`) are in place. This lint surfaces every such case.
+--!
+--! Severity:
+--!   `error`   — fixable, blocks index matching, ship-blocking.
+--!   `warning` — likely-fixable, may not block matching but signals intent.
+--!   `info`    — observational; useful for review, not a defect on its own.
+--!
+--! Categories:
+--!   `inlinability_language`   — implementation function isn't `LANGUAGE sql`.
+--!   `inlinability_volatility` — implementation function is VOLATILE.
+--!   `inlinability_set_clause` — implementation function has a `SET` clause.
+--!   `inlinability_secdef`     — implementation function is `SECURITY DEFINER`.
+--!   `inlinability_transitive` — implementation function is itself inlinable
+--!                                but its body invokes a non-inlinable function
+--!                                (depth 1; the planner can't peek through
+--!                                that boundary).
+--!   `blocker_language`        — encrypted-domain blocker is not LANGUAGE
+--!                                plpgsql. The planner can inline / elide a
+--!                                LANGUAGE sql body when the result is
+--!                                provably unused, silently bypassing the
+--!                                RAISE that the blocker exists to perform.
+--!   `blocker_strict`          — encrypted-domain blocker is STRICT.
+--!                                PostgreSQL skips the body and returns NULL
+--!                                on NULL arguments, silently bypassing the
+--!                                RAISE.
+--!   `domain_over_domain`      — an `eql_v3` encrypted domain is derived from
+--!                                another encrypted domain rather than jsonb.
+--!                                Operators resolve against the ultimate base
+--!                                type, so the derived domain does not
+--!                                inherit the base domain's blocker surface.
+--!   `domain_opclass`          — an operator class is declared FOR TYPE on an
+--!                                `eql_v3` encrypted domain. Opclasses on
+--!                                domains bypass operator resolution; use a
+--!                                functional index on the extractor instead.
+--!
+--! @example
+--! ```
+--! SELECT severity, category, object_name, message
+--!   FROM eql_v3.lints()
+--!  WHERE severity = 'error'
+--!  ORDER BY category, object_name;
+--! ```
+--!
+--! @return SETOF record (severity text, category text, object_name text, message text)
+CREATE OR REPLACE FUNCTION eql_v3.lints()
+RETURNS TABLE (
+  severity text,
+  category text,
+  object_name text,
+  message text
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH
+  -- All operators where at least one operand is an `eql_v3` type. Limits
+  -- the scope of the lint to the operator surface customers actually hit
+  -- via SQL (`col = val`, `col @> '...'` and friends).
+  eql_operators AS (
+    SELECT
+      op.oid              AS oprid,
+      op.oprname          AS opname,
+      op.oprcode          AS implfunc,
+      op.oprleft::regtype AS lhs,
+      op.oprright::regtype AS rhs,
+      op.oprcode::regprocedure AS impl_signature
+    FROM pg_operator op
+    WHERE EXISTS (
+        SELECT 1 FROM pg_type t
+         WHERE t.oid IN (op.oprleft, op.oprright)
+           AND t.typnamespace = 'eql_v3'::regnamespace
+      )
+  ),
+
+  -- Cross-join with each operator's implementation function metadata.
+  -- One row per operator; columns describe the inlinability of the impl.
+  op_impl AS (
+    SELECT
+      eo.opname,
+      eo.lhs,
+      eo.rhs,
+      eo.implfunc                                  AS impl_oid,
+      eo.impl_signature::text                       AS impl_signature,
+      lang_l.lanname                                AS lang,
+      p.provolatile                                 AS volatility,
+      p.proconfig                                   AS config,
+      p.prosecdef                                   AS secdef,
+      p.prosrc                                      AS body
+    FROM eql_operators eo
+    JOIN pg_proc p ON p.oid = eo.implfunc
+    JOIN pg_language lang_l ON lang_l.oid = p.prolang
+  ),
+
+  -- Encrypted-domain blockers: functions in `eql_v3` whose body contains
+  -- a blocker marker emitted by the codegen (any of the
+  -- `encrypted_domain_unsupported_*` helper calls — `_bool` for boolean
+  -- blockers, `_jsonb` for the native-jsonb-operator blockers; plus the
+  -- literal `is not supported for` for older path-operator blockers) AND
+  -- that take at least one `eql_v3` domain over jsonb argument. The argument
+  -- filter excludes the shared `encrypted_domain_unsupported_*(text, text)`
+  -- helpers themselves, which contain the marker in their body but are not
+  -- blockers (they take text arguments, not a domain).
+  encrypted_domain_blockers AS (
+    SELECT
+      p.oid                                        AS oid,
+      p.oid::regprocedure::text                    AS signature,
+      lang_l.lanname                               AS lang,
+      p.proisstrict                                AS isstrict
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_catalog.pg_language lang_l ON lang_l.oid = p.prolang
+    WHERE n.nspname = 'eql_v3'
+      AND (p.prosrc LIKE '%encrypted_domain_unsupported%'
+        OR p.prosrc LIKE '%is not supported for%')
+      AND EXISTS (
+        SELECT 1
+        FROM pg_catalog.unnest(p.proargtypes::oid[]) AS arg(typ)
+        JOIN pg_catalog.pg_type dt ON dt.oid = arg.typ
+        JOIN pg_catalog.pg_namespace dn ON dn.oid = dt.typnamespace
+        JOIN pg_catalog.pg_type bt ON bt.oid = dt.typbasetype
+        WHERE dt.typtype = 'd'
+          AND bt.typname = 'jsonb'
+          AND dn.nspname = 'eql_v3'
+      )
+  )
+
+  -- ┌─────────────────────────────────────────────────────────────────┐
+  -- │ Direct inlinability checks: each row examines one operator's    │
+  -- │ implementation function and emits a violation if any rule is    │
+  -- │ broken. Multiple violations on the same function become         │
+  -- │ multiple rows (developers see every reason it doesn't inline).  │
+  -- └─────────────────────────────────────────────────────────────────┘
+
+  SELECT
+    'error'                                                             AS severity,
+    'inlinability_language'                                             AS category,
+    format('operator %s(%s, %s) -> %s',
+           opname, lhs, rhs, impl_signature)                            AS object_name,
+    format(
+      'Operator implementation function is `LANGUAGE %s`; only `LANGUAGE sql` functions can be inlined by the planner. Bare `col %s val` queries fall back to seq scan even when a matching functional index exists.',
+      lang, opname)                                                     AS message
+  FROM op_impl
+  WHERE lang <> 'sql'
+    AND NOT EXISTS (
+      SELECT 1 FROM encrypted_domain_blockers b
+      WHERE b.oid = op_impl.impl_oid
+    )
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'inlinability_volatility',
+    format('operator %s(%s, %s) -> %s', opname, lhs, rhs, impl_signature),
+    format(
+      'Operator implementation function is `VOLATILE`. The Postgres planner refuses to inline volatile functions into index expressions, so functional indexes never engage. Mark the function `IMMUTABLE` (or `STABLE` if it depends on session state).',
+      opname)
+  FROM op_impl
+  WHERE volatility = 'v'
+    AND NOT EXISTS (
+      SELECT 1 FROM encrypted_domain_blockers b
+      WHERE b.oid = op_impl.impl_oid
+    )
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'inlinability_set_clause',
+    format('operator %s(%s, %s) -> %s', opname, lhs, rhs, impl_signature),
+    format(
+      'Operator implementation function has a `SET` clause (e.g. `SET search_path = ...`). Per Postgres function-inlining rules, any `SET` clause blocks inlining. Use schema-qualified identifiers in the body and remove the `SET` clause to allow the planner to inline.')
+  FROM op_impl
+  WHERE config IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM encrypted_domain_blockers b
+      WHERE b.oid = op_impl.impl_oid
+    )
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'inlinability_secdef',
+    format('operator %s(%s, %s) -> %s', opname, lhs, rhs, impl_signature),
+    'Operator implementation function is `SECURITY DEFINER`. Such functions cannot be inlined; remove `SECURITY DEFINER` or use a non-inlinable wrapper layer.'
+  FROM op_impl
+  WHERE secdef
+    AND NOT EXISTS (
+      SELECT 1 FROM encrypted_domain_blockers b
+      WHERE b.oid = op_impl.impl_oid
+    )
+
+  -- ┌─────────────────────────────────────────────────────────────────┐
+  -- │ Transitive inlinability: an operator implementation function    │
+  -- │ that's itself inlinable can still fail to inline if its body    │
+  -- │ calls a non-inlinable function. Walk one level via pg_depend.   │
+  -- │                                                                 │
+  -- │ Postgres records function-to-function dependencies in           │
+  -- │ pg_depend with deptype 'n' (normal) when one function references│
+  -- │ another in its body — but only at CREATE time and only for      │
+  -- │ direct calls. This is good enough for v1; deeper transitive     │
+  -- │ analysis is a follow-up.                                        │
+  -- └─────────────────────────────────────────────────────────────────┘
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'inlinability_transitive',
+    format('operator %s(%s, %s) -> %s', oi.opname, oi.lhs, oi.rhs,
+           oi.impl_signature),
+    format(
+      'Operator implementation function is inlinable but invokes non-inlinable function `%s` (lang=%s, volatility=%s%s). The chain blocks at depth 1: the planner inlines the outer call but cannot reduce the inner call into an index expression.',
+      called.proname,
+      called_lang.lanname,
+      CASE called.provolatile
+        WHEN 'i' THEN 'IMMUTABLE'
+        WHEN 's' THEN 'STABLE'
+        WHEN 'v' THEN 'VOLATILE'
+      END,
+      CASE WHEN called.proconfig IS NOT NULL
+           THEN ', has SET clause'
+           ELSE '' END)
+  FROM op_impl oi
+  -- Only worth the transitive check if the outer function is otherwise
+  -- inlinable — otherwise the direct lints above already report it.
+  JOIN pg_proc outer_p ON outer_p.oid = oi.impl_signature::regprocedure
+  JOIN pg_depend d
+    ON d.classid = 'pg_proc'::regclass
+   AND d.objid = outer_p.oid
+   AND d.refclassid = 'pg_proc'::regclass
+   AND d.deptype = 'n'
+  JOIN pg_proc called ON called.oid = d.refobjid
+  JOIN pg_language called_lang ON called_lang.oid = called.prolang
+  WHERE oi.lang = 'sql'
+    AND oi.volatility IN ('i', 's')
+    AND oi.config IS NULL
+    AND NOT oi.secdef
+    AND called.oid <> outer_p.oid
+    AND (
+         called_lang.lanname <> 'sql'
+      OR called.provolatile = 'v'
+      OR called.proconfig IS NOT NULL
+      OR called.prosecdef
+    )
+
+  -- ┌─────────────────────────────────────────────────────────────────┐
+  -- │ Encrypted-domain footguns: blockers exist to RAISE, so they     │
+  -- │ have inverted inlinability requirements vs operator impls.      │
+  -- │ A LANGUAGE sql blocker can be elided by the planner; a STRICT   │
+  -- │ blocker returns NULL on NULL args. Both silently re-enable      │
+  -- │ operators the storage variant is supposed to block.             │
+  -- └─────────────────────────────────────────────────────────────────┘
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'blocker_language',
+    format('function %s', signature),
+    format(
+      'Encrypted-domain blocker is `LANGUAGE %s`; must be `LANGUAGE plpgsql` so the RAISE is opaque to the planner. A `LANGUAGE sql` body is inlinable and may be elided when the result is provably unused, silently re-enabling the operator.',
+      lang)
+  FROM encrypted_domain_blockers
+  WHERE lang <> 'plpgsql'
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'blocker_strict',
+    format('function %s', signature),
+    'Encrypted-domain blocker is `STRICT`. PostgreSQL skips the body and returns NULL on a NULL argument, silently bypassing the RAISE. Remove `STRICT`.'
+  FROM encrypted_domain_blockers
+  WHERE isstrict
+
+  -- ┌─────────────────────────────────────────────────────────────────┐
+  -- │ Domain identity: an encrypted-domain must be defined directly   │
+  -- │ over jsonb. Operators resolve against the ultimate base type,   │
+  -- │ so domain-over-domain inherits jsonb's operator surface and not │
+  -- │ the base domain's blockers.                                     │
+  -- └─────────────────────────────────────────────────────────────────┘
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'domain_over_domain',
+    format('domain %I.%I', dn.nspname, dt.typname),
+    format(
+      'Domain `%s.%s` is derived from another encrypted-domain `%s.%s` rather than jsonb. Operators resolve against the ultimate base type, so the derived domain does not inherit the base domain''s operator surface and storage blockers do not engage. Define this domain directly over jsonb.',
+      dn.nspname, dt.typname, bn.nspname, bt.typname)
+  FROM pg_catalog.pg_type dt
+  JOIN pg_catalog.pg_namespace dn ON dn.oid = dt.typnamespace
+  JOIN pg_catalog.pg_type bt ON bt.oid = dt.typbasetype
+  JOIN pg_catalog.pg_namespace bn ON bn.oid = bt.typnamespace
+  WHERE dt.typtype = 'd'
+    AND dn.nspname = 'eql_v3'
+    AND bt.typtype = 'd'
+    AND bn.nspname = 'eql_v3'
+
+  -- ┌─────────────────────────────────────────────────────────────────┐
+  -- │ Domain opclass: an operator class declared FOR TYPE on an       │
+  -- │ encrypted-domain bypasses operator resolution at index time.    │
+  -- │ Use a functional index on the extractor instead.                │
+  -- └─────────────────────────────────────────────────────────────────┘
+
+  UNION ALL
+
+  SELECT
+    'error',
+    'domain_opclass',
+    format('opclass %I.%I FOR TYPE %s.%s', cn.nspname, oc.opcname, tn.nspname, t.typname),
+    format(
+      'Operator class `%s.%s` is declared FOR TYPE `%s.%s`, which is an encrypted-domain type. Opclasses on domains bypass operator resolution. Use a functional index on the extractor (e.g. `%s.eq_term(col)`, `%s.ord_term(col)`) instead.',
+      cn.nspname, oc.opcname, tn.nspname, t.typname, tn.nspname, tn.nspname)
+  FROM pg_catalog.pg_opclass oc
+  JOIN pg_catalog.pg_type t ON t.oid = oc.opcintype
+  JOIN pg_catalog.pg_namespace tn ON tn.oid = t.typnamespace
+  JOIN pg_catalog.pg_namespace cn ON cn.oid = oc.opcnamespace
+  WHERE t.typtype = 'd'
+    AND tn.nspname = 'eql_v3'
+
+  ORDER BY 1, 2, 3;
+$$;
+
+COMMENT ON FUNCTION eql_v3.lints() IS
+  'EQL lint: returns one row per non-inlinable operator implementation. '
+  'Run `SELECT * FROM eql_v3.lints() WHERE severity = ''error''` for a '
+  'CI-gateable check that all operator implementations on eql_v3 types are '
+  'eligible for planner inlining.';
 -- AUTOMATICALLY GENERATED FILE.
 
 --! @file encrypted_domain/int4/int4_ord_aggregates.sql
@@ -17574,976 +17938,6 @@ CREATE AGGREGATE eql_v3.max(eql_v3.int4_ord_ore) (
   stype = eql_v3.int4_ord_ore,
   combinefunc = eql_v3.max_sfunc,
   parallel = safe
-);
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_ore_aggregates.sql
---! @brief Aggregates for eql_v3.timestamptz_ord_ore.
-
---! @brief State function for min on eql_v3.timestamptz_ord_ore.
---! @param state eql_v3.timestamptz_ord_ore
---! @param value eql_v3.timestamptz_ord_ore
---! @return eql_v3.timestamptz_ord_ore
-CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.timestamptz_ord_ore, value eql_v3.timestamptz_ord_ore)
-RETURNS eql_v3.timestamptz_ord_ore
-LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
-SET search_path = pg_catalog, extensions, public
-AS $$
-BEGIN
-  IF value < state THEN
-    RETURN value;
-  END IF;
-  RETURN state;
-END;
-$$;
-
---! @brief min aggregate for eql_v3.timestamptz_ord_ore.
---! @param input eql_v3.timestamptz_ord_ore
---! @return eql_v3.timestamptz_ord_ore
-CREATE AGGREGATE eql_v3.min(eql_v3.timestamptz_ord_ore) (
-  sfunc = eql_v3.min_sfunc,
-  stype = eql_v3.timestamptz_ord_ore,
-  combinefunc = eql_v3.min_sfunc,
-  parallel = safe
-);
-
---! @brief State function for max on eql_v3.timestamptz_ord_ore.
---! @param state eql_v3.timestamptz_ord_ore
---! @param value eql_v3.timestamptz_ord_ore
---! @return eql_v3.timestamptz_ord_ore
-CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.timestamptz_ord_ore, value eql_v3.timestamptz_ord_ore)
-RETURNS eql_v3.timestamptz_ord_ore
-LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
-SET search_path = pg_catalog, extensions, public
-AS $$
-BEGIN
-  IF value > state THEN
-    RETURN value;
-  END IF;
-  RETURN state;
-END;
-$$;
-
---! @brief max aggregate for eql_v3.timestamptz_ord_ore.
---! @param input eql_v3.timestamptz_ord_ore
---! @return eql_v3.timestamptz_ord_ore
-CREATE AGGREGATE eql_v3.max(eql_v3.timestamptz_ord_ore) (
-  sfunc = eql_v3.max_sfunc,
-  stype = eql_v3.timestamptz_ord_ore,
-  combinefunc = eql_v3.max_sfunc,
-  parallel = safe
-);
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_functions.sql
---! @brief Functions for eql_v3.timestamptz.
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b jsonb)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return boolean
-CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param selector text
---! @return eql_v3.timestamptz
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector text)
-RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param selector integer
---! @return eql_v3.timestamptz
-CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector integer)
-RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param selector eql_v3.timestamptz
---! @return eql_v3.timestamptz
-CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz)
-RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param selector text
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector text)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param selector integer
---! @return text
-CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector integer)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param selector eql_v3.timestamptz
---! @return text
-CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz)
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text
---! @return boolean
-CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz, b text)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return boolean
-CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz, b text[])
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonpath
---! @return boolean
-CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz, b jsonpath)
-RETURNS boolean IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return text
-CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz, b text[])
-RETURNS text IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b integer
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b integer)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b text[]
---! @return jsonb
-CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz, b text[])
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b eql_v3.timestamptz
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b eql_v3.timestamptz)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a eql_v3.timestamptz
---! @param b jsonb
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b jsonb)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
-
---! @brief Unsupported operator blocker for eql_v3.timestamptz.
---! @param a jsonb
---! @param b eql_v3.timestamptz
---! @return jsonb
-CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz)
-RETURNS jsonb IMMUTABLE PARALLEL SAFE
-AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
-LANGUAGE plpgsql;
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_eq_operators.sql
---! @brief Operators for eql_v3.timestamptz_eq.
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
-  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
-  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR ? (
-  FUNCTION = eql_v3."?",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
-);
-
-CREATE OPERATOR ?| (
-  FUNCTION = eql_v3."?|",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR ?& (
-  FUNCTION = eql_v3."?&",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR @? (
-  FUNCTION = eql_v3."@?",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR @@ (
-  FUNCTION = eql_v3."@@",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR #> (
-  FUNCTION = eql_v3."#>",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #>> (
-  FUNCTION = eql_v3."#>>",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #- (
-  FUNCTION = eql_v3."#-",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
-);
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_ord_aggregates.sql
---! @brief Aggregates for eql_v3.timestamptz_ord.
-
---! @brief State function for min on eql_v3.timestamptz_ord.
---! @param state eql_v3.timestamptz_ord
---! @param value eql_v3.timestamptz_ord
---! @return eql_v3.timestamptz_ord
-CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.timestamptz_ord, value eql_v3.timestamptz_ord)
-RETURNS eql_v3.timestamptz_ord
-LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
-SET search_path = pg_catalog, extensions, public
-AS $$
-BEGIN
-  IF value < state THEN
-    RETURN value;
-  END IF;
-  RETURN state;
-END;
-$$;
-
---! @brief min aggregate for eql_v3.timestamptz_ord.
---! @param input eql_v3.timestamptz_ord
---! @return eql_v3.timestamptz_ord
-CREATE AGGREGATE eql_v3.min(eql_v3.timestamptz_ord) (
-  sfunc = eql_v3.min_sfunc,
-  stype = eql_v3.timestamptz_ord,
-  combinefunc = eql_v3.min_sfunc,
-  parallel = safe
-);
-
---! @brief State function for max on eql_v3.timestamptz_ord.
---! @param state eql_v3.timestamptz_ord
---! @param value eql_v3.timestamptz_ord
---! @return eql_v3.timestamptz_ord
-CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.timestamptz_ord, value eql_v3.timestamptz_ord)
-RETURNS eql_v3.timestamptz_ord
-LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
-SET search_path = pg_catalog, extensions, public
-AS $$
-BEGIN
-  IF value > state THEN
-    RETURN value;
-  END IF;
-  RETURN state;
-END;
-$$;
-
---! @brief max aggregate for eql_v3.timestamptz_ord.
---! @param input eql_v3.timestamptz_ord
---! @return eql_v3.timestamptz_ord
-CREATE AGGREGATE eql_v3.max(eql_v3.timestamptz_ord) (
-  sfunc = eql_v3.max_sfunc,
-  stype = eql_v3.timestamptz_ord,
-  combinefunc = eql_v3.max_sfunc,
-  parallel = safe
-);
--- AUTOMATICALLY GENERATED FILE.
-
---! @file encrypted_domain/timestamptz/timestamptz_operators.sql
---! @brief Operators for eql_v3.timestamptz.
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR = (
-  FUNCTION = eql_v3.eq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <> (
-  FUNCTION = eql_v3.neq,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR < (
-  FUNCTION = eql_v3.lt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <= (
-  FUNCTION = eql_v3.lte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR > (
-  FUNCTION = eql_v3.gt,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR >= (
-  FUNCTION = eql_v3.gte,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR @> (
-  FUNCTION = eql_v3.contains,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR <@ (
-  FUNCTION = eql_v3.contained_by,
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
-);
-
-CREATE OPERATOR -> (
-  FUNCTION = eql_v3."->",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
-);
-
-CREATE OPERATOR ->> (
-  FUNCTION = eql_v3."->>",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR ? (
-  FUNCTION = eql_v3."?",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
-);
-
-CREATE OPERATOR ?| (
-  FUNCTION = eql_v3."?|",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR ?& (
-  FUNCTION = eql_v3."?&",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR @? (
-  FUNCTION = eql_v3."@?",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR @@ (
-  FUNCTION = eql_v3."@@",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
-);
-
-CREATE OPERATOR #> (
-  FUNCTION = eql_v3."#>",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #>> (
-  FUNCTION = eql_v3."#>>",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
-);
-
-CREATE OPERATOR - (
-  FUNCTION = eql_v3."-",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR #- (
-  FUNCTION = eql_v3."#-",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
-);
-
-CREATE OPERATOR || (
-  FUNCTION = eql_v3."||",
-  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
 );
 -- AUTOMATICALLY GENERATED FILE.
 
@@ -28081,6 +27475,976 @@ CREATE OPERATOR || (
   FUNCTION = eql_v3."||",
   LEFTARG = jsonb, RIGHTARG = eql_v3.float4
 );
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_functions.sql
+--! @brief Functions for eql_v3.timestamp.
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamp, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamp)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param selector text
+--! @return eql_v3.timestamp
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp, selector text)
+RETURNS eql_v3.timestamp IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param selector integer
+--! @return eql_v3.timestamp
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamp, selector integer)
+RETURNS eql_v3.timestamp IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp
+--! @return eql_v3.timestamp
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamp)
+RETURNS eql_v3.timestamp IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamp, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param selector eql_v3.timestamp
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamp)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamp, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamp, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamp, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamp, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamp, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamp, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamp, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamp, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamp, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b eql_v3.timestamp
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp, b eql_v3.timestamp)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a eql_v3.timestamp
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamp, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamp.
+--! @param a jsonb
+--! @param b eql_v3.timestamp
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamp)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamp'; END; $$
+LANGUAGE plpgsql;
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.timestamp_ord.
+
+--! @brief State function for min on eql_v3.timestamp_ord.
+--! @param state eql_v3.timestamp_ord
+--! @param value eql_v3.timestamp_ord
+--! @return eql_v3.timestamp_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.timestamp_ord, value eql_v3.timestamp_ord)
+RETURNS eql_v3.timestamp_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.timestamp_ord.
+--! @param input eql_v3.timestamp_ord
+--! @return eql_v3.timestamp_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.timestamp_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.timestamp_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.timestamp_ord.
+--! @param state eql_v3.timestamp_ord
+--! @param value eql_v3.timestamp_ord
+--! @return eql_v3.timestamp_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.timestamp_ord, value eql_v3.timestamp_ord)
+RETURNS eql_v3.timestamp_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.timestamp_ord.
+--! @param input eql_v3.timestamp_ord
+--! @return eql_v3.timestamp_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.timestamp_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.timestamp_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_eq_operators.sql
+--! @brief Operators for eql_v3.timestamp_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = eql_v3.timestamp_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp_eq
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.timestamp_ord_ore.
+
+--! @brief State function for min on eql_v3.timestamp_ord_ore.
+--! @param state eql_v3.timestamp_ord_ore
+--! @param value eql_v3.timestamp_ord_ore
+--! @return eql_v3.timestamp_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.timestamp_ord_ore, value eql_v3.timestamp_ord_ore)
+RETURNS eql_v3.timestamp_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.timestamp_ord_ore.
+--! @param input eql_v3.timestamp_ord_ore
+--! @return eql_v3.timestamp_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.timestamp_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.timestamp_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.timestamp_ord_ore.
+--! @param state eql_v3.timestamp_ord_ore
+--! @param value eql_v3.timestamp_ord_ore
+--! @return eql_v3.timestamp_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.timestamp_ord_ore, value eql_v3.timestamp_ord_ore)
+RETURNS eql_v3.timestamp_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.timestamp_ord_ore.
+--! @param input eql_v3.timestamp_ord_ore
+--! @return eql_v3.timestamp_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.timestamp_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.timestamp_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);
+-- AUTOMATICALLY GENERATED FILE.
+
+--! @file encrypted_domain/timestamp/timestamp_operators.sql
+--! @brief Operators for eql_v3.timestamp.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = eql_v3.timestamp
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamp, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamp
+);
 
 --! @file v3/sem/ore_block_256/operator_class.sql
 --! @brief B-tree operator family + default class on eql_v3.ore_block_256.
@@ -28294,7 +28658,7 @@ CREATE OPERATOR CLASS eql_v3.ore_cllw_ops
     FUNCTION 1 eql_v3.compare_ore_cllw_term(eql_v3.ore_cllw, eql_v3.ore_cllw);
 
 --! @file v3/jsonb/aggregates.sql
---! @brief min / max aggregates over eql_v3.ste_vec_entry.
+--! @brief min / max aggregates over eql_v3.jsonb_entry.
 --!
 --! SteVec document entries extracted at a selector (`doc -> 'sel'`) order by
 --! their CLLW ORE (`oc`) term, so the extremum is picked by comparing
@@ -28318,20 +28682,20 @@ CREATE OPERATOR CLASS eql_v3.ore_cllw_ops
 --!   row is `oc`-less. An all-`oc`-less input has no orderable extremum and
 --!   returns the (arbitrary) STRICT seed.
 
---! @brief State function for min on eql_v3.ste_vec_entry.
+--! @brief State function for min on eql_v3.jsonb_entry.
 --!
 --! Keeps whichever orderable entry has the lesser CLLW ORE term. STRICT, so SQL
 --! NULL entries are skipped by the aggregate machinery; `oc`-less (non-orderable)
 --! entries are skipped explicitly (see the @note on this file).
 --!
---! @param state eql_v3.ste_vec_entry Running extremum.
---! @param value eql_v3.ste_vec_entry Candidate entry.
---! @return eql_v3.ste_vec_entry The lesser orderable entry by `ore_cllw`.
-CREATE FUNCTION eql_v3.ste_vec_entry_min_sfunc(
-  state eql_v3.ste_vec_entry,
-  value eql_v3.ste_vec_entry
+--! @param state eql_v3.jsonb_entry Running extremum.
+--! @param value eql_v3.jsonb_entry Candidate entry.
+--! @return eql_v3.jsonb_entry The lesser orderable entry by `ore_cllw`.
+CREATE FUNCTION eql_v3.jsonb_entry_min_sfunc(
+  state eql_v3.jsonb_entry,
+  value eql_v3.jsonb_entry
 )
-RETURNS eql_v3.ste_vec_entry
+RETURNS eql_v3.jsonb_entry
 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
 SET search_path = pg_catalog, extensions, public
 AS $$
@@ -28352,29 +28716,29 @@ BEGIN
 END;
 $$;
 
---! @brief min aggregate over eql_v3.ste_vec_entry.
---! @param input eql_v3.ste_vec_entry
---! @return eql_v3.ste_vec_entry The entry with the smallest CLLW ORE term.
-CREATE AGGREGATE eql_v3.min(eql_v3.ste_vec_entry) (
-  sfunc = eql_v3.ste_vec_entry_min_sfunc,
-  stype = eql_v3.ste_vec_entry,
-  combinefunc = eql_v3.ste_vec_entry_min_sfunc,
+--! @brief min aggregate over eql_v3.jsonb_entry.
+--! @param input eql_v3.jsonb_entry
+--! @return eql_v3.jsonb_entry The entry with the smallest CLLW ORE term.
+CREATE AGGREGATE eql_v3.min(eql_v3.jsonb_entry) (
+  sfunc = eql_v3.jsonb_entry_min_sfunc,
+  stype = eql_v3.jsonb_entry,
+  combinefunc = eql_v3.jsonb_entry_min_sfunc,
   parallel = safe
 );
 
---! @brief State function for max on eql_v3.ste_vec_entry.
+--! @brief State function for max on eql_v3.jsonb_entry.
 --!
 --! Keeps whichever orderable entry has the greater CLLW ORE term. `oc`-less
---! entries are skipped, mirroring `ste_vec_entry_min_sfunc` (see the file @note).
+--! entries are skipped, mirroring `jsonb_entry_min_sfunc` (see the file @note).
 --!
---! @param state eql_v3.ste_vec_entry Running extremum.
---! @param value eql_v3.ste_vec_entry Candidate entry.
---! @return eql_v3.ste_vec_entry The greater orderable entry by `ore_cllw`.
-CREATE FUNCTION eql_v3.ste_vec_entry_max_sfunc(
-  state eql_v3.ste_vec_entry,
-  value eql_v3.ste_vec_entry
+--! @param state eql_v3.jsonb_entry Running extremum.
+--! @param value eql_v3.jsonb_entry Candidate entry.
+--! @return eql_v3.jsonb_entry The greater orderable entry by `ore_cllw`.
+CREATE FUNCTION eql_v3.jsonb_entry_max_sfunc(
+  state eql_v3.jsonb_entry,
+  value eql_v3.jsonb_entry
 )
-RETURNS eql_v3.ste_vec_entry
+RETURNS eql_v3.jsonb_entry
 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
 SET search_path = pg_catalog, extensions, public
 AS $$
@@ -28395,21 +28759,21 @@ BEGIN
 END;
 $$;
 
---! @brief max aggregate over eql_v3.ste_vec_entry.
---! @param input eql_v3.ste_vec_entry
---! @return eql_v3.ste_vec_entry The entry with the largest CLLW ORE term.
-CREATE AGGREGATE eql_v3.max(eql_v3.ste_vec_entry) (
-  sfunc = eql_v3.ste_vec_entry_max_sfunc,
-  stype = eql_v3.ste_vec_entry,
-  combinefunc = eql_v3.ste_vec_entry_max_sfunc,
+--! @brief max aggregate over eql_v3.jsonb_entry.
+--! @param input eql_v3.jsonb_entry
+--! @return eql_v3.jsonb_entry The entry with the largest CLLW ORE term.
+CREATE AGGREGATE eql_v3.max(eql_v3.jsonb_entry) (
+  sfunc = eql_v3.jsonb_entry_max_sfunc,
+  stype = eql_v3.jsonb_entry,
+  combinefunc = eql_v3.jsonb_entry_max_sfunc,
   parallel = safe
 );
 
 --! @file v3/jsonb/operators.sql
---! @brief Operators on eql_v3.json and eql_v3.ste_vec_entry.
+--! @brief Operators on eql_v3.json and eql_v3.jsonb_entry.
 
 ------------------------------------------------------------------------------
--- -> field accessor (returns ste_vec_entry)
+-- -> field accessor (returns jsonb_entry)
 ------------------------------------------------------------------------------
 
 --! @brief -> operator with text selector.
@@ -28431,9 +28795,9 @@ CREATE AGGREGATE eql_v3.max(eql_v3.ste_vec_entry) (
 --!
 --! @param e eql_v3.json Root encrypted payload.
 --! @param selector text Selector hash.
---! @return eql_v3.ste_vec_entry Matching entry merged with root meta, or NULL.
+--! @return eql_v3.jsonb_entry Matching entry merged with root meta, or NULL.
 CREATE FUNCTION eql_v3."->"(e eql_v3.json, selector text)
-  RETURNS eql_v3.ste_vec_entry
+  RETURNS eql_v3.jsonb_entry
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
   SELECT (
@@ -28443,7 +28807,7 @@ AS $$
       '$.sv[*] ? (@.s == $sel)'::jsonpath,
       jsonb_build_object('sel', selector)
     )
-  )::eql_v3.ste_vec_entry
+  )::eql_v3.jsonb_entry
 $$;
 
 CREATE OPERATOR ->(
@@ -28455,18 +28819,21 @@ CREATE OPERATOR ->(
 --! @brief -> operator with integer array index (0-based, JSONB convention).
 --! @param e eql_v3.json Encrypted sv-array payload.
 --! @param selector integer Array index.
---! @return eql_v3.ste_vec_entry Matching entry merged with root meta, or NULL.
+--! @return eql_v3.jsonb_entry Matching entry merged with root meta, or NULL.
 CREATE FUNCTION eql_v3."->"(e eql_v3.json, selector integer)
-  RETURNS eql_v3.ste_vec_entry
+  RETURNS eql_v3.jsonb_entry
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
   SELECT CASE
     WHEN eql_v3.is_ste_vec_array(e) THEN
-      -- `->(eql_v3.json, text)` operator is already created earlier in
-      -- this file, so a bare `e -> 'sv'` would resolve to that selector-lookup
-      -- operator (searching for an sv entry with selector 'sv') instead of
-      -- native jsonb array access. Casting to jsonb forces native `->`.
-      (eql_v3.meta_data(e) || (e::jsonb -> 'sv' -> selector))::eql_v3.ste_vec_entry
+      -- NOTE: `e::jsonb` makes the native-jsonb traversal explicit. `'sv'` is an
+      -- unknown-typed literal, so `e -> 'sv'` already flattens `eql_v3.json` to
+      -- its base type and binds native `jsonb -> text` (see the @warning above) —
+      -- the custom `->(eql_v3.json, text)` operator does NOT capture a bare
+      -- untyped literal. The cast documents that intent and guards the `-> selector`
+      -- (integer) hop from ever resolving to the v3 `->(eql_v3.json, integer)`
+      -- operator instead of native array access.
+      (eql_v3.meta_data(e) || (e::jsonb -> 'sv' -> selector))::eql_v3.jsonb_entry
     ELSE NULL
   END
 $$;
@@ -28484,7 +28851,7 @@ CREATE OPERATOR ->(
 --! @brief ->> operator with text selector. Inlinable alias of -> coerced to
 --!        text.
 --!
---! Intentional v2 parity: this serializes the entire matched ste_vec_entry
+--! Intentional v2 parity: this serializes the entire matched jsonb_entry
 --! object as JSON text. It does not decrypt or return scalar plaintext like
 --! native `jsonb ->>`.
 --! @param e eql_v3.json Encrypted payload.
@@ -28543,15 +28910,15 @@ CREATE OPERATOR @>(
   RIGHTARG=eql_v3.json
 );
 
---! @brief @> contains operator with an ste_vec_query needle.
+--! @brief @> contains operator with an jsonb_query needle.
 --!
 --! Inlines to native `jsonb @>` over `eql_v3.to_ste_vec_query(a)::jsonb`, so a
 --! functional GIN index on the same expression engages.
 --!
 --! @param a eql_v3.json Container.
---! @param b eql_v3.ste_vec_query Query payload.
+--! @param b eql_v3.jsonb_query Query payload.
 --! @return boolean True if a contains b.
-CREATE FUNCTION eql_v3."@>"(a eql_v3.json, b eql_v3.ste_vec_query)
+CREATE FUNCTION eql_v3."@>"(a eql_v3.json, b eql_v3.jsonb_query)
 RETURNS boolean
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28561,18 +28928,18 @@ $$;
 CREATE OPERATOR @>(
   FUNCTION=eql_v3."@>",
   LEFTARG=eql_v3.json,
-  RIGHTARG=eql_v3.ste_vec_query
+  RIGHTARG=eql_v3.jsonb_query
 );
 
---! @brief @> contains operator with a single ste_vec_entry needle.
+--! @brief @> contains operator with a single jsonb_entry needle.
 --!
 --! Wraps the entry into a single-element sv array (stripping `c`) and reduces
 --! to the same `to_ste_vec_query(a)::jsonb @> needle::jsonb` form.
 --!
 --! @param a eql_v3.json Container.
---! @param b eql_v3.ste_vec_entry Single entry.
+--! @param b eql_v3.jsonb_entry Single entry.
 --! @return boolean True if a contains an sv entry matching b.
-CREATE FUNCTION eql_v3."@>"(a eql_v3.json, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3."@>"(a eql_v3.json, b eql_v3.jsonb_entry)
 RETURNS boolean
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28594,7 +28961,7 @@ $$;
 CREATE OPERATOR @>(
   FUNCTION=eql_v3."@>",
   LEFTARG=eql_v3.json,
-  RIGHTARG=eql_v3.ste_vec_entry
+  RIGHTARG=eql_v3.jsonb_entry
 );
 
 ------------------------------------------------------------------------------
@@ -28618,11 +28985,11 @@ CREATE OPERATOR <@(
   RIGHTARG=eql_v3.json
 );
 
---! @brief <@ contained-by operator with an ste_vec_query LHS.
---! @param a eql_v3.ste_vec_query Query payload.
+--! @brief <@ contained-by operator with an jsonb_query LHS.
+--! @param a eql_v3.jsonb_query Query payload.
 --! @param b eql_v3.json Container.
 --! @return boolean True if b contains a.
-CREATE FUNCTION eql_v3."<@"(a eql_v3.ste_vec_query, b eql_v3.json)
+CREATE FUNCTION eql_v3."<@"(a eql_v3.jsonb_query, b eql_v3.json)
 RETURNS boolean
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28631,15 +28998,15 @@ $$;
 
 CREATE OPERATOR <@(
   FUNCTION=eql_v3."<@",
-  LEFTARG=eql_v3.ste_vec_query,
+  LEFTARG=eql_v3.jsonb_query,
   RIGHTARG=eql_v3.json
 );
 
---! @brief <@ contained-by operator with a ste_vec_entry LHS.
---! @param a eql_v3.ste_vec_entry Single entry.
+--! @brief <@ contained-by operator with a jsonb_entry LHS.
+--! @param a eql_v3.jsonb_entry Single entry.
 --! @param b eql_v3.json Container.
 --! @return boolean True if b contains a.
-CREATE FUNCTION eql_v3."<@"(a eql_v3.ste_vec_entry, b eql_v3.json)
+CREATE FUNCTION eql_v3."<@"(a eql_v3.jsonb_entry, b eql_v3.json)
 RETURNS boolean
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28648,20 +29015,20 @@ $$;
 
 CREATE OPERATOR <@(
   FUNCTION=eql_v3."<@",
-  LEFTARG=eql_v3.ste_vec_entry,
+  LEFTARG=eql_v3.jsonb_entry,
   RIGHTARG=eql_v3.json
 );
 
 ------------------------------------------------------------------------------
--- ste_vec_entry comparisons
+-- jsonb_entry comparisons
 ------------------------------------------------------------------------------
 
---! @brief Equality on ste_vec_entry via eq_term (hm-or-oc byte equality).
+--! @brief Equality on jsonb_entry via eq_term (hm-or-oc byte equality).
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if the entries are equal
-CREATE FUNCTION eql_v3.eq(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.eq(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28670,20 +29037,20 @@ $$;
 
 CREATE OPERATOR = (
   FUNCTION = eql_v3.eq,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = =,
   NEGATOR  = <>,
   RESTRICT = eqsel,
   JOIN     = eqjoinsel
 );
 
---! @brief Inequality on ste_vec_entry via eq_term.
+--! @brief Inequality on jsonb_entry via eq_term.
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if the entries are not equal
-CREATE FUNCTION eql_v3.neq(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.neq(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28692,20 +29059,20 @@ $$;
 
 CREATE OPERATOR <> (
   FUNCTION = eql_v3.neq,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = <>,
   NEGATOR  = =,
   RESTRICT = neqsel,
   JOIN     = neqjoinsel
 );
 
---! @brief Less-than on ste_vec_entry via ore_cllw.
+--! @brief Less-than on jsonb_entry via ore_cllw.
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if a is less than b
-CREATE FUNCTION eql_v3.lt(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.lt(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28714,20 +29081,20 @@ $$;
 
 CREATE OPERATOR < (
   FUNCTION = eql_v3.lt,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = >,
   NEGATOR  = >=,
   RESTRICT = scalarltsel,
   JOIN     = scalarltjoinsel
 );
 
---! @brief Less-than-or-equal on ste_vec_entry via ore_cllw.
+--! @brief Less-than-or-equal on jsonb_entry via ore_cllw.
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if a is less than or equal to b
-CREATE FUNCTION eql_v3.lte(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.lte(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28736,20 +29103,20 @@ $$;
 
 CREATE OPERATOR <= (
   FUNCTION = eql_v3.lte,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = >=,
   NEGATOR  = >,
   RESTRICT = scalarlesel,
   JOIN     = scalarlejoinsel
 );
 
---! @brief Greater-than on ste_vec_entry via ore_cllw.
+--! @brief Greater-than on jsonb_entry via ore_cllw.
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if a is greater than b
-CREATE FUNCTION eql_v3.gt(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.gt(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28758,20 +29125,20 @@ $$;
 
 CREATE OPERATOR > (
   FUNCTION = eql_v3.gt,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = <,
   NEGATOR  = <=,
   RESTRICT = scalargtsel,
   JOIN     = scalargtjoinsel
 );
 
---! @brief Greater-than-or-equal on ste_vec_entry via ore_cllw.
+--! @brief Greater-than-or-equal on jsonb_entry via ore_cllw.
 --! @internal
---! @param a eql_v3.ste_vec_entry Left operand
---! @param b eql_v3.ste_vec_entry Right operand
+--! @param a eql_v3.jsonb_entry Left operand
+--! @param b eql_v3.jsonb_entry Right operand
 --! @return boolean True if a is greater than or equal to b
-CREATE FUNCTION eql_v3.gte(a eql_v3.ste_vec_entry, b eql_v3.ste_vec_entry)
+CREATE FUNCTION eql_v3.gte(a eql_v3.jsonb_entry, b eql_v3.jsonb_entry)
   RETURNS boolean
   LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -28780,8 +29147,8 @@ $$;
 
 CREATE OPERATOR >= (
   FUNCTION = eql_v3.gte,
-  LEFTARG  = eql_v3.ste_vec_entry,
-  RIGHTARG = eql_v3.ste_vec_entry,
+  LEFTARG  = eql_v3.jsonb_entry,
+  RIGHTARG = eql_v3.jsonb_entry,
   COMMUTATOR = <=,
   NEGATOR  = <,
   RESTRICT = scalargesel,
@@ -28792,7 +29159,7 @@ CREATE OPERATOR >= (
 --! @brief Native-jsonb firewall for eql_v3.json.
 --!
 --! eql_v3.json SUPPORTS @> <@ -> ->> (see operators.sql). Comparisons
---! = <> < <= > >= are supported on eql_v3.ste_vec_entry only, not on the root
+--! = <> < <= > >= are supported on eql_v3.jsonb_entry only, not on the root
 --! document domain.
 --! Every OTHER native jsonb operator reachable via domain fallback against the
 --! base type jsonb is BLOCKED here so an encrypted column can never silently
@@ -29306,3 +29673,105 @@ CREATE OPERATOR <@ (
   LEFTARG = jsonb,
   RIGHTARG = eql_v3.json
 );
+--! @file pin_search_path_v3.sql
+--! @brief Post-install: pin search_path on every eql_v3.* function.
+--!
+--! Appended verbatim by `tasks/build.sh` to the end of the v3-only release
+--! artifact, AFTER all src/v3/**/*.sql files have been concatenated. It lives
+--! outside src/ so it stays out of the dependency graph.
+--!
+--! Iterates over functions in the `eql_v3` schema and applies a fixed
+--! `search_path` via `ALTER FUNCTION ... SET search_path = ...`, satisfying
+--! Supabase splinter's `function_search_path_mutable` lint.
+--!
+--! @note A SET clause disables SQL-function inlining. The inline-critical SEM
+--!       helpers (ore_block_256_*, ore_cllw_*, ore_cllw/has_ore_cllw,
+--!       hmac_256, bloom_filter over jsonb) and the encrypted-domain family
+--!       (recognised structurally) are deliberately left unpinned.
+--! @see tasks/test/splinter.sh
+--! @see tasks/build.sh
+
+DO $$
+DECLARE
+  fn_oid oid;
+  inline_critical_oids oid[];
+  jsonb_oid oid;
+BEGIN
+  SELECT t.oid INTO jsonb_oid
+  FROM pg_catalog.pg_type t
+  JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+  WHERE n.nspname = 'pg_catalog' AND t.typname = 'jsonb';
+
+  IF jsonb_oid IS NULL THEN
+    RAISE EXCEPTION 'pin_search_path_v3: type pg_catalog.jsonb not found';
+  END IF;
+
+  -- eql_v3 SEM index-term functions that must stay inlinable for
+  -- functional-index matching (no SET, IMMUTABLE). Mirrors the eql_v3 clause
+  -- in the legacy combined pin_search_path.sql.
+  SELECT pg_catalog.array_agg(p.oid) INTO inline_critical_oids
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'eql_v3'
+    AND (
+      (p.pronargs = 2
+        AND p.proname IN ('ore_block_256_eq', 'ore_block_256_neq',
+                          'ore_block_256_lt', 'ore_block_256_lte',
+                          'ore_block_256_gt', 'ore_block_256_gte'))
+      OR (p.pronargs = 2
+        AND p.proname IN ('ore_cllw_eq', 'ore_cllw_neq',
+                          'ore_cllw_lt', 'ore_cllw_lte',
+                          'ore_cllw_gt', 'ore_cllw_gte'))
+      OR (p.pronargs = 1
+        AND p.proname IN ('ore_cllw', 'has_ore_cllw')
+        AND p.proargtypes[0] = jsonb_oid)
+      OR (p.pronargs = 1
+        AND p.proname = 'hmac_256'
+        AND p.proargtypes[0] = jsonb_oid)
+      OR (p.pronargs = 1
+        AND p.proname = 'bloom_filter'
+        AND p.proargtypes[0] = jsonb_oid)
+    );
+
+  FOR fn_oid IN
+    SELECT p.oid
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'eql_v3'
+      AND p.prokind IN ('f', 'w')
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_catalog.unnest(coalesce(p.proconfig, '{}'::text[])) c
+        WHERE c LIKE 'search_path=%'
+      )
+      AND NOT (p.oid = ANY (coalesce(inline_critical_oids, '{}'::oid[])))
+      -- Encrypted-domain family — structural skip: LANGUAGE sql, IMMUTABLE,
+      -- taking >=1 argument typed as a jsonb-backed DOMAIN in eql_v3.
+      AND NOT (
+        p.prolang = (SELECT l.oid FROM pg_catalog.pg_language l
+                     WHERE l.lanname = 'sql')
+        AND p.provolatile = 'i'
+        AND EXISTS (
+          SELECT 1
+          FROM pg_catalog.unnest(p.proargtypes::oid[]) AS arg(typ)
+          JOIN pg_catalog.pg_type dt ON dt.oid = arg.typ
+          JOIN pg_catalog.pg_namespace dn ON dn.oid = dt.typnamespace
+          WHERE dt.typtype = 'd'
+            AND dt.typbasetype = jsonb_oid
+            AND dn.nspname = 'eql_v3'
+        )
+      )
+      -- Comment-marker fallback for hand-written inline-critical extension
+      -- functions that take no domain argument.
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_description d
+        WHERE d.objoid = p.oid
+          AND d.classoid = 'pg_catalog.pg_proc'::regclass
+          AND d.description LIKE 'eql-inline-critical%'
+      )
+  LOOP
+    EXECUTE pg_catalog.format(
+      'ALTER FUNCTION %s SET search_path = pg_catalog, extensions, public',
+      fn_oid::regprocedure
+    );
+  END LOOP;
+END $$;

--- a/packages/stack/__tests__/helpers/eql-v3.ts
+++ b/packages/stack/__tests__/helpers/eql-v3.ts
@@ -11,16 +11,23 @@ const eqlV3SqlPath = resolve(
   '../fixtures/eql-v3/cipherstash-encrypt-v3.sql',
 )
 
-async function hasEqlV3TextSearch(sql: postgres.Sql): Promise<boolean> {
+// The sentinel must be a type that exists ONLY in the currently vendored
+// bundle, so a database still carrying an older EQL v3 install is detected as
+// stale and reinstalled (the bundle's leading DROP SCHEMA … CASCADE replaces
+// the old install wholesale). eql_v3.timestamp is new in the current bundle
+// (the timestamptz → timestamp rename, encrypt-query-language@2e64ca73); the
+// previous sentinel, eql_v3.text_search, exists in both generations and would
+// leave a stale install in place.
+async function hasCurrentEqlV3(sql: postgres.Sql): Promise<boolean> {
   const [row] = await sql<{ installed: boolean }[]>`
-    SELECT to_regtype('eql_v3.text_search') IS NOT NULL AS installed
+    SELECT to_regtype('eql_v3.timestamp') IS NOT NULL AS installed
   `
   return row?.installed ?? false
 }
 
 /**
  * Install the generated EQL v3 SQL bundle only when the target database does
- * not already expose eql_v3.text_search.
+ * not already expose the current bundle's sentinel type (see hasCurrentEqlV3).
  *
  * The bundle starts with DROP SCHEMA IF EXISTS eql_v3 CASCADE, so callers must
  * never run it unconditionally against a shared test database.
@@ -36,13 +43,13 @@ export async function installEqlV3IfNeeded(sql: postgres.Sql): Promise<void> {
     await reserved`SELECT pg_advisory_lock(${EQL_V3_ADVISORY_LOCK_ID})`
 
     try {
-      if (await hasEqlV3TextSearch(reserved)) return
+      if (await hasCurrentEqlV3(reserved)) return
 
       const eqlV3Sql = await readFile(eqlV3SqlPath, 'utf8')
       await reserved.unsafe(eqlV3Sql)
 
-      if (!(await hasEqlV3TextSearch(reserved))) {
-        throw new Error('EQL v3 installation did not create eql_v3.text_search')
+      if (!(await hasCurrentEqlV3(reserved))) {
+        throw new Error('EQL v3 installation did not create eql_v3.timestamp')
       }
     } finally {
       await reserved`SELECT pg_advisory_unlock(${EQL_V3_ADVISORY_LOCK_ID})`

--- a/packages/stack/__tests__/schema-v3-client.test.ts
+++ b/packages/stack/__tests__/schema-v3-client.test.ts
@@ -18,7 +18,7 @@ const users = encryptedTable('schema_v3_client_users', {
   // match models by JS property (`createdOn`) yet address the FFI/config by DB
   // name (`created_on`). The round-trip tests below exercise that mapping.
   createdOn: types.Date('created_on'),
-  occurredAt: types.Timestamptz('occurred_at'),
+  occurredAt: types.Timestamp('occurred_at'),
 })
 
 describeLive('eql_v3 client integration', () => {
@@ -219,22 +219,22 @@ describeLive('eql_v3 client integration', () => {
     expect(decrypted.notes).toBe('hello')
   }, 30000)
 
-  // Hygiene: `occurredAt` (a timestamptz column, camelCase property →
+  // Hygiene: `occurredAt` (a timestamp column, camelCase property →
   // snake_case DB name `occurred_at`) was declared in the test table but never
   // asserted. Give it a real round-trip through the model path, complementing
   // the `createdOn` date case above. (`matrix-live.test.ts` is the canonical
-  // generic coverage for all timestamptz tiers; this pins the named column.)
+  // generic coverage for all timestamp tiers; this pins the named column.)
   //
   // SKIPPED (CI run 28569708268, PR #540): fails against live credentials —
   // decrypted `occurredAt` comes back at midnight (`00:00:00.000Z`), losing
   // the time-of-day. Root cause: `@cipherstash/protect-ffi`'s native
   // `CastAs` has a distinct `'timestamp'` variant (full date+time) separate
   // from `'date'` (calendar-date only), but this SDK's `CastAs`/`PlaintextKind`
-  // types never included `'timestamp'` — every `timestamptz` domain sets
+  // types never included `'timestamp'` — every `timestamp` domain sets
   // `cast_as: 'date'`, identical to the plain `date` domain, so the native
   // layer truncates it. Pre-existing SDK gap, not a test bug; re-enable once
-  // `timestamptz` gets its own native cast_as.
-  it.skip('round-trips a timestamptz occurredAt column through the model path', async () => {
+  // `timestamp` gets its own native cast_as.
+  it.skip('round-trips a timestamp occurredAt column through the model path', async () => {
     const typed = typedClient(protectClient, users)
     // Zero milliseconds: the FFI drops sub-second precision, so a ms-bearing
     // instant would perturb the reconstructed value.

--- a/packages/stack/__tests__/schema-v3-client.test.ts
+++ b/packages/stack/__tests__/schema-v3-client.test.ts
@@ -225,16 +225,12 @@ describeLive('eql_v3 client integration', () => {
   // the `createdOn` date case above. (`matrix-live.test.ts` is the canonical
   // generic coverage for all timestamp tiers; this pins the named column.)
   //
-  // SKIPPED (CI run 28569708268, PR #540): fails against live credentials —
-  // decrypted `occurredAt` comes back at midnight (`00:00:00.000Z`), losing
-  // the time-of-day. Root cause: `@cipherstash/protect-ffi`'s native
-  // `CastAs` has a distinct `'timestamp'` variant (full date+time) separate
-  // from `'date'` (calendar-date only), but this SDK's `CastAs`/`PlaintextKind`
-  // types never included `'timestamp'` — every `timestamp` domain sets
-  // `cast_as: 'date'`, identical to the plain `date` domain, so the native
-  // layer truncates it. Pre-existing SDK gap, not a test bug; re-enable once
-  // `timestamp` gets its own native cast_as.
-  it.skip('round-trips a timestamp occurredAt column through the model path', async () => {
+  // Time-of-day preservation: every `timestamp` domain now sets
+  // `cast_as: 'timestamp'` (distinct from `'date'`), so the native FFI keeps the
+  // full instant instead of truncating to midnight. This test pins that — a
+  // ms-zeroed `12:34:56` value must round-trip exactly. (Was skipped while every
+  // timestamp domain wrongly set `cast_as: 'date'`; re-enabled with that fix.)
+  it('round-trips a timestamp occurredAt column through the model path', async () => {
     const typed = typedClient(protectClient, users)
     // Zero milliseconds: the FFI drops sub-second precision, so a ms-bearing
     // instant would perturb the reconstructed value.

--- a/packages/stack/__tests__/schema-v3.test-d.ts
+++ b/packages/stack/__tests__/schema-v3.test-d.ts
@@ -58,7 +58,7 @@ describe('eql_v3 schema type inference', () => {
       name: types.Text('name'),
       age: types.Int4('age'),
       active: types.Bool('active'),
-      createdAt: types.Timestamptz('created_at'),
+      createdAt: types.Timestamp('created_at'),
       score: types.Float8('score'),
     })
 
@@ -166,7 +166,7 @@ describe('eql_v3 client integration (type-level acceptance)', () => {
       emailEq: types.TextEq('email_eq'),
       emailMatch: types.TextMatch('email_match'),
       emailSearch: types.TextSearch('email_search'),
-      createdAt: types.TimestamptzOrd('created_at'),
+      createdAt: types.TimestampOrd('created_at'),
     })
     const client = {} as EncryptionClient
 
@@ -297,7 +297,7 @@ describe('eql_v3 model encryption inference', () => {
     // ('occurredAt'). Model inference keys off the PROPERTY name, so `occurredAt`
     // must become `Encrypted` while unrelated fields are preserved verbatim.
     const events = encryptedTable('events', {
-      occurredAt: types.Timestamptz('created_at'),
+      occurredAt: types.Timestamp('created_at'),
     })
     const client = {} as EncryptionClient
 

--- a/packages/stack/__tests__/schema-v3.test.ts
+++ b/packages/stack/__tests__/schema-v3.test.ts
@@ -458,3 +458,22 @@ describe('eql_v3 text order domains carry the hm (unique) index (regression)', (
     })
   })
 })
+
+describe('eql_v3 timestamp domains emit cast_as "timestamp" (time-of-day preserved)', () => {
+  // The FFI has a distinct `timestamp` cast (full date+time) separate from
+  // `date` (calendar-date only). Every timestamp domain must emit
+  // `cast_as: 'timestamp'` so the native layer keeps the time-of-day instead of
+  // truncating to midnight (see schema-v3-client occurredAt round-trip).
+  it.each([
+    ['timestamp', types.Timestamp],
+    ['timestamp_eq', types.TimestampEq],
+    ['timestamp_ord_ore', types.TimestampOrdOre],
+    ['timestamp_ord', types.TimestampOrd],
+  ] as const)('%s emits cast_as "timestamp"', (_name, builder) => {
+    expect(builder('c').build().cast_as).toBe('timestamp')
+  })
+
+  it('the plain date domain still emits cast_as "date"', () => {
+    expect(types.Date('c').build().cast_as).toBe('date')
+  })
+})

--- a/packages/stack/__tests__/schema-v3.test.ts
+++ b/packages/stack/__tests__/schema-v3.test.ts
@@ -280,7 +280,7 @@ describe('eql_v3 buildEncryptConfig', () => {
     // report "column not found in Encrypt config" at encrypt time.
     const users = encryptedTable('accounts', {
       createdOn: types.Date('created_on'),
-      lastSeen: types.Timestamptz('last_seen'),
+      lastSeen: types.Timestamp('last_seen'),
     })
     const config = buildEncryptConfig(users)
     expect(Object.keys(config.tables.accounts).sort()).toEqual([
@@ -297,7 +297,7 @@ describe('eql_v3 buildEncryptConfig', () => {
     // (it keys by DB name); `buildColumnKeyMap()` recovers it.
     const users = encryptedTable('accounts', {
       createdOn: types.Date('created_on'),
-      lastSeen: types.Timestamptz('last_seen'),
+      lastSeen: types.Timestamp('last_seen'),
       email: types.TextSearch('email'),
     })
     expect(users.buildColumnKeyMap()).toEqual({

--- a/packages/stack/__tests__/typed-client-v3.test-d.ts
+++ b/packages/stack/__tests__/typed-client-v3.test-d.ts
@@ -16,7 +16,7 @@ const users = encryptedTable('users', {
   email: types.TextEq('email'), // equality only
   bio: types.TextSearch('bio'), // equality + order + free-text
   note: types.Text('note'), // storage only (not queryable)
-  createdAt: types.TimestamptzOrd('created_at'), // equality + order
+  createdAt: types.TimestampOrd('created_at'), // equality + order
 })
 
 // A second registered table whose `weight` domain (int4_ord) is NOT present in
@@ -78,7 +78,7 @@ describe('typed v3 client — encryptQuery constrains queryType to capabilities'
     client.encryptQuery(new Date(), {
       table: users,
       column: users.createdAt, // equality + order, no free-text
-      // @ts-expect-error - timestamptz_ord column does not support 'freeTextSearch'
+      // @ts-expect-error - timestamp_ord column does not support 'freeTextSearch'
       queryType: 'freeTextSearch',
     })
   })
@@ -127,7 +127,7 @@ describe('typed v3 client — model encrypt validates schema fields', () => {
 describe('typed v3 client — model decrypt yields precise plaintext', () => {
   it('reconstructs schema columns to their plaintext type regardless of the input field type', () => {
     // Input is the encrypted row; output pins each schema column to its plaintext
-    // type (Date for timestamptz, string for text).
+    // type (Date for timestamp, string for text).
     expectTypeOf<
       V3DecryptedModel<
         typeof users,

--- a/packages/stack/__tests__/typed-client-v3.test.ts
+++ b/packages/stack/__tests__/typed-client-v3.test.ts
@@ -3,7 +3,7 @@ import type { EncryptionClient } from '@/encryption'
 import { encryptedTable, typedClient, types } from '@/encryption/v3'
 
 const table = encryptedTable('t', {
-  when: types.Timestamptz('when'),
+  when: types.Timestamp('when'),
   note: types.Text('note'),
   // camelCase JS property → snake_case DB name: reconstruction must key by the
   // JS property (how the decrypted row is keyed), not the DB column name.

--- a/packages/stack/__tests__/v3-matrix/catalog.ts
+++ b/packages/stack/__tests__/v3-matrix/catalog.ts
@@ -217,10 +217,10 @@ export const V3_MATRIX = {
   'eql_v3.date_ord_ore': { builder: types.DateOrdOre, ColumnClass: EncryptedDateOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   'eql_v3.date_ord': { builder: types.DateOrd, ColumnClass: EncryptedDateOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   // timestamp
-  'eql_v3.timestamp': { builder: types.Timestamp, ColumnClass: EncryptedTimestampColumn, castAs: 'date', capabilities: STORAGE, indexes: NONE, samples: DATE_S },
-  'eql_v3.timestamp_eq': { builder: types.TimestampEq, ColumnClass: EncryptedTimestampEqColumn, castAs: 'date', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
-  'eql_v3.timestamp_ord_ore': { builder: types.TimestampOrdOre, ColumnClass: EncryptedTimestampOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
-  'eql_v3.timestamp_ord': { builder: types.TimestampOrd, ColumnClass: EncryptedTimestampOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
+  'eql_v3.timestamp': { builder: types.Timestamp, ColumnClass: EncryptedTimestampColumn, castAs: 'timestamp', capabilities: STORAGE, indexes: NONE, samples: DATE_S },
+  'eql_v3.timestamp_eq': { builder: types.TimestampEq, ColumnClass: EncryptedTimestampEqColumn, castAs: 'timestamp', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
+  'eql_v3.timestamp_ord_ore': { builder: types.TimestampOrdOre, ColumnClass: EncryptedTimestampOrdOreColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
+  'eql_v3.timestamp_ord': { builder: types.TimestampOrd, ColumnClass: EncryptedTimestampOrdColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   // numeric
   'eql_v3.numeric': { builder: types.Numeric, ColumnClass: EncryptedNumericColumn, castAs: 'number', capabilities: STORAGE, indexes: NONE, samples: NUMERIC_S, errorSamples: NUM_ERR },
   'eql_v3.numeric_eq': { builder: types.NumericEq, ColumnClass: EncryptedNumericEqColumn, castAs: 'number', capabilities: EQ, indexes: UNIQUE_IDX, samples: NUMERIC_S, errorSamples: NUM_ERR },

--- a/packages/stack/__tests__/v3-matrix/catalog.ts
+++ b/packages/stack/__tests__/v3-matrix/catalog.ts
@@ -54,10 +54,10 @@ import {
   EncryptedTextOrdColumn,
   EncryptedTextOrdOreColumn,
   EncryptedTextSearchColumn,
-  EncryptedTimestamptzColumn,
-  EncryptedTimestamptzEqColumn,
-  EncryptedTimestamptzOrdColumn,
-  EncryptedTimestamptzOrdOreColumn,
+  EncryptedTimestampColumn,
+  EncryptedTimestampEqColumn,
+  EncryptedTimestampOrdColumn,
+  EncryptedTimestampOrdOreColumn,
   types,
 } from '@/eql/v3'
 import type { ColumnSchema } from '@/schema'
@@ -216,11 +216,11 @@ export const V3_MATRIX = {
   'eql_v3.date_eq': { builder: types.DateEq, ColumnClass: EncryptedDateEqColumn, castAs: 'date', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
   'eql_v3.date_ord_ore': { builder: types.DateOrdOre, ColumnClass: EncryptedDateOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   'eql_v3.date_ord': { builder: types.DateOrd, ColumnClass: EncryptedDateOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
-  // timestamptz
-  'eql_v3.timestamptz': { builder: types.Timestamptz, ColumnClass: EncryptedTimestamptzColumn, castAs: 'date', capabilities: STORAGE, indexes: NONE, samples: DATE_S },
-  'eql_v3.timestamptz_eq': { builder: types.TimestamptzEq, ColumnClass: EncryptedTimestamptzEqColumn, castAs: 'date', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
-  'eql_v3.timestamptz_ord_ore': { builder: types.TimestamptzOrdOre, ColumnClass: EncryptedTimestamptzOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
-  'eql_v3.timestamptz_ord': { builder: types.TimestamptzOrd, ColumnClass: EncryptedTimestamptzOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
+  // timestamp
+  'eql_v3.timestamp': { builder: types.Timestamp, ColumnClass: EncryptedTimestampColumn, castAs: 'date', capabilities: STORAGE, indexes: NONE, samples: DATE_S },
+  'eql_v3.timestamp_eq': { builder: types.TimestampEq, ColumnClass: EncryptedTimestampEqColumn, castAs: 'date', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
+  'eql_v3.timestamp_ord_ore': { builder: types.TimestampOrdOre, ColumnClass: EncryptedTimestampOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
+  'eql_v3.timestamp_ord': { builder: types.TimestampOrd, ColumnClass: EncryptedTimestampOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   // numeric
   'eql_v3.numeric': { builder: types.Numeric, ColumnClass: EncryptedNumericColumn, castAs: 'number', capabilities: STORAGE, indexes: NONE, samples: NUMERIC_S, errorSamples: NUM_ERR },
   'eql_v3.numeric_eq': { builder: types.NumericEq, ColumnClass: EncryptedNumericEqColumn, castAs: 'number', capabilities: EQ, indexes: UNIQUE_IDX, samples: NUMERIC_S, errorSamples: NUM_ERR },

--- a/packages/stack/__tests__/v3-matrix/catalog.ts
+++ b/packages/stack/__tests__/v3-matrix/catalog.ts
@@ -192,6 +192,15 @@ const DATE_S = [
   new Date('2026-07-01T00:00:00.000Z'),
   new Date('1970-01-01T00:00:00.000Z'),
 ] as const
+// Timestamp domains (`cast_as: 'timestamp'`) preserve the full instant, unlike
+// `date` which truncates to midnight. These samples deliberately carry a
+// NON-ZERO time-of-day so the live round-trip actually detects a regression
+// that truncates to the day boundary — reusing the midnight-only `DATE_S` here
+// would let such a regression pass silently (see matrix.test.ts).
+const TS_S = [
+  new Date('2026-07-01T12:34:56.000Z'),
+  new Date('1970-01-01T23:59:59.000Z'),
+] as const
 // Every number domain rejects these via the global encrypt guard.
 const NUM_ERR = [
   Number.NaN,
@@ -217,10 +226,10 @@ export const V3_MATRIX = {
   'eql_v3.date_ord_ore': { builder: types.DateOrdOre, ColumnClass: EncryptedDateOrdOreColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   'eql_v3.date_ord': { builder: types.DateOrd, ColumnClass: EncryptedDateOrdColumn, castAs: 'date', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
   // timestamp
-  'eql_v3.timestamp': { builder: types.Timestamp, ColumnClass: EncryptedTimestampColumn, castAs: 'timestamp', capabilities: STORAGE, indexes: NONE, samples: DATE_S },
-  'eql_v3.timestamp_eq': { builder: types.TimestampEq, ColumnClass: EncryptedTimestampEqColumn, castAs: 'timestamp', capabilities: EQ, indexes: UNIQUE_IDX, samples: DATE_S },
-  'eql_v3.timestamp_ord_ore': { builder: types.TimestampOrdOre, ColumnClass: EncryptedTimestampOrdOreColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
-  'eql_v3.timestamp_ord': { builder: types.TimestampOrd, ColumnClass: EncryptedTimestampOrdColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: DATE_S },
+  'eql_v3.timestamp': { builder: types.Timestamp, ColumnClass: EncryptedTimestampColumn, castAs: 'timestamp', capabilities: STORAGE, indexes: NONE, samples: TS_S },
+  'eql_v3.timestamp_eq': { builder: types.TimestampEq, ColumnClass: EncryptedTimestampEqColumn, castAs: 'timestamp', capabilities: EQ, indexes: UNIQUE_IDX, samples: TS_S },
+  'eql_v3.timestamp_ord_ore': { builder: types.TimestampOrdOre, ColumnClass: EncryptedTimestampOrdOreColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: TS_S },
+  'eql_v3.timestamp_ord': { builder: types.TimestampOrd, ColumnClass: EncryptedTimestampOrdColumn, castAs: 'timestamp', capabilities: ORD, indexes: ORE_IDX, samples: TS_S },
   // numeric
   'eql_v3.numeric': { builder: types.Numeric, ColumnClass: EncryptedNumericColumn, castAs: 'number', capabilities: STORAGE, indexes: NONE, samples: NUMERIC_S, errorSamples: NUM_ERR },
   'eql_v3.numeric_eq': { builder: types.NumericEq, ColumnClass: EncryptedNumericEqColumn, castAs: 'number', capabilities: EQ, indexes: UNIQUE_IDX, samples: NUMERIC_S, errorSamples: NUM_ERR },

--- a/packages/stack/__tests__/v3-matrix/matrix.test-d.ts
+++ b/packages/stack/__tests__/v3-matrix/matrix.test-d.ts
@@ -25,7 +25,7 @@ const records = encryptedTable('records', {
   count: V3_MATRIX['eql_v3.int4'].builder('count'), // number, storage-only
   score: V3_MATRIX['eql_v3.int4_eq'].builder('score'), // number, equality
   rank: V3_MATRIX['eql_v3.int4_ord'].builder('rank'), // number, order + range
-  createdAt: V3_MATRIX['eql_v3.timestamptz_ord'].builder('created_at'), // date
+  createdAt: V3_MATRIX['eql_v3.timestamp_ord'].builder('created_at'), // date
   email: V3_MATRIX['eql_v3.text_search'].builder('email'), // string, full-text
   active: V3_MATRIX['eql_v3.bool'].builder('active'), // boolean, storage-only
 })

--- a/packages/stack/__tests__/v3-matrix/matrix.test.ts
+++ b/packages/stack/__tests__/v3-matrix/matrix.test.ts
@@ -41,4 +41,27 @@ describe('eql_v3 type-driven domain matrix (runtime)', () => {
   ] as const)('%s uses non-empty positive samples for live Postgres inserts', (eqlType) => {
     expect(V3_MATRIX[eqlType].samples[0]).not.toBe('')
   })
+
+  // `timestamp` domains set `cast_as: 'timestamp'` (not `'date'`) precisely to
+  // preserve the time-of-day. The live matrix can only PROVE that preservation
+  // if its samples actually carry a non-zero time-of-day: a regression back to
+  // `'date'` truncation collapses the instant to midnight, so midnight-only
+  // samples (`DATE_S`) would survive truncation and pass silently. This guards
+  // the live suite's truncation-detection power at build time — flip the
+  // timestamp rows back to `DATE_S` and this fails.
+  it.each([
+    'eql_v3.timestamp',
+    'eql_v3.timestamp_eq',
+    'eql_v3.timestamp_ord_ore',
+    'eql_v3.timestamp_ord',
+  ] as const)('%s carries a sample with a non-zero time-of-day', (eqlType) => {
+    const samples = V3_MATRIX[eqlType].samples as readonly Date[]
+    const hasTimeOfDay = (d: Date) =>
+      d.getUTCHours() +
+        d.getUTCMinutes() +
+        d.getUTCSeconds() +
+        d.getUTCMilliseconds() >
+      0
+    expect(samples.some(hasTimeOfDay)).toBe(true)
+  })
 })

--- a/packages/stack/__tests__/wasm-inline-normalize.test.ts
+++ b/packages/stack/__tests__/wasm-inline-normalize.test.ts
@@ -10,6 +10,7 @@ const EXPECTED_MAPPING: Readonly<Record<string, string>> = {
   bigint: 'big_int',
   boolean: 'boolean',
   date: 'date',
+  timestamp: 'timestamp',
   number: 'double',
   string: 'text',
   json: 'jsonb',

--- a/packages/stack/scripts/install-eql-v3.ts
+++ b/packages/stack/scripts/install-eql-v3.ts
@@ -21,7 +21,7 @@ const sql = postgres(process.env.DATABASE_URL, { prepare: false })
 
 try {
   await installEqlV3IfNeeded(sql)
-  console.log('eql_v3.text_search is installed')
+  console.log('eql_v3 (current bundle) is installed')
 } finally {
   await sql.end()
 }

--- a/packages/stack/src/encryption/v3.ts
+++ b/packages/stack/src/encryption/v3.ts
@@ -9,6 +9,7 @@ import type {
   V3EncryptedModel,
   V3ModelInput,
 } from '@/eql/v3'
+import { DATE_LIKE_CASTS } from '@/eql/v3/columns'
 import { type EncryptionError, EncryptionErrorTypes } from '@/errors'
 import type { LockContextInput } from '@/identity'
 import type {
@@ -141,7 +142,9 @@ function rowReconstructor(
   const dateProperties = Object.entries(propToDb)
     .filter(([, dbName]) => {
       const castAs = columns[dbName]?.cast_as
-      return castAs === 'date' || castAs === 'timestamp'
+      // Date-like casts share one source of truth with the type-level
+      // reconstruction (`PlaintextFromKind`) — see `DATE_LIKE_CASTS`.
+      return (DATE_LIKE_CASTS as readonly string[]).includes(castAs as string)
     })
     .map(([property]) => property)
 

--- a/packages/stack/src/encryption/v3.ts
+++ b/packages/stack/src/encryption/v3.ts
@@ -137,9 +137,12 @@ function rowReconstructor(
   // config keyed by DB name — bridge the two via the table's property→DB map.
   const { columns } = table.build()
   const propToDb = table.buildColumnKeyMap()
-  // Only date columns need per-row work; resolve them up front.
+  // Only date-like columns need per-row work; resolve them up front.
   const dateProperties = Object.entries(propToDb)
-    .filter(([, dbName]) => columns[dbName]?.cast_as === 'date')
+    .filter(([, dbName]) => {
+      const castAs = columns[dbName]?.cast_as
+      return castAs === 'date' || castAs === 'timestamp'
+    })
     .map(([property]) => property)
 
   return (row) => {

--- a/packages/stack/src/encryption/v3.ts
+++ b/packages/stack/src/encryption/v3.ts
@@ -37,7 +37,7 @@ import {
  * Every method derives its types from the concrete `table` / `column` builder
  * arguments (which carry their branded types at the call site), so:
  * - `encrypt` / `encryptQuery` pin the plaintext to the column's domain type
- *   (`text → string`, `timestamptz → Date`, …);
+ *   (`text → string`, `timestamp → Date`, …);
  * - `encryptQuery` additionally constrains `queryType` to the column's
  *   capabilities and rejects storage-only columns outright;
  * - `encryptModel` / `bulkEncryptModels` validate schema-column fields against

--- a/packages/stack/src/eql/v3/columns.ts
+++ b/packages/stack/src/eql/v3/columns.ts
@@ -23,8 +23,10 @@ export type QueryCapabilities = Readonly<{
 }>
 
 /** The plaintext (TypeScript) kind a v3 domain decrypts to. A subset of the
- * SDK `CastAs` enum, restricted to the scalar kinds v3 domains actually use. */
-type PlaintextKind = 'string' | 'number' | 'boolean' | 'date'
+ * SDK `CastAs` enum, restricted to the scalar kinds v3 domains actually use.
+ * `timestamp` decrypts to `Date` just like `date`, but carries the full instant
+ * (its `cast_as` tells the FFI not to truncate the time-of-day). */
+type PlaintextKind = 'string' | 'number' | 'boolean' | 'date' | 'timestamp'
 
 /**
  * The full, literal definition of a v3 domain. This is the LOAD-BEARING type:
@@ -166,22 +168,22 @@ export const DATE_ORD = {
 
 export const TIMESTAMP = {
   eqlType: 'eql_v3.timestamp',
-  castAs: 'date',
+  castAs: 'timestamp',
   capabilities: STORAGE_ONLY,
 } as const
 export const TIMESTAMP_EQ = {
   eqlType: 'eql_v3.timestamp_eq',
-  castAs: 'date',
+  castAs: 'timestamp',
   capabilities: EQUALITY_ONLY,
 } as const
 export const TIMESTAMP_ORD_ORE = {
   eqlType: 'eql_v3.timestamp_ord_ore',
-  castAs: 'date',
+  castAs: 'timestamp',
   capabilities: ORDER_AND_RANGE,
 } as const
 export const TIMESTAMP_ORD = {
   eqlType: 'eql_v3.timestamp_ord',
-  castAs: 'date',
+  castAs: 'timestamp',
   capabilities: ORDER_AND_RANGE,
 } as const
 
@@ -618,7 +620,7 @@ type PlaintextFromKind<K extends PlaintextKind> = K extends 'string'
     ? number
     : K extends 'boolean'
       ? boolean
-      : K extends 'date'
+      : K extends 'date' | 'timestamp'
         ? Date
         : never
 

--- a/packages/stack/src/eql/v3/columns.ts
+++ b/packages/stack/src/eql/v3/columns.ts
@@ -22,11 +22,25 @@ export type QueryCapabilities = Readonly<{
   freeTextSearch: boolean
 }>
 
+/**
+ * The `cast_as` kinds whose decrypted plaintext reconstructs to a JS `Date`.
+ *
+ * SINGLE SOURCE OF TRUTH for the date-like set. Both the type-level
+ * {@link PlaintextFromKind} and the runtime `rowReconstructor` (encryption/v3.ts)
+ * derive their "reconstructs to `Date`" decision from this array, so the next
+ * `Date`-backed cast is added in exactly one place — never hand-synced across a
+ * type and a runtime guard that could silently drift.
+ *
+ * (`timestamp` reconstructs to `Date` just like `date`, but its `cast_as` tells
+ * the FFI not to truncate the time-of-day.)
+ */
+export const DATE_LIKE_CASTS = ['date', 'timestamp'] as const
+/** A `cast_as` kind that reconstructs to `Date` — see {@link DATE_LIKE_CASTS}. */
+export type DateLikeCast = (typeof DATE_LIKE_CASTS)[number]
+
 /** The plaintext (TypeScript) kind a v3 domain decrypts to. A subset of the
- * SDK `CastAs` enum, restricted to the scalar kinds v3 domains actually use.
- * `timestamp` decrypts to `Date` just like `date`, but carries the full instant
- * (its `cast_as` tells the FFI not to truncate the time-of-day). */
-type PlaintextKind = 'string' | 'number' | 'boolean' | 'date' | 'timestamp'
+ * SDK `CastAs` enum, restricted to the scalar kinds v3 domains actually use. */
+type PlaintextKind = 'string' | 'number' | 'boolean' | DateLikeCast
 
 /**
  * The full, literal definition of a v3 domain. This is the LOAD-BEARING type:
@@ -620,7 +634,7 @@ type PlaintextFromKind<K extends PlaintextKind> = K extends 'string'
     ? number
     : K extends 'boolean'
       ? boolean
-      : K extends 'date' | 'timestamp'
+      : K extends DateLikeCast
         ? Date
         : never
 

--- a/packages/stack/src/eql/v3/columns.ts
+++ b/packages/stack/src/eql/v3/columns.ts
@@ -164,23 +164,23 @@ export const DATE_ORD = {
   capabilities: ORDER_AND_RANGE,
 } as const
 
-export const TIMESTAMPTZ = {
-  eqlType: 'eql_v3.timestamptz',
+export const TIMESTAMP = {
+  eqlType: 'eql_v3.timestamp',
   castAs: 'date',
   capabilities: STORAGE_ONLY,
 } as const
-export const TIMESTAMPTZ_EQ = {
-  eqlType: 'eql_v3.timestamptz_eq',
+export const TIMESTAMP_EQ = {
+  eqlType: 'eql_v3.timestamp_eq',
   castAs: 'date',
   capabilities: EQUALITY_ONLY,
 } as const
-export const TIMESTAMPTZ_ORD_ORE = {
-  eqlType: 'eql_v3.timestamptz_ord_ore',
+export const TIMESTAMP_ORD_ORE = {
+  eqlType: 'eql_v3.timestamp_ord_ore',
   castAs: 'date',
   capabilities: ORDER_AND_RANGE,
 } as const
-export const TIMESTAMPTZ_ORD = {
-  eqlType: 'eql_v3.timestamptz_ord',
+export const TIMESTAMP_ORD = {
+  eqlType: 'eql_v3.timestamp_ord',
   castAs: 'date',
   capabilities: ORDER_AND_RANGE,
 } as const
@@ -496,18 +496,18 @@ export class EncryptedDateOrdColumn extends EncryptedV3Column<
   typeof DATE_ORD
 > {}
 
-// timestamptz
-export class EncryptedTimestamptzColumn extends EncryptedV3Column<
-  typeof TIMESTAMPTZ
+// timestamp
+export class EncryptedTimestampColumn extends EncryptedV3Column<
+  typeof TIMESTAMP
 > {}
-export class EncryptedTimestamptzEqColumn extends EncryptedV3Column<
-  typeof TIMESTAMPTZ_EQ
+export class EncryptedTimestampEqColumn extends EncryptedV3Column<
+  typeof TIMESTAMP_EQ
 > {}
-export class EncryptedTimestamptzOrdOreColumn extends EncryptedV3Column<
-  typeof TIMESTAMPTZ_ORD_ORE
+export class EncryptedTimestampOrdOreColumn extends EncryptedV3Column<
+  typeof TIMESTAMP_ORD_ORE
 > {}
-export class EncryptedTimestamptzOrdColumn extends EncryptedV3Column<
-  typeof TIMESTAMPTZ_ORD
+export class EncryptedTimestampOrdColumn extends EncryptedV3Column<
+  typeof TIMESTAMP_ORD
 > {}
 
 // numeric
@@ -579,10 +579,10 @@ export type AnyEncryptedV3Column =
   | EncryptedDateEqColumn
   | EncryptedDateOrdOreColumn
   | EncryptedDateOrdColumn
-  | EncryptedTimestamptzColumn
-  | EncryptedTimestamptzEqColumn
-  | EncryptedTimestamptzOrdOreColumn
-  | EncryptedTimestamptzOrdColumn
+  | EncryptedTimestampColumn
+  | EncryptedTimestampEqColumn
+  | EncryptedTimestampOrdOreColumn
+  | EncryptedTimestampOrdColumn
   | EncryptedNumericColumn
   | EncryptedNumericEqColumn
   | EncryptedNumericOrdOreColumn

--- a/packages/stack/src/eql/v3/index.ts
+++ b/packages/stack/src/eql/v3/index.ts
@@ -49,10 +49,10 @@ export {
   EncryptedTextOrdColumn,
   EncryptedTextOrdOreColumn,
   EncryptedTextSearchColumn,
-  EncryptedTimestamptzColumn,
-  EncryptedTimestamptzEqColumn,
-  EncryptedTimestamptzOrdColumn,
-  EncryptedTimestamptzOrdOreColumn,
+  EncryptedTimestampColumn,
+  EncryptedTimestampEqColumn,
+  EncryptedTimestampOrdColumn,
+  EncryptedTimestampOrdOreColumn,
   TEXT_SEARCH_EQL_TYPE,
 } from './columns'
 export type {

--- a/packages/stack/src/eql/v3/types.ts
+++ b/packages/stack/src/eql/v3/types.ts
@@ -35,10 +35,10 @@ import {
   EncryptedTextOrdColumn,
   EncryptedTextOrdOreColumn,
   EncryptedTextSearchColumn,
-  EncryptedTimestamptzColumn,
-  EncryptedTimestamptzEqColumn,
-  EncryptedTimestamptzOrdColumn,
-  EncryptedTimestamptzOrdOreColumn,
+  EncryptedTimestampColumn,
+  EncryptedTimestampEqColumn,
+  EncryptedTimestampOrdColumn,
+  EncryptedTimestampOrdOreColumn,
   FLOAT4,
   FLOAT4_EQ,
   FLOAT4_ORD,
@@ -64,10 +64,10 @@ import {
   TEXT_MATCH,
   TEXT_ORD,
   TEXT_ORD_ORE,
-  TIMESTAMPTZ,
-  TIMESTAMPTZ_EQ,
-  TIMESTAMPTZ_ORD,
-  TIMESTAMPTZ_ORD_ORE,
+  TIMESTAMP,
+  TIMESTAMP_EQ,
+  TIMESTAMP_ORD,
+  TIMESTAMP_ORD_ORE,
 } from './columns'
 
 /**
@@ -75,7 +75,7 @@ import {
  * EQL v3 column; the member name mirrors the underlying `eql_v3.<name>` domain
  * (strip the `eql_v3.` prefix, PascalCase each `_`-separated segment). So
  * `types.TextEq('actor')` builds an `eql_v3.text_eq` column, `types.Int4Ord`
- * an `eql_v3.int4_ord`, `types.Timestamptz` an `eql_v3.timestamptz`, and so on.
+ * an `eql_v3.int4_ord`, `types.Timestamp` an `eql_v3.timestamp`, and so on.
  *
  * Each factory returns the CONCRETE column class instance (never the widened
  * `AnyEncryptedV3Column`) so per-column plaintext / query-capability inference
@@ -87,7 +87,7 @@ import {
  * const events = encryptedTable('events', {
  *   actor:     types.TextEq('actor'),           // equality
  *   weight:    types.Int4Ord('weight'),         // order + range
- *   createdAt: types.Timestamptz('created_at'), // storage only
+ *   createdAt: types.Timestamp('created_at'), // storage only
  * })
  * ```
  *
@@ -118,15 +118,14 @@ export const types = {
     new EncryptedDateOrdOreColumn(name, DATE_ORD_ORE),
   DateOrd: (name: string) => new EncryptedDateOrdColumn(name, DATE_ORD),
 
-  // timestamptz
-  Timestamptz: (name: string) =>
-    new EncryptedTimestamptzColumn(name, TIMESTAMPTZ),
-  TimestamptzEq: (name: string) =>
-    new EncryptedTimestamptzEqColumn(name, TIMESTAMPTZ_EQ),
-  TimestamptzOrdOre: (name: string) =>
-    new EncryptedTimestamptzOrdOreColumn(name, TIMESTAMPTZ_ORD_ORE),
-  TimestamptzOrd: (name: string) =>
-    new EncryptedTimestamptzOrdColumn(name, TIMESTAMPTZ_ORD),
+  // timestamp
+  Timestamp: (name: string) => new EncryptedTimestampColumn(name, TIMESTAMP),
+  TimestampEq: (name: string) =>
+    new EncryptedTimestampEqColumn(name, TIMESTAMP_EQ),
+  TimestampOrdOre: (name: string) =>
+    new EncryptedTimestampOrdOreColumn(name, TIMESTAMP_ORD_ORE),
+  TimestampOrd: (name: string) =>
+    new EncryptedTimestampOrdColumn(name, TIMESTAMP_ORD),
 
   // numeric
   Numeric: (name: string) => new EncryptedNumericColumn(name, NUMERIC),

--- a/packages/stack/src/schema/index.ts
+++ b/packages/stack/src/schema/index.ts
@@ -38,15 +38,29 @@ export const eqlCastAsEnum = z
     'double',
     'boolean',
     'date',
+    'timestamp',
     'jsonb',
   ])
   .default('text')
 
 /**
  * SDK-facing data types — developer-friendly aliases accepted by `dataType()`.
+ *
+ * `timestamp` is distinct from `date`: `date` is calendar-date only (time-of-day
+ * truncated to midnight), while `timestamp` preserves the full date+time. v3
+ * `timestamp` domains set `cast_as: 'timestamp'` so the FFI keeps the instant.
  */
 export const castAsEnum = z
-  .enum(['bigint', 'boolean', 'date', 'number', 'string', 'json', 'text'])
+  .enum([
+    'bigint',
+    'boolean',
+    'date',
+    'timestamp',
+    'number',
+    'string',
+    'json',
+    'text',
+  ])
   .default('text')
 
 /**
@@ -69,6 +83,8 @@ export function toEqlCastAs(value: CastAs): EqlCastAs {
       return 'boolean'
     case 'date':
       return 'date'
+    case 'timestamp':
+      return 'timestamp'
     case 'json':
       return 'jsonb'
   }

--- a/packages/stack/src/schema/index.ts
+++ b/packages/stack/src/schema/index.ts
@@ -227,7 +227,7 @@ export class EncryptedField {
    * a different type so the encryption layer knows how to encode the plaintext
    * before encrypting.
    *
-   * @param castAs - The plaintext data type: `'string'`, `'number'`, `'boolean'`, `'date'`, `'text'`, `'bigint'`, or `'json'`.
+   * @param castAs - The plaintext data type: `'string'`, `'number'`, `'boolean'`, `'date'`, `'timestamp'`, `'text'`, `'bigint'`, or `'json'`. Use `'timestamp'` (not `'date'`) to preserve time-of-day — `'date'` truncates to midnight.
    * @returns This `EncryptedField` instance for method chaining.
    *
    * @example
@@ -276,7 +276,7 @@ export class EncryptedColumn {
    * a different type so the encryption layer knows how to encode the plaintext
    * before encrypting.
    *
-   * @param castAs - The plaintext data type: `'string'`, `'number'`, `'boolean'`, `'date'`, `'bigint'`, or `'json'`.
+   * @param castAs - The plaintext data type: `'string'`, `'number'`, `'boolean'`, `'date'`, `'timestamp'`, `'text'`, `'bigint'`, or `'json'`. Use `'timestamp'` (not `'date'`) to preserve time-of-day — `'date'` truncates to midnight.
    * @returns This `EncryptedColumn` instance for method chaining.
    *
    * @example


### PR DESCRIPTION
Stacked on #541. Tracks `encrypt-query-language@2e64ca73`, which renames the `eql_v3.timestamptz*` domains to `eql_v3.timestamp*`, and fixes the time-of-day truncation those domains suffered.

## 1. Bundle rename — `timestamptz` → `timestamp`

```typescript
import { encryptedTable, types } from "@cipherstash/stack/eql/v3";

const events = encryptedTable("events", {
  occurredAt: types.Timestamp("occurred_at"),      // was types.Timestamptz
});
```

- `types.Timestamptz*` → `types.Timestamp*`; domain consts / classes / `eqlType` (`eql_v3.timestamptz*` → `eql_v3.timestamp*`); barrel re-exports.
- Regenerated the vendored SQL fixture (`cipherstash-encrypt-v3.sql`).
- Install tooling: the stale-install sentinel moves from `eql_v3.text_search` (present in both bundle generations) to `eql_v3.timestamp` (new this bundle), so a DB carrying an older install is detected as stale and reinstalled.

## 2. `cast_as` fix — preserve time-of-day

The native protect-ffi `CastAs` has a distinct `timestamp` variant (full date+time) separate from `date` (calendar-date only). Every timestamp domain was set to `cast_as: 'date'`, so the native layer truncated the time-of-day to midnight on decrypt. Now:

```typescript
types.Timestamp("t").build().cast_as    // 'timestamp'  (was 'date')
types.Date("d").build().cast_as         // 'date'       (unchanged)
```

- `castAsEnum` (SDK/native) and `eqlCastAsEnum` (wasm, via `toEqlCastAs`) gain `timestamp`; `toEqlCastAs('timestamp') → 'timestamp'`.
- `PlaintextKind` gains `timestamp` (decrypts to `Date`, like `date`); the four `TIMESTAMP*` domain consts set `castAs: 'timestamp'`.
- Typed client `reconstructRow` rebuilds `Date` for `timestamp` as well as `date`.
- Re-enables the previously-skipped `schema-v3-client` `occurredAt` round-trip (a ms-zeroed `12:34:56` instant) to pin time-of-day preservation live in CI.

## Verified

- SDK level: timestamp columns emit `cast_as: 'timestamp'`, date stays `date`, `encryptConfigSchema` validates, full `pnpm build` typechecks (incl. `toEqlCastAs` exhaustiveness).
- 210 v3 runtime + 58 type tests pass; no regressions. The live SQL/round-trip tests (incl. the re-enabled `occurredAt`) run in CI with credentials.

Note: the base commit on this branch (`test(stack): v3 lock-context coverage …`) belongs to #541 and will drop from this diff once #541 merges.