### PR TITLE
chore: enter pre-release mode (rc) → Stack family 1.0.0-rc.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,25 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@cipherstash/e2e": "0.0.2",
+    "@cipherstash/basic-example": "1.2.13",
+    "@cipherstash/prisma-next-example": "0.0.5",
+    "@cipherstash/supabase-worker-example": "0.0.0",
+    "@cipherstash/bench": "0.0.4",
+    "stash": "0.17.1",
+    "@cipherstash/drizzle": "3.0.3",
+    "@cipherstash/migrate": "0.2.0",
+    "@cipherstash/nextjs": "4.1.1",
+    "@cipherstash/prisma-next": "0.3.2",
+    "@cipherstash/protect": "12.0.1",
+    "@cipherstash/protect-dynamodb": "12.0.1",
+    "@cipherstash/schema": "3.0.1",
+    "@cipherstash/stack": "0.19.0",
+    "@cipherstash/stack-drizzle": "0.0.0",
+    "@cipherstash/stack-supabase": "0.0.0",
+    "@cipherstash/test-kit": "0.0.0",
+    "@cipherstash/wizard": "0.4.0"
+  },
+  "changesets": []
+}

--- a/.changeset/stack-1-0-0-rc.md
+++ b/.changeset/stack-1-0-0-rc.md
@@ -1,0 +1,13 @@
+---
+'@cipherstash/stack': major
+'@cipherstash/stack-drizzle': major
+'@cipherstash/stack-supabase': major
+'stash': major
+---
+
+CipherStash Stack 1.0 (release candidate).
+
+This is the first 1.0-line release of `@cipherstash/stack`, the first published
+release of the split-out EQL v3 adapters `@cipherstash/stack-drizzle` and
+`@cipherstash/stack-supabase`, and moves the `stash` CLI to 1.0 alongside them.
+These four packages now version together as the Stack 1.0 family.


### PR DESCRIPTION
Enters changesets **pre-release mode** (`rc` tag) and adds a **major** changeset for the Stack 1.0 family so the next release cuts `1.0.0-rc.0`.

## What this PR does
- `.changeset/pre.json` — enters pre mode with tag `rc`.
- `.changeset/stack-1-0-0-rc.md` — a `major` changeset for `@cipherstash/stack`, `@cipherstash/stack-drizzle`, `@cipherstash/stack-supabase`, and `stash`.

Verified locally (throwaway `changeset version`): those four resolve to **`1.0.0-rc.0`**; other packages with pending changesets take their own bump with an `-rc.0` suffix (e.g. `@cipherstash/schema → 3.0.2-rc.0`).

## What happens after merge
1. The `changesets/action` opens/updates a **"Version Packages" PR** showing `1.0.0-rc.0` for the four. **That PR is the review gate** — nothing publishes until it's merged.
2. Merging the Version Packages PR runs `pnpm run release` → publishes under the **`rc` npm dist-tag** (pre mode does this automatically; `latest` stays on current stable).

## Publishing prerequisites

- ✅ **New-package bootstrap — DONE.** `@cipherstash/stack-drizzle` and `@cipherstash/stack-supabase` had never been published, so npm OIDC trusted publishing couldn't authenticate them (a trusted publisher is configured per *existing* package). They have now been bootstrapped on the registry and **trusted publishing is configured** for both, so the OIDC publish in `release.yml` will authenticate them like the existing packages. No change to `release.yml` was needed — and deliberately **no `NPM_TOKEN`** was added (it would make changesets/action write a token `.npmrc` that shadows OIDC and fail the whole run: E404, npm/cli#8976).

## ⚠️ Still read before merging the Version Packages PR
- **Pre mode is repo-wide and sticky to `main`.** While `pre.json` is on main, *every* package with pending changesets publishes as `-rc.0` under the `rc` tag (not just the four), and successive merges yield rc.1, rc.2, …. For GA: `pnpm changeset pre exit`, PR to main, merge.

https://claude.ai/code/session_01MxTTPaPP16m6br7Hoab94w