### PR TITLE
ci(integration): serialize live-DB jobs to stop host-port collisions

### DIFF
--- a/.github/workflows/integration-drizzle.yml
+++ b/.github/workflows/integration-drizzle.yml
@@ -58,6 +58,18 @@ jobs:
   integration:
     name: Drizzle v3 integration (db=${{ matrix.db }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Serialize every job that brings up the SAME docker-compose stack, so no two
+    # bind the same fixed host ports on a shared runner at once (the "address
+    # already in use" flake). Keyed by the compose variant, NOT the ref (two PRs
+    # contend for a host port just as much as two pushes to one PR), so it
+    # serializes across refs. The `supabase` leg uses the SAME supabase compose
+    # (55430 / 55433) as the Supabase workflow and shares its key
+    # (`integration-live-db-supabase`), so the two workflows queue rather than
+    # collide; the `postgres` leg (55432) has its own key and still runs in
+    # parallel with them.
+    concurrency:
+      group: integration-live-db-${{ matrix.db }}
+      cancel-in-progress: false
     # Fork PRs have no secrets. Skip cleanly rather than fail on something the
     # contributor cannot fix — `tests.yml` still gives them a green signal.
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -133,6 +145,14 @@ jobs:
           client-id: ${{ vars.CS_CLIENT_ID }}
           client-key: ${{ secrets.CS_CLIENT_KEY }}
           client-access-key: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+
+      # Belt-and-braces for the concurrency guard: a run that was hard-killed
+      # (runner crash / forced cancel) can skip its `down` and leak a container
+      # holding the host port onto a REUSED runner. Tear any prior stack down
+      # before starting a fresh one. `|| true` so a clean runner (nothing to
+      # remove) is not an error.
+      - name: Clear any leaked containers from a prior run
+        run: docker compose -f local/docker-compose.${{ matrix.db }}.yml down -v --remove-orphans || true
 
       - name: Start ${{ matrix.db }}
         run: docker compose -f local/docker-compose.${{ matrix.db }}.yml up -d --wait

--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -50,6 +50,18 @@ jobs:
   integration:
     name: Supabase v3 integration (db=${{ matrix.db }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Serialize every job that brings up the SAME docker-compose stack, so no two
+    # bind the same fixed host ports (55430 / 55433) on a shared runner at once —
+    # the "address already in use" flake. The group is keyed by the compose
+    # variant, NOT the ref: two different PRs contend for the same host port just
+    # as much as two pushes to one PR, so it must serialize across refs. It is the
+    # SAME key the Drizzle workflow's matching leg uses (`integration-live-db-<db>`),
+    # so those two workflows also queue against each other rather than colliding.
+    # `cancel-in-progress: false` queues (a live-DB job that shares one ZeroKMS
+    # workspace should finish, not be interrupted mid-run).
+    concurrency:
+      group: integration-live-db-${{ matrix.db }}
+      cancel-in-progress: false
     # Fork PRs have no secrets. Skip cleanly rather than fail loudly on something
     # the contributor cannot fix — `tests.yml` still gives them a green signal.
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -105,6 +117,14 @@ jobs:
           client-id: ${{ vars.CS_CLIENT_ID }}
           client-key: ${{ secrets.CS_CLIENT_KEY }}
           client-access-key: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+
+      # Belt-and-braces for the concurrency guard: a run that was hard-killed
+      # (runner crash / forced cancel) can skip its `down` and leak a container
+      # holding the host port onto a REUSED runner. Tear any prior stack down
+      # before starting a fresh one. `|| true` so a clean runner (nothing to
+      # remove) is not an error.
+      - name: Clear any leaked containers from a prior run
+        run: docker compose -f local/docker-compose.${{ matrix.db }}.yml down -v --remove-orphans || true
 
       - name: Start ${{ matrix.db }}
         run: docker compose -f local/docker-compose.${{ matrix.db }}.yml up -d --wait


### PR DESCRIPTION
## Problem

The Supabase v3 integration job on #586 failed CI — but not on anything in the PR. It died in the **Start** step, before any test ran:

```
Error response from daemon: failed to set up container networking:
failed to bind host port for 0.0.0.0:55430:172.18.0.3:3000/tcp: address already in use
```

Both `integration-supabase.yml` and `integration-drizzle.yml` bring up docker-compose stacks that bind **fixed host ports** (55430 / 55432 / 55433) on shared Blacksmith runners, with **no concurrency guard**. When two such jobs land on the same host at once — or a container leaks onto a reused runner from a hard-killed prior run — the second one can't bind the port and the whole job fails. A re-run of #586's job passed with no code change, confirming the flake.

The contention isn't just within one workflow: the Drizzle `supabase` matrix leg brings up the **same** supabase compose (55430/55433) as the Supabase workflow, so they can collide with each other too.

## Fix

**Job-level concurrency keyed by the compose variant** on both workflows:

```yaml
concurrency:
  group: integration-live-db-${{ matrix.db }}
  cancel-in-progress: false
```

- Keyed by the compose/port group, **not the ref** — two different PRs contend for a host port just as much as two pushes to one PR, so it must serialize across refs.
- The Drizzle `supabase` leg shares the Supabase workflow's key (`integration-live-db-supabase`), so those two **queue** instead of colliding on 55430/55433. The Drizzle `postgres` leg (55432) has its own key and still runs in parallel.
- `cancel-in-progress: false` queues rather than cancels — a live-DB job that shares one ZeroKMS workspace should finish, not be interrupted mid-run.

**Pre-`up` cleanup** on both (belt-and-braces for a container leaked onto a reused runner by a hard-killed run that skipped its `down`):

```yaml
- name: Clear any leaked containers from a prior run
  run: docker compose -f local/docker-compose.${{ matrix.db }}.yml down -v --remove-orphans || true
```

## Notes

- CI-tooling only — no changeset (no published-package behaviour changes) and no skill updates (not a supply-chain-policy change).
- The fully robust fix would be to stop binding fixed host ports (per-run compose project + ephemeral ports, read the mapped port in the harness). That's a larger change; this pair of guards resolves the observed flake cheaply.