### PR TITLE
chore(release): prep EQL v3 1.0 GA — major changeset + RC publish workflow

### DIFF
--- a/.changeset/eql-v3-1-0-ga.md
+++ b/.changeset/eql-v3-1-0-ga.md
@@ -1,0 +1,20 @@
+---
+'@cipherstash/stack': major
+'@cipherstash/stack-drizzle': major
+'@cipherstash/stack-supabase': major
+---
+
+CipherStash Stack 1.0 — EQL v3 general availability.
+
+The first stable (1.0) release of `@cipherstash/stack` and its adapter packages,
+built on EQL v3 (`eql-3.0.0`) and `@cipherstash/protect-ffi` 0.29:
+
+- Typed v3 schema authoring (`types` / `encryptedTable` from
+  `@cipherstash/stack/eql/v3`) and a typed encryption client (`EncryptionV3`
+  from `@cipherstash/stack/v3`).
+- EQL v3 Drizzle and Supabase integrations, split into their own packages —
+  `@cipherstash/stack-drizzle` and `@cipherstash/stack-supabase`.
+
+This is a breaking, major release. See the individual package CHANGELOGs for the
+full v3 surface. The previous EQL v2 (0.x) line remains available under its
+published release tags (`@cipherstash/stack@0.x`).

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,90 @@
+name: Release JS (RC)
+
+# Prerelease (release-candidate) publishing for the EQL v3 1.0 line. A faithful
+# mirror of `release.yml` — same npm OIDC trusted publishing, same github-hosted
+# runner for provenance — with two differences:
+#
+#   1. It runs on the release branch(es) (`release/**`), never `main`. `main`
+#      keeps its own 0.x cadence via `release.yml`; this line is independent.
+#   2. It publishes under the `rc` npm dist-tag, so `@latest` is untouched
+#      (`npm i @cipherstash/stack` stays on the stable release; `@rc` opts in).
+#
+# REQUIRES the release branch to be in Changesets PRERELEASE mode — i.e. a
+# committed `.changeset/pre.json` (`pnpm changeset pre enter rc`). Without it,
+# `changeset version` produces stable versions, not `-rc.N`. `changesets/action`
+# opens a "Version Packages" PR with the rc versions; merging it triggers this
+# workflow again with no pending changesets, and the publish step runs.
+#
+# `workflow_dispatch` is included for manual runs, but note it only appears in
+# the Actions UI once this file is on the default branch — until then, the
+# `push` trigger on `release/**` is the reliable path.
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # Required for changesets to commit and push
+  pull-requests: write # Required for changesets to check existing PRs
+
+on:
+  push:
+    branches:
+      - 'release/**'
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release RC
+    # GitHub-hosted (not Blacksmith): npm provenance attestations, generated
+    # automatically by OIDC trusted publishing, are only accepted from
+    # github-hosted runners — self-hosted runners are rejected with E422.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6.0.9
+        name: Install pnpm
+        with:
+          run_install: false
+          # Supply-chain hardening — never cache the pnpm store; a poisoned
+          # cache entry would execute in this credential-bearing workflow.
+          cache: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          # No `cache:`, and package-manager-cache disabled. This workflow
+          # publishes to npm (OIDC trusted publishing) and must not restore the
+          # GitHub Actions cache — a cache-poisoning / supply-chain vector.
+          # Enforced by .github/workflows/tests-supply-chain.yml.
+          package-manager-cache: false
+
+      # node-pty's install hook falls back to `node-gyp rebuild` when no
+      # linux-x64 prebuild matches. pnpm/action-setup v6 no longer ships
+      # node-gyp on PATH, so install it explicitly.
+      - name: Install node-gyp
+        run: npm install -g node-gyp
+
+      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships
+      # npm 10.x. `changeset publish` shells out to this npm to publish.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Publish RC to npm
+        id: changesets
+        uses: changesets/action@v1.9.0
+        with:
+          # `release:rc` = `pnpm run build && changeset publish --tag rc`.
+          publish: pnpm run release:rc
+          commitMode: 'github-api'
+        env:
+          # No NPM_TOKEN — publishing authenticates via npm OIDC trusted
+          # publishing (id-token: write above). If NPM_TOKEN is set,
+          # changesets/action writes a token .npmrc that shadows OIDC and
+          # every publish fails with E404 (see npm/cli#8976).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint:runners": "node scripts/lint-no-hardcoded-runners.mjs",
     "lint:workflow-cache": "node scripts/lint-no-workflow-caching.mjs",
     "release": "pnpm run build && changeset publish",
