### PR TITLE
chore(deps): bump the actions-minor-patch group with 2 updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,11 +31,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/init@v4.36.2
+        uses: github/codeql-action/init@v4.36.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -282,7 +282,7 @@ jobs:
         run: npm install -g node-gyp
 
       - name: Install Deno
-        uses: denoland/setup-deno@v2.0.4
+        uses: denoland/setup-deno@v2.0.5
         with:
           deno-version: v2.x
 


### PR DESCRIPTION
Replaces #633 — Dependabot-authored PRs fail CI because the dependabot actor does not receive the repo secrets the test jobs need; this is the same change re-pushed from a maintainer branch so CI runs with full credentials.

Contents are the cherry-picked Dependabot commit; for the npm groups the lockfile was regenerated against current main (post-#667, which removed packages/drizzle from the workspace). Verified locally: build green.

When this merges, Dependabot will detect the dependencies are current and close #633 automatically.

https://claude.ai/code/session_01MxTTPaPP16m6br7Hoab94w