### PR TITLE
docs(stack): protect-ffi 0.26 changeset — region→workspaceCrn migration + server-side lock-context enforcement note

### DIFF
--- a/.changeset/stack-protect-ffi-0-26-oidc-strategy.md
+++ b/.changeset/stack-protect-ffi-0-26-oidc-strategy.md
@@ -29,4 +29,8 @@ This replaces the old ceremony (`new LockContext()` → `await lc.identify(jwt)`
 - **`LockContext.identify()` / `getLockContext()`** are **deprecated** (kept for backwards compatibility); the strategy handles token acquisition.
 - **Strategies are re-exported** from `@cipherstash/stack` (`OidcFederationStrategy`, `AccessKeyStrategy`, `AutoStrategy`, `DeviceSessionStrategy`) and from `@cipherstash/stack/wasm-inline` (`OidcFederationStrategy`, `AccessKeyStrategy`) so integrators don't need a separate `@cipherstash/auth` install. `AuthStrategy` remains re-exported for the structural type.
 
+**Migrating `region` → `workspaceCrn` (WASM-inline).** If you previously passed `region` (or relied on `CS_REGION`) to the WASM-inline `Encryption()` path, replace it with your workspace CRN: set `workspaceCrn` in config (or `CS_WORKSPACE_CRN` in the environment) to the value shown in the CipherStash dashboard (`crn:<region>.aws:<workspace-id>` — it embeds the region, which is now derived from it). `region` is ignored if passed.
+
+**Lock-context enforcement is now server-side only.** Because the client no longer resolves a per-user CTS token at `withLockContext` time, it also cannot fail fast there: a wrong or missing identity claim surfaces as a ZeroKMS **decryption failure** (the data key simply doesn't unlock), not as a client-side error before the request. The cryptographic guarantee is unchanged — enforcement happens in ZeroKMS — but anyone relying on the old client-side throw for early feedback should assert on the operation's `failure` result instead.
+
 Existing credential / env behaviour is preserved when `config.strategy` is omitted.


### PR DESCRIPTION
Two wording additions to `.changeset/stack-protect-ffi-0-26-oidc-strategy.md`, flagged by the consolidated review on #547 (🟢 items — the review confirmed the `minor` bump is semver-correct pre-1.0, so this is documentation only):

1. **Explicit `region` → `workspaceCrn` migration paragraph** for the WASM-inline path: set `workspaceCrn` / `CS_WORKSPACE_CRN` to the dashboard CRN (`crn:<region>.aws:<workspace-id>`), the region is derived from it, and a passed `region` is ignored.
2. **Server-side-only lock-context enforcement spelled out**: the client no longer resolves a per-user CTS token at `withLockContext` time, so a wrong/missing identity claim surfaces as a ZeroKMS decryption failure rather than a client-side throw. Guarantee unchanged (ZeroKMS enforces); early-feedback callers should assert on the operation's `failure` result.

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for users upgrading to the latest encryption and auth packages.
  * Clarified the new configuration format for inline WASM encryption, including the switch from region-based settings to workspace CRN values.
  * Noted that region settings are now ignored if still provided.
* **Bug Fixes**
  * Documented a change in lock-context error handling: identity-related issues may now appear during decryption instead of failing immediately, and callers should check operation results for failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->