+    "release:rc": "pnpm run build && changeset publish --tag rc",
     "test": "turbo test --filter './packages/*'",
     "test:e2e": "turbo run test:e2e",
     "test:scripts": "vitest run --config scripts/vitest.config.mjs"


### PR DESCRIPTION
Prep for cutting `@cipherstash/stack` (+ adapters) as **1.0.0-rc**, then GA. Lands on the v3 branch (`feat/eql-v3-text-search-schema`) so both the RC branch and eventual `main` inherit it. No release is performed by this PR.

## What's here

**1. `major` changeset** (`.changeset/eql-v3-1-0-ga.md`) for `@cipherstash/stack`, `@cipherstash/stack-drizzle`, `@cipherstash/stack-supabase`.

Why it's needed: the 36 pending v3 changesets are all `minor`/`patch`, so they resolve to **0.20.0** — nothing targets 1.0. `changeset status` with this added:

| package | bump | → version |
|---|---|---|
| `@cipherstash/stack` | **major** | **1.0.0** (`1.0.0-rc.0` in pre mode) |
| `@cipherstash/stack-drizzle` | **major** | **1.0.0** |
| `@cipherstash/stack-supabase` | **major** | **1.0.0** |
| `@cipherstash/schema` | patch | 3.0.2 *(own 3.x line — deliberately not majored)* |
| `@cipherstash/prisma-next` | minor | 0.4.0 *(own 0.x line — not majored)* |

`schema` is already at 3.x, so majoring it would produce **4.0.0** — checking versions caught that. `prisma-next` keeps its own 0.x line. If you *do* want `prisma-next` at 1.0 too, say so and I'll add it.

**2. `release-rc.yml`** — a faithful mirror of `release.yml` (same npm OIDC trusted publishing on a github-hosted runner for provenance), with two differences:
- runs on `release/**` branches, never `main` — so `main` keeps its 0.x cadence via `release.yml`, independent of this line;
- publishes under the **`rc`** npm dist-tag, so `@latest` is untouched (`npm i @cipherstash/stack` stays stable; `@rc` opts in).

It requires the release branch to be in Changesets **prerelease mode** (a committed `.changeset/pre.json`). `workflow_dispatch` is included but only shows in the UI once this file reaches the default branch — until then the `release/**` push trigger is the reliable path.

**3. `release:rc` script** — `pnpm run build && changeset publish --tag rc`.

## Cutting the RC (the irreversible steps — left to you)

From the v3 branch once this merges:
```bash
git switch -c release/1.0 feat/eql-v3-text-search-schema
pnpm changeset pre enter rc      # commits .changeset/pre.json (branch-local)
pnpm changeset:version           # → 1.0.0-rc.0 (+ CHANGELOGs); commit
git push -u origin release/1.0   # release-rc.yml opens a "Version Packages" PR
# merge that PR → release-rc.yml publishes 1.0.0-rc.0 under the `rc` tag
```
Iterate (`changeset version` → rc.1, rc.2…). For GA: `pnpm changeset pre exit`, `changeset version` → `1.0.0`, then bring `main` to the v3 line (its `major` changeset lands as the stable 1.0.0 via `release.yml`).

> Note on `rc.1`: pre mode's first version is `rc.0`. To publish `rc.1` specifically, version once more (or edit `pre.json`).

## Not needed here

CI-tooling + the GA changeset only — no separate changeset for the workflow/script, and no skill changes.