### PR TITLE
docs: refresh published package READMEs after protectjs → stack rename

### DIFF
--- a/.changeset/refresh-package-readmes.md
+++ b/.changeset/refresh-package-readmes.md
@@ -1,0 +1,11 @@
+---
+'@cipherstash/stack': patch
+'stash': patch
+'@cipherstash/protect': patch
+'@cipherstash/schema': patch
+'@cipherstash/drizzle': patch
+'@cipherstash/nextjs': patch
+'@cipherstash/protect-dynamodb': patch
+---
+
+Documentation: refresh package READMEs after the protectjs → stack repository rename. Fixed repository and license links, replaced dead in-repo docs links with cipherstash.com/docs URLs, rewrote the incorrect @cipherstash/nextjs README, and added guidance pointing new projects to @cipherstash/stack.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
 # stash
 
 [![npm version](https://img.shields.io/npm/v/stash.svg?style=for-the-badge&labelColor=000000)](https://www.npmjs.com/package/stash)
-[![License: MIT](https://img.shields.io/npm/l/stash.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/protectjs/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/stash.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/stack/blob/main/LICENSE.md)
 
 The single CLI for CipherStash. It handles authentication, project initialization, EQL database lifecycle (install, upgrade, validate, push, migrate), schema building, and encrypted secrets management. Install it as a devDependency alongside the runtime SDK `@cipherstash/stack`.
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -1,8 +1,11 @@
-# Protect.js Drizzle ORM Integration
+# CipherStash Drizzle ORM Integration
 
 **Type-safe encryption for Drizzle ORM with searchable queries**
 
-Seamlessly integrate Protect.js with Drizzle ORM and PostgreSQL to encrypt your data while maintaining full query capabilities—equality, range queries, text search, and sorting—all with complete TypeScript type safety.
+Seamlessly integrate CipherStash encryption with Drizzle ORM and PostgreSQL to encrypt your data while maintaining full query capabilities—equality, range queries, text search, and sorting—all with complete TypeScript type safety.
+
+> [!TIP]
+> For new projects we recommend [`@cipherstash/stack`](https://www.npmjs.com/package/@cipherstash/stack), which provides this integration as `encryptedType`, `extractEncryptionSchema`, and `createEncryptionOperators` from `@cipherstash/stack/drizzle`. See the [Drizzle docs](https://cipherstash.com/docs/stack/cipherstash/encryption/drizzle). This package documents the legacy `@cipherstash/protect`-based API.
 
 ## Features
 

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -8,5 +8,5 @@ This package is part of the [CipherStash Stack](https://github.com/cipherstash/s
 - [Identity-aware encryption](https://cipherstash.com/docs/stack/cipherstash/encryption/identity)
 
 > [!IMPORTANT]
-> `@cipherstash/stack` relies on a native Node.js module and must be excluded from bundling.
-> See the [bundling guide](https://cipherstash.com/docs/stack/deploy/bundling) for the required `serverExternalPackages` configuration in Next.js.
+> The default `@cipherstash/stack` entry relies on a native Node.js module and must be excluded from bundling — see the [bundling guide](https://cipherstash.com/docs/stack/deploy/bundling) for the required `serverExternalPackages` configuration in Next.js.
+> Alternatively, `@cipherstash/stack/wasm-inline` is designed to be bundled (no native module) and works in edge/serverless runtimes.

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,4 +1,12 @@
-# @cipherstash/protect
+# @cipherstash/nextjs
 
-This is the main package for the CipherStash Protect JavaScript Package.
-Please refer to the [main README](https://github.com/cipherstash/protectjs) for more information.
+Next.js helpers for CipherStash encryption, including Clerk integration via the `@cipherstash/nextjs/clerk` export.
+
+This package is part of the [CipherStash Stack](https://github.com/cipherstash/stack). For most applications we recommend the main [`@cipherstash/stack`](https://www.npmjs.com/package/@cipherstash/stack) package.
+
+- [Documentation](https://cipherstash.com/docs)
+- [Identity-aware encryption](https://cipherstash.com/docs/stack/cipherstash/encryption/identity)
+
+> [!IMPORTANT]
+> `@cipherstash/stack` relies on a native Node.js module and must be excluded from bundling.
+> See the [bundling guide](https://cipherstash.com/docs/stack/deploy/bundling) for the required `serverExternalPackages` configuration in Next.js.

--- a/packages/protect-dynamodb/README.md
+++ b/packages/protect-dynamodb/README.md
@@ -7,7 +7,7 @@ Helpers for using [CipherStash encryption](https://github.com/cipherstash/stack)
 
 [![Built by CipherStash](https://raw.githubusercontent.com/cipherstash/meta/refs/heads/main/csbadge.svg)](https://cipherstash.com)
 [![NPM version](https://img.shields.io/npm/v/@cipherstash/protect-dynamodb.svg?style=for-the-badge&labelColor=000000)](https://www.npmjs.com/package/@cipherstash/protect-dynamodb)
-[![License](https://img.shields.io/npm/l/@cipherstash/protect.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/stack/blob/main/LICENSE.md)
+[![License](https://img.shields.io/npm/l/@cipherstash/protect-dynamodb.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/stack/blob/main/LICENSE.md)
 
 ## Installation
 

--- a/packages/protect-dynamodb/README.md
+++ b/packages/protect-dynamodb/README.md
@@ -1,10 +1,13 @@
-# Protect.js DynamoDB Helpers
+# CipherStash DynamoDB Helpers
 
-Helpers for using CipherStash [Protect.js](https://github.com/cipherstash/protectjs) with DynamoDB.
+Helpers for using [CipherStash encryption](https://github.com/cipherstash/stack) with DynamoDB.
+
+> [!TIP]
+> For new projects we recommend [`@cipherstash/stack`](https://www.npmjs.com/package/@cipherstash/stack), which provides this functionality as `encryptedDynamoDB` from `@cipherstash/stack/dynamodb`. See the [DynamoDB docs](https://cipherstash.com/docs/stack/cipherstash/encryption/dynamodb). This package documents the legacy `@cipherstash/protect` API.
 
 [![Built by CipherStash](https://raw.githubusercontent.com/cipherstash/meta/refs/heads/main/csbadge.svg)](https://cipherstash.com)
 [![NPM version](https://img.shields.io/npm/v/@cipherstash/protect-dynamodb.svg?style=for-the-badge&labelColor=000000)](https://www.npmjs.com/package/@cipherstash/protect-dynamodb)
-[![License](https://img.shields.io/npm/l/@cipherstash/protect.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/protectjs/blob/main/LICENSE.md)
+[![License](https://img.shields.io/npm/l/@cipherstash/protect.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/stack/blob/main/LICENSE.md)
 
 ## Installation
 

--- a/packages/protect/README.md
+++ b/packages/protect/README.md
@@ -25,19 +25,19 @@
         src="https://img.shields.io/npm/dm/@cipherstash/protect.svg?style=for-the-badge&labelColor=000000"
       />
     </a>
-    <a href="https://github.com/cipherstash/protectjs/stargazers">
+    <a href="https://github.com/cipherstash/stack/stargazers">
       <img
         alt="GitHub stars"
-        src="https://img.shields.io/github/stars/cipherstash/protectjs?style=for-the-badge&labelColor=000000"
+        src="https://img.shields.io/github/stars/cipherstash/stack?style=for-the-badge&labelColor=000000"
       />
     </a>
-    <a href="https://github.com/cipherstash/protectjs/blob/main/LICENSE.md">
+    <a href="https://github.com/cipherstash/stack/blob/main/LICENSE.md">
       <img
         alt="License"
         src="https://img.shields.io/npm/l/@cipherstash/protect.svg?style=for-the-badge&labelColor=000000"
       />
     </a>
-    <a href="https://github.com/cipherstash/protectjs/tree/main/docs">
+    <a href="https://cipherstash.com/docs">
       <img
         alt="Docs"
         src="https://img.shields.io/badge/docs-Read-blue?style=for-the-badge&labelColor=000000"
@@ -50,6 +50,9 @@
 
 <!-- start -->
 
+> [!TIP]
+> `@cipherstash/protect` is the core encryption library that powers [`@cipherstash/stack`](https://www.npmjs.com/package/@cipherstash/stack). For new projects we recommend `@cipherstash/stack`, which re-exports this functionality alongside integrations for Drizzle, Supabase, DynamoDB, secrets, and identity-aware encryption. See the [CipherStash docs](https://cipherstash.com/docs) for the current API.
+
 Protect.js lets you encrypt every value with its own key—without sacrificing performance or usability. Encryption happens in your app; ciphertext is stored in your database.
 
 Per‑value unique keys are powered by CipherStash [ZeroKMS](https://cipherstash.com/products/zerokms) bulk key operations, backed by a root key in [AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html).
@@ -58,7 +61,7 @@ Encrypted data is structured as an [EQL](https://github.com/cipherstash/encrypt-
 
 > [!IMPORTANT]
 > Searching, sorting, and filtering on encrypted data is currently only supported when storing encrypted data in PostgreSQL.
-> Read more about [searching encrypted data](./docs/concepts/searchable-encryption.md).
+> Read more about [searching encrypted data](https://cipherstash.com/docs/stack/cipherstash/encryption/searchable-encryption).
 
 Looking for DynamoDB support? Check out the [Protect.js for DynamoDB helper library](https://www.npmjs.com/package/@cipherstash/protect-dynamodb).
 
@@ -100,7 +103,7 @@ const decrypted = await client.decrypt(encrypted.data);
 
 ## Architecture (high level)
 
-![Protect.js Architecture Diagram](https://github.com/cipherstash/protectjs/blob/main/docs/images/protectjs-architecture.png)
+![Protect.js Architecture Diagram](https://raw.githubusercontent.com/cipherstash/stack/45e40dc888ddc412c361139192ed24668d3db60d/docs/images/protectjs-architecture.png)
 
 ## Table of contents
 
@@ -120,7 +123,7 @@ const decrypted = await client.decrypt(encrypted.data);
 - [Contributing](#contributing)
 - [License](#license)
 
-For more specific documentation, refer to the [docs](https://github.com/cipherstash/protectjs/tree/main/docs).
+For more specific documentation, refer to the [docs](https://cipherstash.com/docs).
 
 ## Features
 
@@ -173,7 +176,7 @@ Read more about [building and bundling with Protect.js](#builds-and-bundling).
 ## Getting started
 
 - 🆕 **Existing app?** Skip to [the next step](#configuration).
-- 🌱 **Clean slate?** Check out the [getting started tutorial](./docs/getting-started.md).
+- 🌱 **Clean slate?** Check out the [getting started tutorial](https://cipherstash.com/docs/stack/quickstart).
 
 ### Configuration
 
@@ -249,7 +252,7 @@ export const documents = csTable("documents", {
 });
 ```
 
-Read more about [defining your schema](./docs/reference/schema.md).
+Read more about [defining your schema](https://cipherstash.com/docs/stack/cipherstash/encryption/schema).
 
 ### Initialize the Protect client
 
@@ -850,15 +853,15 @@ CREATE TABLE users (
 
 > [!WARNING]
 > The `eql_v2_encrypted` type is a [composite type](https://www.postgresql.org/docs/current/rowtypes.html) and each ORM/client has a different way of handling inserts and selects.
-> We've documented how to handle inserts and selects for the different ORMs/clients in the [docs](./docs/reference/working-with-composite-types.md).
+> We've documented how to handle inserts and selects for the different ORMs/clients in the [docs](https://cipherstash.com/docs).
 
-Read more about [how to search encrypted data](./docs/reference/searchable-encryption-postgres.md) in the docs.
+Read more about [how to search encrypted data](https://cipherstash.com/docs/stack/cipherstash/encryption/searchable-encryption) in the docs.
 
 ## Identity-aware encryption
 
 > [!IMPORTANT]
 > Right now identity-aware encryption is only supported if you are using [Clerk](https://clerk.com/) as your identity provider.
-> Read more about [lock contexts with Clerk and Next.js](./docs/how-to/lock-contexts-with-clerk.md).
+> Read more about [lock contexts with Clerk and Next.js](https://cipherstash.com/docs/stack/cipherstash/encryption/identity).
 
 Protect.js can add an additional layer of protection to your data by requiring a valid JWT to perform a decryption.
 
@@ -993,7 +996,7 @@ const bulkDecryptedResult = await protectClient
 Protect.js currently supports encrypting and decrypting text.
 Other data types like booleans, dates, ints, floats, and JSON are well-supported in other CipherStash products, and will be coming to Protect.js soon.
 
-Until support for other data types are available, you can express interest in this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/protectjs/issues/48).
+Until support for other data types are available, you can express interest in this feature by adding a :+1: on this [GitHub Issue](https://github.com/cipherstash/stack/issues/48).
 
 ## Searchable encryption
 
@@ -1002,7 +1005,7 @@ Protect.js supports searching encrypted data in PostgreSQL:
 - **Text columns**: Use `.equality()`, `.freeTextSearch()`, and `.orderAndRange()` for exact match, text search, and sorting/range queries.
 - **JSONB columns**: Use `.searchableJson()` (recommended) to enable encrypted JSONPath selector and containment queries on JSON data. The query operation is automatically inferred from the plaintext type.
 
-Read more about [searching encrypted data](./docs/concepts/searchable-encryption.md) and the [PostgreSQL implementation details](./docs/reference/searchable-encryption-postgres.md) in the docs.
+Read more about [searching encrypted data](https://cipherstash.com/docs/stack/cipherstash/encryption/searchable-encryption) and the [PostgreSQL implementation details](https://cipherstash.com/docs/stack/cipherstash/encryption/searchable-encryption) in the docs.
 
 ## Multi-tenant encryption
 
@@ -1056,9 +1059,9 @@ PROTECT_LOG_LEVEL=error  # Enable error logging
 ## CipherStash Client
 
 Protect.js is built on top of the CipherStash Client Rust SDK which is embedded with the `@cipherstash/protect-ffi` package.
-The `@cipherstash/protect-ffi` source code is available on [GitHub](https://github.com/cipherstash/protectjs-ffi).
+The `@cipherstash/protect-ffi` source code is available on [GitHub](https://github.com/cipherstash/stack-ffi).
 
-Read more about configuring the CipherStash Client in the [configuration docs](./docs/reference/configuration.md).
+Read more about configuring the CipherStash Client in the [configuration docs](https://cipherstash.com/docs/stack/reference).
 
 ## Example applications
 
@@ -1070,7 +1073,7 @@ Check out the [example applications](./examples):
 - [Next.js and lock contexts example using Clerk](/examples/nextjs-clerk) demonstrates how to protect data with identity-aware encryption
 
 `@cipherstash/protect` can be used with most ORMs.
-If you're interested in using `@cipherstash/protect` with a specific ORM, please [create an issue](https://github.com/cipherstash/protectjs/issues/new).
+If you're interested in using `@cipherstash/protect` with a specific ORM, please [create an issue](https://github.com/cipherstash/stack/issues/new).
 
 ## Builds and bundling
 
@@ -1078,11 +1081,11 @@ If you're interested in using `@cipherstash/protect` with a specific ORM, please
 
 Here are a few resources to help based on your tool set:
 
-- [Required Next.js configuration](./docs/how-to/nextjs-external-packages.md).
-- [SST and AWS serverless functions](./docs/how-to/sst-external-packages.md).
+- [Required Next.js configuration](https://cipherstash.com/docs/stack/deploy/bundling).
+- [SST and AWS serverless functions](https://cipherstash.com/docs/stack/deploy/bundling).
   
 > [!TIP]
-> Deploying to Linux (e.g., AWS Lambda) with npm lockfile v3 and seeing runtime module load errors? See the troubleshooting guide: [`docs/how-to/npm-lockfile-v3`](./docs/how-to/npm-lockfile-v3-linux-deployments.md).
+> Deploying to Linux (e.g., AWS Lambda) with npm lockfile v3 and seeing runtime module load errors? See the troubleshooting guide: [bundling guide](https://cipherstash.com/docs/stack/deploy/bundling).
 
 ## Contributing
 
@@ -1096,4 +1099,4 @@ Protect.js is [MIT licensed](./LICENSE.md).
 
 ### Didn't find what you wanted?
 
-[Click here to let us know what was missing from our docs.](https://github.com/cipherstash/protectjs/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md)
+[Click here to let us know what was missing from our docs.](https://github.com/cipherstash/stack/issues/new?template=docs-feedback.yml&title=[Docs:]%20Feedback%20on%20README.md)

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,10 +1,13 @@
 # @cipherstash/schema
 
-A TypeScript schema builder for CipherStash Protect.js that enables you to define encryption schemas with searchable encryption capabilities.
+A TypeScript schema builder for CipherStash encryption that enables you to define encryption schemas with searchable encryption capabilities.
 
 ## Overview
 
-`@cipherstash/schema` is a standalone package that provides the schema building functionality used by `@cipherstash/protect`. While not required for basic Protect.js usage, this package is available if you need to build encryption configuration schemas directly or want to understand the underlying schema structure.
+`@cipherstash/schema` is a standalone package that provides the schema building functionality used by `@cipherstash/protect`. While not required for typical usage, this package is available if you need to build encryption configuration schemas directly or want to understand the underlying schema structure.
+
+> [!TIP]
+> For new projects we recommend [`@cipherstash/stack`](https://www.npmjs.com/package/@cipherstash/stack), which exposes this functionality as `encryptedTable` / `encryptedColumn` from `@cipherstash/stack/schema`. The `csTable` / `csColumn` API documented below is the legacy naming used by `@cipherstash/protect`.
 
 ## Installation
 

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -3,7 +3,7 @@
 The all-in-one TypeScript SDK for the CipherStash data security stack.
 
 [![npm version](https://img.shields.io/npm/v/@cipherstash/stack.svg?style=for-the-badge&labelColor=000000)](https://www.npmjs.com/package/@cipherstash/stack)
-[![License: MIT](https://img.shields.io/npm/l/@cipherstash/stack.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/protectjs/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/npm/l/@cipherstash/stack.svg?style=for-the-badge&labelColor=000000)](https://github.com/cipherstash/stack/blob/main/LICENSE.md)
 [![TypeScript](https://img.shields.io/badge/TypeScript-first-blue?style=for-the-badge&labelColor=000000)](https://www.typescriptlang.org/)
 
 --
@@ -687,4 +687,4 @@ All method signatures on the encryption client (`encrypt`, `decrypt`, `encryptMo
 
 ## License
 
-MIT - see [LICENSE.md](https://github.com/cipherstash/protectjs/blob/main/LICENSE.md).
+MIT - see [LICENSE.md](https://github.com/cipherstash/stack/blob/main/LICENSE.md).


### PR DESCRIPTION
## Summary

Follow-up to #552 covering the READMEs that ship to npm. These still carried pre-rename content:

- **All packages** — repository, license, and star-badge URLs pointed at `cipherstash/protectjs`; now `cipherstash/stack`.
- **`@cipherstash/protect`** — 14 links pointed at the in-repo `docs/` tree removed in def9f4bd (broken both on GitHub and npm). Each is remapped to the equivalent cipherstash.com/docs page; the architecture diagram is pinned to a permalink of the last commit containing the image. Added a tip directing new projects to `@cipherstash/stack`.
- **`@cipherstash/nextjs`** — README was flat-out wrong ("This is the main package for the CipherStash Protect JavaScript Package"). Rewritten to describe what the package actually is, with the bundling caveat.
- **`@cipherstash/schema`**, **`@cipherstash/drizzle`**, **`@cipherstash/protect-dynamodb`** — retitled away from Protect.js branding, with tips pointing at the `@cipherstash/stack` equivalents. The legacy `csTable`/`protect()` API docs are left intact since those packages still export that API.

Includes a patch changeset for the seven affected published packages so the corrected READMEs actually reach npm.

## Notes

- The `Protect.js` name is retained inside `packages/protect/README.md` body copy — that package's identity is still Protect.js; only repo links and dead docs links changed there.
- Root README.md untouched (#526).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed READMEs across CipherStash packages to reflect current branding, repository renames, and corrected license/repository links.
  * Replaced the Next.js README with updated guidance, including integration pointers and a bundling note.
  * Updated Protect, Drizzle, Schema, and DynamoDB READMEs to link to the correct CipherStash docs and clarify that new projects should use `@cipherstash/stack` (legacy `@cipherstash/protect` is still documented).
  * Refreshed the CLI README’s MIT badge link.
* **Chores**
  * Applied patch-level version bumps to ship the README updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->