### PR TITLE
feat(stack): rename config.strategy to authStrategy; document auth + keysets

### DIFF
--- a/.changeset/rename-strategy-to-auth-strategy.md
+++ b/.changeset/rename-strategy-to-auth-strategy.md
@@ -21,4 +21,4 @@ const client = await Encryption({
 
 The `Encryption()` TypeDoc now documents the default `auto` strategy (env vars → local dev profile via `npx stash auth login`), the four `CS_*` production/CI variables, custom strategies (`AccessKeyStrategy`, `OidcFederationStrategy`), lock context, and keysets for multi-tenant isolation.
 
-Note: the `@cipherstash/stack/wasm-inline` entry still uses `config.strategy`; aligning that entry point to `authStrategy` is tracked as a follow-up.
+The `@cipherstash/stack/wasm-inline` entry (Deno / Edge / Workers / Bun) gets the same rename so the Node and WASM interfaces stay in sync: `WasmClientConfig.authStrategy` is the documented field, `strategy` is a deprecated alias that still works and warns at runtime.

--- a/.changeset/rename-strategy-to-auth-strategy.md
+++ b/.changeset/rename-strategy-to-auth-strategy.md
@@ -1,0 +1,24 @@
+---
+"@cipherstash/stack": minor
+---
+
+Rename the encryption client's auth strategy config field from `config.strategy` to **`config.authStrategy`** to make its purpose clear, and expand the `Encryption()` TypeDoc with a full authentication and keysets walkthrough.
+
+**`config.authStrategy`** is the new, documented field for supplying an auth strategy (`OidcFederationStrategy`, `AccessKeyStrategy`, or any `{ getToken() }` object). **`config.strategy` is retained as a deprecated alias** — passing it still works and forwards to the client, but logs a one-time runtime deprecation warning. When both are set, `authStrategy` wins (and the deprecation warning still fires so the leftover field gets cleaned up).
+
+```ts
+import { Encryption, OidcFederationStrategy } from "@cipherstash/stack"
+
+const client = await Encryption({
+  schemas: [users],
+  config: {
+    authStrategy: OidcFederationStrategy.create(workspaceCrn, () => getUserJwt()),
+  },
+})
+```
+
+**Migration:** rename `config.strategy` → `config.authStrategy`. No behavioural change beyond the deprecation warning; the field is forwarded to protect-ffi's `strategy` option exactly as before.
+
+The `Encryption()` TypeDoc now documents the default `auto` strategy (env vars → local dev profile via `npx stash auth login`), the four `CS_*` production/CI variables, custom strategies (`AccessKeyStrategy`, `OidcFederationStrategy`), lock context, and keysets for multi-tenant isolation.
+
+Note: the `@cipherstash/stack/wasm-inline` entry still uses `config.strategy`; aligning that entry point to `authStrategy` is tracked as a follow-up.

--- a/packages/stack/__tests__/init-strategy.test.ts
+++ b/packages/stack/__tests__/init-strategy.test.ts
@@ -1,13 +1,16 @@
 /**
- * Tests for the optional `config.strategy` auth strategy.
+ * Tests for the optional `config.authStrategy` auth strategy (and its
+ * deprecated `config.strategy` alias).
  *
  * protect-ffi (0.25+) lets `newClient` take an `AuthStrategy` (any
  * `{ getToken(): Promise<{ token }> }` object — the shape every
  * `@cipherstash/auth` strategy satisfies, including
  * `OidcFederationStrategy` for per-user identity-bound encryption).
- * `Encryption` exposes it via `config.strategy`; when provided it must
- * reach `newClient` as `opts.strategy`, and when omitted the option must
- * be absent so the default credentials-derived strategy is used.
+ * `Encryption` exposes it via `config.authStrategy`; when provided it must
+ * reach `newClient` as `opts.strategy` (the FFI's option name), and when
+ * omitted the option must be absent so the default `auto` strategy is used.
+ * The legacy `config.strategy` field is still honoured (with a runtime
+ * deprecation warning) until it is removed.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -30,28 +33,28 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('Encryption config.strategy', () => {
-  it('forwards a supplied strategy to newClient', async () => {
-    const strategy: AuthStrategy = {
+describe('Encryption config.authStrategy', () => {
+  it('forwards a supplied authStrategy to newClient', async () => {
+    const authStrategy: AuthStrategy = {
       getToken: vi.fn(async () => ({ token: 'service-token' })),
     }
 
-    await Encryption({ schemas: [users], config: { strategy } })
+    await Encryption({ schemas: [users], config: { authStrategy } })
 
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
-    expect(opts.strategy).toBe(strategy)
+    expect(opts.strategy).toBe(authStrategy)
   })
 
-  it('passes the strategy alongside the credential clientOpts', async () => {
-    const strategy: AuthStrategy = {
+  it('passes the authStrategy alongside the credential clientOpts', async () => {
+    const authStrategy: AuthStrategy = {
       getToken: vi.fn(async () => ({ token: 'service-token' })),
     }
 
     await Encryption({
       schemas: [users],
       config: {
-        strategy,
+        authStrategy,
         workspaceCrn: 'crn:ap-southeast-2.aws:test-workspace',
         clientId: 'client-id',
         clientKey: 'client-key',
@@ -60,8 +63,8 @@ describe('Encryption config.strategy', () => {
 
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
-    expect(opts.strategy).toBe(strategy)
-    // clientKey is still required even when a strategy is supplied.
+    expect(opts.strategy).toBe(authStrategy)
+    // clientKey is still required even when an authStrategy is supplied.
     expect(opts.clientOpts.clientKey).toBe('client-key')
     expect(opts.clientOpts.workspaceCrn).toBe(
       'crn:ap-southeast-2.aws:test-workspace',
@@ -83,7 +86,10 @@ describe('Encryption config.strategy', () => {
       })),
     }
 
-    await Encryption({ schemas: [users], config: { strategy: oidcStrategy } })
+    await Encryption({
+      schemas: [users],
+      config: { authStrategy: oidcStrategy },
+    })
 
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
@@ -96,6 +102,48 @@ describe('Encryption config.strategy', () => {
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
     expect(opts.strategy).toBeUndefined()
+  })
+})
+
+describe('Encryption config.strategy (deprecated alias)', () => {
+  it('still forwards a deprecated strategy to newClient and warns once', async () => {
+    // The rename warning is deduped per process, so this must be the first
+    // test in the file that passes `config.strategy`; the other suites use
+    // `authStrategy` and never trip the flag.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const strategy: AuthStrategy = {
+      getToken: vi.fn(async () => ({ token: 'service-token' })),
+    }
+
+    await Encryption({ schemas: [users], config: { strategy } })
+
+    // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
+    const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
+    expect(opts.strategy).toBe(strategy)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('`config.strategy` is deprecated'),
+    )
+
+    warn.mockRestore()
+  })
+
+  it('prefers authStrategy over the deprecated strategy when both are set', async () => {
+    const strategy: AuthStrategy = {
+      getToken: vi.fn(async () => ({ token: 'legacy-token' })),
+    }
+    const authStrategy: AuthStrategy = {
+      getToken: vi.fn(async () => ({ token: 'new-token' })),
+    }
+
+    await Encryption({
+      schemas: [users],
+      config: { strategy, authStrategy },
+    })
+
+    // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
+    const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
+    expect(opts.strategy).toBe(authStrategy)
   })
 })
 

--- a/packages/stack/__tests__/init-strategy.test.ts
+++ b/packages/stack/__tests__/init-strategy.test.ts
@@ -13,7 +13,8 @@
  * deprecation warning) until it is removed.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetStrategyDeprecationWarningForTests } from '@/encryption'
 import { EncryptionV3 } from '@/encryption/v3'
 import { Encryption } from '@/index'
 import { encryptedColumn, encryptedTable } from '@/schema'
@@ -29,8 +30,19 @@ const users = encryptedTable('users', {
   email: encryptedColumn('email'),
 })
 
+// Silence + capture the deprecation warning, and reset its once-per-process
+// latch, so each test asserts warning behaviour deterministically regardless
+// of order. `afterEach` restores the spy even if an assertion throws mid-test.
+let warnSpy: ReturnType<typeof vi.spyOn>
+
 beforeEach(() => {
   vi.clearAllMocks()
+  __resetStrategyDeprecationWarningForTests()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
 })
 
 describe('Encryption config.authStrategy', () => {
@@ -106,12 +118,7 @@ describe('Encryption config.authStrategy', () => {
 })
 
 describe('Encryption config.strategy (deprecated alias)', () => {
-  it('still forwards a deprecated strategy to newClient and warns once', async () => {
-    // The rename warning is deduped per process, so this must be the first
-    // test in the file that passes `config.strategy`; the other suites use
-    // `authStrategy` and never trip the flag.
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
+  it('still forwards a deprecated strategy to newClient and warns', async () => {
     const strategy: AuthStrategy = {
       getToken: vi.fn(async () => ({ token: 'service-token' })),
     }
@@ -121,14 +128,12 @@ describe('Encryption config.strategy (deprecated alias)', () => {
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
     expect(opts.strategy).toBe(strategy)
-    expect(warn).toHaveBeenCalledWith(
+    expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('`config.strategy` is deprecated'),
     )
-
-    warn.mockRestore()
   })
 
-  it('prefers authStrategy over the deprecated strategy when both are set', async () => {
+  it('prefers authStrategy over the deprecated strategy when both are set, and still warns', async () => {
     const strategy: AuthStrategy = {
       getToken: vi.fn(async () => ({ token: 'legacy-token' })),
     }
@@ -144,6 +149,21 @@ describe('Encryption config.strategy (deprecated alias)', () => {
     // biome-ignore lint/suspicious/noExplicitAny: reading recorded mock args
     const opts = vi.mocked(ffi.newClient).mock.calls.at(-1)![0] as any
     expect(opts.strategy).toBe(authStrategy)
+    // The deprecated field is still present, so the nudge to remove it fires
+    // even though `authStrategy` takes precedence.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`config.strategy` is deprecated'),
+    )
+  })
+
+  it('does not warn when only authStrategy is supplied', async () => {
+    const authStrategy: AuthStrategy = {
+      getToken: vi.fn(async () => ({ token: 'new-token' })),
+    }
+
+    await Encryption({ schemas: [users], config: { authStrategy } })
+
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/stack/__tests__/lock-context.test.ts
+++ b/packages/stack/__tests__/lock-context.test.ts
@@ -38,7 +38,7 @@ async function userClient(userJwt: string) {
   return Encryption({
     schemas: [users],
     config: {
-      strategy: OidcFederationStrategy.create(crn, () =>
+      authStrategy: OidcFederationStrategy.create(crn, () =>
         Promise.resolve(userJwt),
       ),
     },

--- a/packages/stack/__tests__/wasm-inline-new-client.test.ts
+++ b/packages/stack/__tests__/wasm-inline-new-client.test.ts
@@ -100,12 +100,16 @@ describe('wasm-inline Encryption → newClient (protect-ffi 0.25 single-object f
     expect(arg.encryptConfig.tables.users.email.cast_as).toBe('text')
   })
 
-  it('uses an explicit config.strategy verbatim on the strategy path', async () => {
+  it('uses an explicit config.authStrategy verbatim on the strategy path', async () => {
     const explicit = { getToken: vi.fn() }
     await Encryption({
       schemas: [users],
-      // biome-ignore lint/suspicious/noExplicitAny: exercise the strategy arm of the config union
-      config: { strategy: explicit, clientId: 'cid', clientKey: 'ckey' } as any,
+      config: {
+        authStrategy: explicit,
+        clientId: 'cid',
+        clientKey: 'ckey',
+        // biome-ignore lint/suspicious/noExplicitAny: exercise the authStrategy arm of the config union
+      } as any,
     })
 
     // biome-ignore lint/suspicious/noExplicitAny: reading the recorded single options object

--- a/packages/stack/__tests__/wasm-inline-strategy.test.ts
+++ b/packages/stack/__tests__/wasm-inline-strategy.test.ts
@@ -130,12 +130,14 @@ describe('wasm-inline resolveStrategy', () => {
     expect(() =>
       // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid — JS callers bypass the compile-time union
       resolveStrategy(both as any),
-    ).toThrowError(/mutually exclusive/)
+    ).toThrowError(
+      /`config\.authStrategy` and `config\.accessKey` are mutually exclusive/,
+    )
     // The guard must short-circuit *before* building a strategy.
     expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
   })
 
-  it('throws when the deprecated strategy and accessKey are both supplied', () => {
+  it('throws when the deprecated strategy and accessKey are both supplied, naming `strategy`', () => {
     const both = {
       workspaceCrn: CRN,
       accessKey: 'CSAK.test',
@@ -144,7 +146,10 @@ describe('wasm-inline resolveStrategy', () => {
     expect(() =>
       // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid — JS callers bypass the compile-time union
       resolveStrategy(both as any),
-    ).toThrowError(/mutually exclusive/)
+    ).toThrowError(
+      // Names the field the caller actually set, not the resolved `authStrategy`.
+      /`config\.strategy` and `config\.accessKey` are mutually exclusive/,
+    )
     expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
   })
 })

--- a/packages/stack/__tests__/wasm-inline-strategy.test.ts
+++ b/packages/stack/__tests__/wasm-inline-strategy.test.ts
@@ -7,11 +7,13 @@
  * Deno e2e (`e2e/wasm/roundtrip.test.ts`), which skips without real `CS_*`
  * secrets, so the wiring goes unchecked in the normal suite. These tests mock
  * `@cipherstash/auth/wasm-inline` and assert that the CRN reaches
- * `AccessKeyStrategy.create`, that an explicit `config.strategy` is used
- * verbatim, and that the `strategy` + `accessKey` mutual-exclusion guard fires.
+ * `AccessKeyStrategy.create`, that an explicit `config.authStrategy` is used
+ * verbatim, that the deprecated `config.strategy` alias still works (and warns),
+ * and that the auth-strategy + `accessKey` mutual-exclusion guard fires. This
+ * mirrors the Node entry's `config.authStrategy` contract.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@cipherstash/auth/wasm-inline', () => ({
   AccessKeyStrategy: {
@@ -28,12 +30,25 @@ vi.mock('@cipherstash/protect-ffi/wasm-inline', () => ({
 }))
 
 import { AccessKeyStrategy } from '@cipherstash/auth/wasm-inline'
-import { resolveStrategy } from '../src/wasm-inline'
+import {
+  __resetStrategyDeprecationWarningForTests,
+  resolveStrategy,
+} from '../src/wasm-inline'
 
 const CRN = 'crn:ap-southeast-2.aws:test-workspace'
 
+// Silence + capture the deprecation warning and reset its once-per-process
+// latch so each test asserts warning behaviour deterministically.
+let warnSpy: ReturnType<typeof vi.spyOn>
+
 beforeEach(() => {
   vi.clearAllMocks()
+  __resetStrategyDeprecationWarningForTests()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
 })
 
 describe('wasm-inline resolveStrategy', () => {
@@ -47,15 +62,43 @@ describe('wasm-inline resolveStrategy', () => {
       'CSAK.test',
     )
     expect(strategy).toEqual({ __mock: 'access-key-strategy' })
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 
-  it('uses an explicit config.strategy verbatim and never builds an access key', () => {
+  it('uses an explicit config.authStrategy verbatim and never builds an access key', () => {
     const explicit = { getToken: vi.fn() }
-    // biome-ignore lint/suspicious/noExplicitAny: exercise the strategy arm of the discriminated union directly
+    // biome-ignore lint/suspicious/noExplicitAny: exercise the authStrategy arm of the discriminated union directly
+    const strategy = resolveStrategy({ authStrategy: explicit } as any)
+
+    expect(strategy).toBe(explicit)
+    expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('honours the deprecated config.strategy alias and warns', () => {
+    const explicit = { getToken: vi.fn() }
+    // biome-ignore lint/suspicious/noExplicitAny: exercise the deprecated strategy arm directly
     const strategy = resolveStrategy({ strategy: explicit } as any)
 
     expect(strategy).toBe(explicit)
     expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`config.strategy` is deprecated'),
+    )
+  })
+
+  it('prefers authStrategy over the deprecated strategy when both are set, and still warns', () => {
+    const authStrategy = { getToken: vi.fn() }
+    const strategy = { getToken: vi.fn() }
+    const resolved = resolveStrategy(
+      // biome-ignore lint/suspicious/noExplicitAny: both fields set — JS callers bypass the compile-time union
+      { authStrategy, strategy } as any,
+    )
+
+    expect(resolved).toBe(authStrategy)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('`config.strategy` is deprecated'),
+    )
   })
 
   it('throws when the access-key arm is missing workspaceCrn or accessKey', () => {
@@ -78,7 +121,21 @@ describe('wasm-inline resolveStrategy', () => {
     expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
   })
 
-  it('throws when both strategy and accessKey are supplied', () => {
+  it('throws when both an auth strategy and accessKey are supplied', () => {
+    const both = {
+      workspaceCrn: CRN,
+      accessKey: 'CSAK.test',
+      authStrategy: { getToken: vi.fn() },
+    }
+    expect(() =>
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid — JS callers bypass the compile-time union
+      resolveStrategy(both as any),
+    ).toThrowError(/mutually exclusive/)
+    // The guard must short-circuit *before* building a strategy.
+    expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
+  })
+
+  it('throws when the deprecated strategy and accessKey are both supplied', () => {
     const both = {
       workspaceCrn: CRN,
       accessKey: 'CSAK.test',
@@ -88,7 +145,6 @@ describe('wasm-inline resolveStrategy', () => {
       // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid — JS callers bypass the compile-time union
       resolveStrategy(both as any),
     ).toThrowError(/mutually exclusive/)
-    // The guard must short-circuit *before* building a strategy.
     expect(vi.mocked(AccessKeyStrategy.create)).not.toHaveBeenCalled()
   })
 })

--- a/packages/stack/src/encryption/index.ts
+++ b/packages/stack/src/encryption/index.ts
@@ -127,7 +127,7 @@ export class EncryptionClient {
     clientId?: string
     clientKey?: string
     keyset?: KeysetIdentifier
-    strategy?: AuthStrategy
+    authStrategy?: AuthStrategy
     eqlVersion?: 2 | 3
   }): Promise<Result<EncryptionClient, EncryptionError>> {
     return await withResult(
@@ -145,7 +145,7 @@ export class EncryptionClient {
 
         // newClient handles env var fallback internally via withEnvCredentials,
         // so we pass config values through without manual fallback here.
-        // When `strategy` is supplied, protect-ffi invokes its getToken()
+        // When `authStrategy` is supplied, protect-ffi invokes its getToken()
         // on every ZeroKMS request instead of building an AutoStrategy
         // from the credentials in clientOpts (the clientKey is still used
         // for encryption). Passing `strategy: undefined` is equivalent to
@@ -163,7 +163,7 @@ export class EncryptionClient {
             clientKey: config.clientKey,
             keyset: toFfiKeysetIdentifier(config.keyset),
           },
-          strategy: config.strategy,
+          strategy: config.authStrategy,
           eqlVersion: config.eqlVersion,
         })
 
@@ -673,40 +673,87 @@ export class EncryptionClient {
   }
 }
 
+// Emit the `config.strategy` → `config.authStrategy` rename warning at most
+// once per process so repeated `Encryption()` calls don't spam the console.
+let warnedStrategyDeprecated = false
+function warnStrategyDeprecated(): void {
+  if (warnedStrategyDeprecated) return
+  warnedStrategyDeprecated = true
+  console.warn(
+    '[encryption]: `config.strategy` is deprecated and will be removed in a future release — use `config.authStrategy` instead.',
+  )
+}
+
 /**
  * Creates and initializes an Encryption client for encrypting and decrypting data with CipherStash.
  *
  * Provide at least one schema (from {@link encryptedTable}) so the client knows which tables and
- * columns to use. Credentials are read from the optional `config` or from the environment
- * (`CS_WORKSPACE_CRN`, `CS_CLIENT_ID`, `CS_CLIENT_KEY`, `CS_CLIENT_ACCESS_KEY`).
+ * columns to use:
  *
- * Pass a `config.strategy` to control how ZeroKMS requests are authenticated; its `getToken()`
- * is then used for every request in place of the credentials-derived default. Use
- * `OidcFederationStrategy` for per-user, identity-bound encryption (federates an end user's OIDC
- * JWT into a CTS service token) or `AccessKeyStrategy` for service-to-service / CI. Both are
- * re-exported from `@cipherstash/stack`. See {@link ClientConfig.strategy}.
- *
- * @param config - Initialization options. Must include `schemas`; optionally include `config` for
- *   workspace/keys. Logging is configured via the `STASH_STACK_LOG` environment variable
- *   (`debug | info | error`, default: `error`).
- * @returns A Promise that resolves to an initialized {@link EncryptionClient} ready for
- *   {@link EncryptionClient.encrypt}, {@link EncryptionClient.decrypt}, and related operations.
- *
- * @throws Throws if `schemas` is empty, or if a keyset `id` is supplied but is not a valid UUID.
- *   Also throws if the client fails to initialize (e.g. invalid credentials or config).
- *
- * @example
  * ```typescript
  * import { Encryption, encryptedTable, encryptedColumn } from "@cipherstash/stack"
  *
- * const users = encryptedTable("users", {
- *   email: encryptedColumn("email"),
- * })
+ * const users = encryptedTable("users", { email: encryptedColumn("email") })
  * const client = await Encryption({ schemas: [users] })
  * const result = await client.encrypt("alice@example.com", { column: users.email, table: users })
  * ```
  *
- * @example Per-user, identity-bound encryption
+ * ## Authentication
+ *
+ * By default the client uses the `auto` auth strategy. `auto` first looks for the `CS_*`
+ * environment variables (see below) and, if they are not set, falls back to the local **dev
+ * profile** on your machine. The dev profile also supplies the client key, so during local
+ * development you generally don't need to set any environment variables at all.
+ *
+ * ### Local development — create a dev profile
+ *
+ * Log in once to create the dev profile that `auto` picks up automatically:
+ *
+ * ```bash
+ * npx stash auth login
+ * ```
+ *
+ * ### Production / CI — environment variables
+ *
+ * In production and CI you typically authenticate with the four `CS_*` environment variables
+ * instead of a dev profile. Developers can obtain these values from the
+ * [CipherStash dashboard](https://dashboard.cipherstash.com):
+ *
+ * | Environment variable   | Description                                                                    |
+ * | ---------------------- | ------------------------------------------------------------------------------ |
+ * | `CS_WORKSPACE_CRN`     | The workspace Cloud Resource Name (CRN) that identifies your workspace.         |
+ * | `CS_CLIENT_ID`         | The client identifier issued when you create an access key.                    |
+ * | `CS_CLIENT_KEY`        | The client key material combined with ZeroKMS to perform encryption.           |
+ * | `CS_CLIENT_ACCESS_KEY` | The API access key used to authenticate requests to CipherStash.               |
+ *
+ * When these are set, `auto` uses them in preference to the local dev profile.
+ *
+ * ### Custom auth strategies — `config.authStrategy`
+ *
+ * For finer control, pass an explicit strategy via `config.authStrategy` (from `@cipherstash/auth`,
+ * re-exported by `@cipherstash/stack`). See the `@cipherstash/auth` package for the full list. Two
+ * common choices:
+ *
+ * `AccessKeyStrategy` — like `auto`, but only ever uses an access key; it never falls back to the
+ * local dev profile. Ideal for services and CI:
+ *
+ * ```typescript
+ * import { Encryption, AccessKeyStrategy } from "@cipherstash/stack"
+ *
+ * const client = await Encryption({
+ *   schemas: [users],
+ *   config: {
+ *     authStrategy: AccessKeyStrategy.create(workspaceCrn, accessKey),
+ *   },
+ * })
+ * ```
+ *
+ * `OidcFederationStrategy` — authenticate end users through your own identity provider (Supabase,
+ * Clerk, Auth0 or Okta) by federating their OIDC JWT into a CipherStash token. Add the provider to
+ * your workspace first at
+ * [dashboard.cipherstash.com/workspaces/_/oidc-providers](https://dashboard.cipherstash.com/workspaces/_/oidc-providers)
+ * (the `_` in the URL resolves to whichever workspace you select):
+ *
  * ```typescript
  * import { Encryption, OidcFederationStrategy } from "@cipherstash/stack"
  *
@@ -714,17 +761,63 @@ export class EncryptionClient {
  * const client = await Encryption({
  *   schemas: [users],
  *   config: {
- *     strategy: OidcFederationStrategy.create(workspaceCrn, () => getUserJwt()),
+ *     authStrategy: OidcFederationStrategy.create(workspaceCrn, () => getUserJwt()),
  *   },
  * })
+ * ```
  *
+ * ### Lock context (identity-bound encryption)
+ *
+ * Lock context is an **additional** capability layered on top of `OidcFederationStrategy`: it
+ * requires that strategy, but `OidcFederationStrategy` does not require lock context. It binds a
+ * value to a claim from the user's JWT (typically `sub`) so that only the user who encrypted a
+ * value can decrypt it:
+ *
+ * ```typescript
  * // Bind the data key to the user's `sub` claim.
  * const result = await client
  *   .encrypt("alice@example.com", { column: users.email, table: users })
  *   .withLockContext({ identityClaim: ["sub"] })
  * ```
  *
+ * Because the lock is tied to a specific end user's identity, `AccessKeyStrategy` (which
+ * authenticates a service, not a user) is not valid for lock context — there is no user `sub`
+ * claim to bind to.
+ *
+ * ## Keysets (multi-tenant isolation)
+ *
+ * Pass `config.keyset` to encrypt under a specific **keyset** — a named or UUID-identified keyspace
+ * that gives each tenant its own cryptographic isolation, so data encrypted under one keyset cannot
+ * be decrypted under another. Create and manage keysets in the
+ * [dashboard](https://dashboard.cipherstash.com/workspaces/_/keysets) (the `_` in the URL resolves
+ * to whichever workspace you select); omit `config.keyset` to use the workspace's default keyset.
+ *
+ * ```typescript
+ * const client = await Encryption({
+ *   schemas: [users],
+ *   config: {
+ *     keyset: { name: "tenant-a" }, // or { id: "<uuid>" }
+ *   },
+ * })
+ * ```
+ *
+ * A client is bound to a single keyset for its lifetime, so multi-tenant applications use **one
+ * `Encryption()` client per tenant**. Keysets are orthogonal to `authStrategy` and lock context —
+ * they isolate a whole tenant's *keyspace* (coarse, fixed per client), whereas lock context binds
+ * an individual value to a user's identity claim (fine-grained, per operation) — and can be
+ * combined with both.
+ *
+ * @param config - Initialization options. Must include `schemas`; optionally include `config` for
+ *   credentials and authentication. Logging is configured via the `STASH_STACK_LOG` environment
+ *   variable (`debug | info | error`, default: `error`).
+ * @returns A Promise that resolves to an initialized {@link EncryptionClient} ready for
+ *   {@link EncryptionClient.encrypt}, {@link EncryptionClient.decrypt}, and related operations.
+ *
+ * @throws Throws if `schemas` is empty, or if a keyset `id` is supplied but is not a valid UUID.
+ *   Also throws if the client fails to initialize (e.g. invalid credentials or config).
+ *
  * @see {@link EncryptionClientConfig} for full config options.
+ * @see {@link ClientConfig.authStrategy} for the auth strategy field.
  * @see {@link EncryptionClient} for available methods after initialization.
  */
 export const Encryption = async (
@@ -748,6 +841,13 @@ export const Encryption = async (
     )
   }
 
+  // Resolve the auth strategy, honouring the deprecated `strategy` alias.
+  // `authStrategy` wins when both are set.
+  if (clientConfig?.strategy && !clientConfig.authStrategy) {
+    warnStrategyDeprecated()
+  }
+  const authStrategy = clientConfig?.authStrategy ?? clientConfig?.strategy
+
   const client = new EncryptionClient()
   const encryptConfig = buildEncryptConfig(...schemas)
 
@@ -760,6 +860,7 @@ export const Encryption = async (
   const result = await client.init({
     encryptConfig,
     ...clientConfig,
+    authStrategy,
     eqlVersion,
   })
 

--- a/packages/stack/src/encryption/index.ts
+++ b/packages/stack/src/encryption/index.ts
@@ -685,6 +685,17 @@ function warnStrategyDeprecated(): void {
 }
 
 /**
+ * Reset the once-per-process deprecation-warning latch. Test-only hook so
+ * suites can assert the warning fires deterministically, independent of test
+ * ordering. Not re-exported from the package entry, so it stays off the public
+ * API surface.
+ * @internal
+ */
+export function __resetStrategyDeprecationWarningForTests(): void {
+  warnedStrategyDeprecated = false
+}
+
+/**
  * Creates and initializes an Encryption client for encrypting and decrypting data with CipherStash.
  *
  * Provide at least one schema (from {@link encryptedTable}) so the client knows which tables and
@@ -699,6 +710,10 @@ function warnStrategyDeprecated(): void {
  * ```
  *
  * ## Authentication
+ *
+ * The snippets in this section reuse the `users` schema from the example above, and
+ * `workspaceCrn` / `accessKey` stand in for your own workspace credentials (from the
+ * [dashboard](https://dashboard.cipherstash.com) or the `CS_*` variables below).
  *
  * By default the client uses the `auto` auth strategy. `auto` first looks for the `CS_*`
  * environment variables (see below) and, if they are not set, falls back to the local **dev
@@ -793,6 +808,7 @@ function warnStrategyDeprecated(): void {
  * to whichever workspace you select); omit `config.keyset` to use the workspace's default keyset.
  *
  * ```typescript
+ * // `users` is the schema from the first example above.
  * const client = await Encryption({
  *   schemas: [users],
  *   config: {
@@ -842,8 +858,10 @@ export const Encryption = async (
   }
 
   // Resolve the auth strategy, honouring the deprecated `strategy` alias.
-  // `authStrategy` wins when both are set.
-  if (clientConfig?.strategy && !clientConfig.authStrategy) {
+  // Warn whenever the deprecated field is present at all — even alongside
+  // `authStrategy` — so the leftover field gets cleaned up. `authStrategy`
+  // still wins when both are set.
+  if (clientConfig?.strategy) {
     warnStrategyDeprecated()
   }
   const authStrategy = clientConfig?.authStrategy ?? clientConfig?.strategy

--- a/packages/stack/src/identity/index.ts
+++ b/packages/stack/src/identity/index.ts
@@ -68,7 +68,7 @@ export function resolveLockContext(input: LockContextInput): Context {
  * const client = await Encryption({
  *   schemas,
  *   config: {
- *     strategy: OidcFederationStrategy.create(workspaceCrn, () => getJwt()),
+ *     authStrategy: OidcFederationStrategy.create(workspaceCrn, () => getJwt()),
  *   },
  * })
  *
@@ -118,7 +118,7 @@ export class LockContext {
    *
    * @deprecated Per-operation CTS tokens were removed in protect-ffi 0.25.
    * Authenticate the client as the user with an `OidcFederationStrategy`
-   * (`config.strategy`) instead, and pass the claim to `.withLockContext()`.
+   * (`config.authStrategy`) instead, and pass the claim to `.withLockContext()`.
    * The token fetched here is no longer used by encryption operations. This
    * method is kept for backwards compatibility and will be removed in a
    * future major release.

--- a/packages/stack/src/index.ts
+++ b/packages/stack/src/index.ts
@@ -8,8 +8,8 @@ export {
 } from '@/encryption/helpers'
 export { encryptedColumn, encryptedField, encryptedTable } from '@/schema'
 
-// Re-export auth strategies for convenience. Pass one as `config.strategy` to
-// `Encryption()` to control how ZeroKMS requests are authenticated — notably
+// Re-export auth strategies for convenience. Pass one as `config.authStrategy`
+// to `Encryption()` to control how ZeroKMS requests are authenticated — notably
 // `OidcFederationStrategy` for per-user, identity-bound encryption (pair with
 // `.withLockContext({ identityClaim })`). Re-exported so integrators don't need
 // a separate `@cipherstash/auth` install.

--- a/packages/stack/src/types.ts
+++ b/packages/stack/src/types.ts
@@ -23,11 +23,11 @@ import type {
  * with a `getToken(): Promise<{ token: string }>` method satisfies it —
  * notably the strategies from `@cipherstash/auth`: `OidcFederationStrategy`
  * (per-user, identity-bound encryption) and `AccessKeyStrategy`
- * (service-to-service / CI). When supplied to {@link ClientConfig.strategy},
+ * (service-to-service / CI). When supplied to {@link ClientConfig.authStrategy},
  * `getToken()` is invoked on every ZeroKMS request, taking precedence over
- * the credentials-derived default.
+ * the default `auto` strategy.
  *
- * @see ClientConfig.strategy
+ * @see ClientConfig.authStrategy
  */
 export type { AuthStrategy }
 
@@ -132,7 +132,12 @@ export type ClientConfig = {
    * An optional keyset identifier for multi-tenant encryption.
    * Each keyset provides cryptographic isolation, giving each tenant its own keyspace.
    * Specify by name (`{ name: "tenant-a" }`) or UUID (`{ id: "..." }`).
-   * Keysets are created and managed in the CipherStash dashboard.
+   * Keysets are created and managed in the
+   * [dashboard](https://dashboard.cipherstash.com/workspaces/_/keysets); omit to
+   * use the workspace's default keyset. A client is bound to one keyset for its
+   * lifetime, so use one client per tenant.
+   *
+   * @see {@link Encryption} for the full keysets walkthrough.
    */
   keyset?: KeysetIdentifier
 
@@ -140,8 +145,8 @@ export type ClientConfig = {
    * An optional authentication strategy for ZeroKMS requests, from
    * `@cipherstash/auth` (re-exported by `@cipherstash/stack`). When provided,
    * its `getToken()` is invoked on every ZeroKMS request and takes precedence
-   * over the credentials-derived default strategy (the `clientKey` is still
-   * required for encryption). Use:
+   * over the default `auto` strategy (the `clientKey` is still required for
+   * encryption). Use:
    *
    * - `OidcFederationStrategy` for per-user, identity-bound encryption —
    *   federates an end user's OIDC JWT into a CTS service token, so requests
@@ -151,11 +156,19 @@ export type ClientConfig = {
    * - `AccessKeyStrategy` for service-to-service / CI, or any custom
    *   `{ getToken() }` object for bespoke token acquisition / caching.
    *
-   * Leave unset to let the client build its default strategy from
-   * `workspaceCrn` / `accessKey` / `clientId` / `clientKey` (or the
-   * corresponding `CS_*` environment variables).
+   * Leave unset to use the default `auto` strategy, which reads credentials
+   * from the `CS_*` environment variables and falls back to the local dev
+   * profile created by `npx stash auth login`.
    *
    * @see {@link AuthStrategy}
+   * @see {@link Encryption} for a full walkthrough of the authentication options.
+   */
+  authStrategy?: AuthStrategy
+
+  /**
+   * @deprecated Renamed to {@link ClientConfig.authStrategy}. Still honoured for
+   * backwards compatibility — passing it logs a deprecation warning at runtime —
+   * but it will be removed in a future release. Set `authStrategy` instead.
    */
   strategy?: AuthStrategy
 

--- a/packages/stack/src/wasm-inline.ts
+++ b/packages/stack/src/wasm-inline.ts
@@ -38,17 +38,17 @@
  * For per-user, identity-bound encryption on the edge, build an
  * `OidcFederationStrategy` (federates an end user's OIDC JWT — Clerk,
  * Supabase, … — into a CTS service token) and pass it via
- * `config.strategy`:
+ * `config.authStrategy`:
  *
  * ```ts
  * import { OidcFederationStrategy } from "@cipherstash/stack/wasm-inline"
  * import { cookieStore } from "@cipherstash/auth/cookies"
  *
- * const strategy = OidcFederationStrategy.create(
+ * const authStrategy = OidcFederationStrategy.create(
  *   "crn:ap-southeast-2.aws:my-workspace-id", () => getClerkSessionToken(req),
  *   { store: cookieStore({ request: req, responseHeaders }) },
  * )
- * const client = await Encryption({ schemas, config: { strategy, clientId, clientKey } })
+ * const client = await Encryption({ schemas, config: { authStrategy, clientId, clientKey } })
  * ```
  *
  * For service-to-service / CI use with a custom token store, build an
@@ -82,7 +82,7 @@ import type { Encrypted, EncryptOptions } from '@/types'
 // Schema + type re-exports
 // -----------------------------------------------------------------------
 
-// Auth strategies for `config.strategy` — `OidcFederationStrategy` for
+// Auth strategies for `config.authStrategy` — `OidcFederationStrategy` for
 // per-user identity-bound encryption, `AccessKeyStrategy` for M2M / CI.
 // Re-exported so edge consumers don't need a separate `@cipherstash/auth`
 // import (pair `OidcFederationStrategy` with `cookieStore` from
@@ -151,8 +151,11 @@ export type WasmPlaintext =
  * you. To plug in a custom token store (cookies on Supabase Edge, KV on
  * Cloudflare Workers, …) or to bind encryption to an end user, build the
  * strategy yourself — `AccessKeyStrategy` or `OidcFederationStrategy` —
- * and hand it to `config.strategy` instead. A pre-built strategy already
- * carries the CRN, so `workspaceCrn` is optional on that path.
+ * and hand it to `config.authStrategy` instead. A pre-built strategy
+ * already carries the CRN, so `workspaceCrn` is optional on that path.
+ *
+ * Mirrors the Node `ClientConfig`: `authStrategy` is the documented field,
+ * `strategy` is retained as a deprecated alias (see below).
  */
 export type WasmClientConfig = {
   /** Workspace client identifier — required by the WASM client. */
@@ -160,7 +163,7 @@ export type WasmClientConfig = {
   /** Workspace client key — required by the WASM client. */
   clientKey: string
   // Provide exactly one of `accessKey` (we build the strategy) or a
-  // pre-built `strategy` — never both, never neither.
+  // pre-built auth strategy — never both, never neither.
 } & (
   | {
       /**
@@ -171,17 +174,36 @@ export type WasmClientConfig = {
        */
       workspaceCrn: string
       accessKey: string
+      authStrategy?: never
       strategy?: never
     }
   | {
       /**
-       * Optional on the strategy path. A pre-built `strategy` (e.g.
+       * Optional on the strategy path. A pre-built `authStrategy` (e.g.
        * `OidcFederationStrategy.create(workspaceCrn, …)`) already
        * encapsulates the workspace CRN and region, so the SDK never reads
        * this — supply it if convenient, omit it otherwise.
        */
       workspaceCrn?: string
       accessKey?: never
+      /** A pre-built auth strategy for per-user or M2M authentication. */
+      authStrategy: WasmAuthStrategy
+      /**
+       * @deprecated Renamed to `authStrategy`. Still honoured for backwards
+       * compatibility (it logs a deprecation warning at runtime) but will be
+       * removed in a future release.
+       */
+      strategy?: WasmAuthStrategy
+    }
+  | {
+      workspaceCrn?: string
+      accessKey?: never
+      authStrategy?: never
+      /**
+       * @deprecated Renamed to `authStrategy`. Still honoured for backwards
+       * compatibility (it logs a deprecation warning at runtime) but will be
+       * removed in a future release.
+       */
       strategy: WasmAuthStrategy
     }
 )
@@ -376,35 +398,66 @@ export function getColumnName(col: EncryptOptions['column']): string {
   )
 }
 
+// Emit the `config.strategy` → `config.authStrategy` rename warning at most
+// once per process so repeated `Encryption()` calls don't spam the console.
+// Mirrors the identical latch on the Node entry (`@/encryption`); the two are
+// kept separate so the wasm bundle never imports the Node-only module.
+let warnedStrategyDeprecated = false
+function warnStrategyDeprecated(): void {
+  if (warnedStrategyDeprecated) return
+  warnedStrategyDeprecated = true
+  console.warn(
+    '[encryption]: `config.strategy` is deprecated and will be removed in a future release — use `config.authStrategy` instead.',
+  )
+}
+
+/**
+ * Reset the once-per-process deprecation-warning latch. Test-only hook so
+ * suites can assert the warning fires deterministically, independent of test
+ * ordering.
+ * @internal
+ */
+export function __resetStrategyDeprecationWarningForTests(): void {
+  warnedStrategyDeprecated = false
+}
+
 /**
  * Resolve the auth strategy for the WASM client from its config: an explicit
- * `config.strategy`, or — for the access-key path — an `AccessKeyStrategy`
- * built from the workspace CRN (region derived from it inside
- * `@cipherstash/auth`). `strategy` and `accessKey` are mutually exclusive.
+ * `config.authStrategy` (or the deprecated `config.strategy` alias), or — for
+ * the access-key path — an `AccessKeyStrategy` built from the workspace CRN
+ * (region derived from it inside `@cipherstash/auth`). An auth strategy and
+ * `accessKey` are mutually exclusive.
  *
  * @internal exported for offline unit coverage of the strategy wiring; the
  * gated Deno e2e (`e2e/wasm/roundtrip.test.ts`) is the only other exercise of
  * this path and it skips without real `CS_*` secrets.
  */
 export function resolveStrategy(cfg: WasmClientConfig): WasmAuthStrategy {
-  // The discriminated union rejects `accessKey` + `strategy` together at
+  // Honour the deprecated `strategy` alias; `authStrategy` wins when both are
+  // set. Warn whenever the deprecated field is present at all so the leftover
+  // field gets cleaned up (mirrors the Node entry).
+  if (cfg.strategy) {
+    warnStrategyDeprecated()
+  }
+  const authStrategy = cfg.authStrategy ?? cfg.strategy
+  // The discriminated union rejects an auth strategy + `accessKey` together at
   // compile time, but JS callers (Deno / plain JS) bypass that — guard at
   // runtime so a conflicting config fails loudly instead of silently
   // preferring one.
-  if (cfg.strategy && cfg.accessKey) {
+  if (authStrategy && cfg.accessKey) {
     throw new Error(
-      '[encryption]: `config.strategy` and `config.accessKey` are mutually exclusive — pass exactly one.',
+      '[encryption]: `config.authStrategy` and `config.accessKey` are mutually exclusive — pass exactly one.',
     )
   }
-  if (cfg.strategy) return cfg.strategy
-  // No strategy → the access-key arm, where `workspaceCrn` and `accessKey`
+  if (authStrategy) return authStrategy
+  // No auth strategy → the access-key arm, where `workspaceCrn` and `accessKey`
   // are both required (and so present at runtime); the union widens their
   // static types to `string | undefined`, hence the casts. Guard at runtime
   // so plain JS / Deno callers that bypass the compile-time union fail loudly
   // instead of forwarding `undefined` into `AccessKeyStrategy.create`.
   if (!cfg.workspaceCrn || !cfg.accessKey) {
     throw new Error(
-      '[encryption]: `config.workspaceCrn` and `config.accessKey` are required when `config.strategy` is not provided.',
+      '[encryption]: `config.workspaceCrn` and `config.accessKey` are required when no auth strategy is provided.',
     )
   }
   // `AccessKeyStrategy.create` takes the full workspace CRN — the region is

--- a/packages/stack/src/wasm-inline.ts
+++ b/packages/stack/src/wasm-inline.ts
@@ -445,8 +445,11 @@ export function resolveStrategy(cfg: WasmClientConfig): WasmAuthStrategy {
   // runtime so a conflicting config fails loudly instead of silently
   // preferring one.
   if (authStrategy && cfg.accessKey) {
+    // Name the field the caller actually set — `strategy` when only the
+    // deprecated alias was used — so the message isn't misleading.
+    const field = cfg.authStrategy ? 'authStrategy' : 'strategy'
     throw new Error(
-      '[encryption]: `config.authStrategy` and `config.accessKey` are mutually exclusive — pass exactly one.',
+      `[encryption]: \`config.${field}\` and \`config.accessKey\` are mutually exclusive — pass exactly one.`,
     )
   }
   if (authStrategy) return authStrategy


### PR DESCRIPTION
Closes #563
Closes #564

## What

Renames the encryption client's auth strategy field from `strategy` to **`authStrategy`** (to make its purpose clear), keeps `strategy` as a deprecated alias, and rewrites the `Encryption()` TypeDoc to actually walk developers through authentication and keysets.

## Rename (backwards compatible)

- `ClientConfig.authStrategy` is now the documented field; `ClientConfig.strategy` is retained with an `@deprecated` tag.
- Passing `strategy` still forwards to the client but logs a **one-time** `console.warn` deprecation notice (deduped per process so repeated `Encryption()` calls don't spam). `console.warn` is used deliberately — the Stack `logger.warn` is sampled to `0` at the default `error` log level, so a logger-based notice would be invisible.
- `authStrategy` takes precedence when both are set (the warning still fires whenever the deprecated field is present, so the leftover gets cleaned up).
- `EncryptionClient.init`'s internal config param is renamed to `authStrategy` accordingly; the FFI option name (`strategy`) is unchanged.

### WASM entry kept in sync (`@cipherstash/stack/wasm-inline`)

The Deno / Edge / Workers / Bun entry gets the same rename so both interfaces match: `WasmClientConfig.authStrategy` is the documented field, `strategy` is a deprecated alias. `resolveStrategy` resolves `authStrategy ?? strategy`, keeps the auth-strategy-vs-`accessKey` mutual-exclusion guard (now covering both fields), and emits the same one-time runtime deprecation warning. (Closes #564.)

## TypeDoc rewrite (`Encryption()`)

Now covers:

- **Default `auto` strategy** — tries the `CS_*` env vars first, then falls back to the local dev profile (which also supplies the client key).
- **Local dev**: `npx stash auth login`.
- **Production / CI**: table of `CS_WORKSPACE_CRN`, `CS_CLIENT_ID`, `CS_CLIENT_KEY`, `CS_CLIENT_ACCESS_KEY` with a [dashboard](https://dashboard.cipherstash.com) link.
- **Custom strategies** via `authStrategy`: `AccessKeyStrategy` (service/CI) and `OidcFederationStrategy` (per-user via your own IdP — Supabase/Clerk/Auth0/Okta, with the `/workspaces/_/oidc-providers` link).
- **Lock context** as an identity-bound capability layered on `OidcFederationStrategy` (and why `AccessKeyStrategy` isn't valid for it).
- **Keysets (multi-tenant isolation)** — name/UUID identification, [dashboard link](https://dashboard.cipherstash.com/workspaces/_/keysets), workspace-default fallback, one client per tenant, orthogonal to `authStrategy`/lock context.

Stray `config.strategy` doc references (the `AuthStrategy` type doc, the re-export comment in `index.ts`, and the `LockContext` example/deprecation note in `identity/index.ts`) were updated to `authStrategy`.

## Tests

`__tests__/init-strategy.test.ts` now covers the `authStrategy` field (forwarding, alongside clientOpts, OIDC-shaped, unset), plus a deprecated-alias suite asserting the legacy `strategy` path still forwards **and** warns, and that `authStrategy` beats `strategy`. `lock-context.test.ts` migrated to `authStrategy`. All pass (18 tests across the two files).

## Verification

- `tsc -p tsconfig.typecheck.json --noEmit` — clean.
- Strategy + lock-context tests — green.
- The pre-existing vitest-typecheck failures (`EncryptedPayload`/`EncryptedV3Query` in `types.ts:4,6`) and `noNonNullAssertion` lint warnings are unrelated (confirmed identical on a clean tree).

## Follow-ups (issues opened from the same discussion)

- cipherstash/stack#561 — allow passing a keyset to encrypt/decrypt operations, not just at init (includes a reminder to update the keysets TypeDoc when it lands).
- cipherstash/docs#47 — document the isolation hierarchy (keysets vs auth strategies vs lock context).
- cipherstash/docs#48 — document creating keysets programmatically, linking back to this TypeDoc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `authStrategy` as the primary encryption authentication configuration option, with the same supported strategy types and default behavior as before.
* **Bug Fixes**
  * Improved precedence handling: when both are provided, `authStrategy` takes precedence over the deprecated `strategy` alias.
  * Ensured deprecation warnings for `strategy` are emitted deterministically (one-time per process).
* **Documentation**
  * Updated encryption, identity/lock context, and WASM-inline guidance and examples to use `authStrategy`.
* **Tests**
  * Expanded coverage for deprecated alias behavior and warning/precedence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->