### PR TITLE
docs(agents): correct the auth-strategy config key (config.authStrategy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ Three rules to remember when editing CI or pnpm config:
   - `bulkEncryptModels(models[], table)` / `bulkDecryptModels(models[])`
   - `encryptQuery(value, { table, column, queryType?, returnType? })` for searchable queries
   - `encryptQuery(terms[])` for batch query encryption
-- **Identity-aware encryption**: Authenticate the client as the end user with `OidcFederationStrategy` (`config.strategy`, re-exported from `@cipherstash/stack`), then chain `.withLockContext({ identityClaim })` on operations to bind the data key to a claim. The same claim must be used for encrypt and decrypt. (`LockContext.identify()` from `@cipherstash/stack/identity` is deprecated — the strategy now handles token acquisition; `.withLockContext()` also accepts a `LockContext`.)
+- **Identity-aware encryption**: Authenticate the client as the end user with `OidcFederationStrategy` (`config.authStrategy`, re-exported from `@cipherstash/stack`), then chain `.withLockContext({ identityClaim })` on operations to bind the data key to a claim. The same claim must be used for encrypt and decrypt. (`LockContext.identify()` from `@cipherstash/stack/identity` is deprecated — the strategy now handles token acquisition; `.withLockContext()` also accepts a `LockContext`.)
 - **Integrations**:
   - **Drizzle ORM**: `encryptedType`, `extractEncryptionSchema`, `createEncryptionOperators` from `@cipherstash/stack-drizzle` (EQL v3 factories from `@cipherstash/stack-drizzle/v3`)
   - **Supabase**: `encryptedSupabase` (v2) / `encryptedSupabaseV3` (v3) from `@cipherstash/stack-supabase`


### PR DESCRIPTION
One-line fix: AGENTS.md's identity-aware-encryption bullet named the config key `config.strategy`; the real `ClientConfig` key is **`authStrategy`** (`packages/stack/src/types.ts:145`, and the re-export comment in `packages/stack/src/index.ts` says the same).

Caught while re-reviewing #642 — its examples use the correct key; the drift was in the meta file. No changeset: AGENTS.md is repo-internal (not shipped in any tarball).

https://claude.ai/code/session_01MxTTPaPP16m6br7Hoab94w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated identity-aware encryption guidance to use the correct `config.authStrategy` setting when authenticating with OIDC federation.
  * Clarified the existing chaining and lock-context requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->