### PR TITLE
ci: skip secret-consuming live jobs on Dependabot PRs

### DIFF
--- a/.github/workflows/integration-drizzle.yml
+++ b/.github/workflows/integration-drizzle.yml
@@ -76,7 +76,12 @@ jobs:
       cancel-in-progress: false
     # Fork PRs have no secrets. Skip cleanly rather than fail on something the
     # contributor cannot fix — `tests.yml` still gives them a green signal.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Dependabot PRs are skipped for the same reason: they run under the
+    # Dependabot secret store, which does not carry the identity suites'
+    # CLERK_MACHINE_TOKEN, so the lock-context suite would fail-loud (by design
+    # it throws rather than skips) on a change Dependabot cannot fix. A
+    # dependency bump's real signal is `tests.yml` + the lockfile checks.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-prisma-next.yml
+++ b/.github/workflows/integration-prisma-next.yml
@@ -65,7 +65,11 @@ jobs:
       cancel-in-progress: false
     # Fork PRs have no secrets. Skip cleanly rather than fail on something the
     # contributor cannot fix — `tests.yml` still gives them a green signal.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Dependabot PRs skip for the same reason: they run under the Dependabot
+    # secret store (a distinct, narrower set), so a secret-consuming live suite
+    # can fail on a change Dependabot cannot fix. A dependency bump's real
+    # signal is `tests.yml` + the lockfile checks.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-supabase.yml
+++ b/.github/workflows/integration-supabase.yml
@@ -64,7 +64,11 @@ jobs:
       cancel-in-progress: false
     # Fork PRs have no secrets. Skip cleanly rather than fail loudly on something
     # the contributor cannot fix — `tests.yml` still gives them a green signal.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Dependabot PRs skip for the same reason: they run under the Dependabot
+    # secret store (a distinct, narrower set), so a secret-consuming live suite
+    # can fail on a change Dependabot cannot fix. A dependency bump's real
+    # signal is `tests.yml` + the lockfile checks.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     strategy:
       # A one-element matrix, not a cross-product: the Supabase adapter only ever

--- a/.github/workflows/prisma-example-readme-e2e.yml
+++ b/.github/workflows/prisma-example-readme-e2e.yml
@@ -33,7 +33,10 @@ jobs:
     # Skip cleanly on fork PRs where secrets aren't available. The
     # test's `describe.skipIf(!authConfigured)` would also skip, but
     # gating at the job level produces a clean "skipped" status.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Dependabot PRs skip too — they run under the Dependabot secret store, so a
+    # secret-consuming live suite can fail on a change Dependabot cannot fix;
+    # `tests.yml` + lockfile checks are the real signal for a dependency bump.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     env:
       CS_WORKSPACE_CRN: ${{ vars.CS_WORKSPACE_CRN }}

--- a/.github/workflows/prisma-next-e2e.yml
+++ b/.github/workflows/prisma-next-e2e.yml
@@ -34,8 +34,11 @@ jobs:
     # Skip cleanly on fork PRs where secrets aren't available. The
     # global-setup hook in the suite hard-errors when `CS_WORKSPACE_CRN`
     # is unset; gating at the job level produces a clean "skipped"
-    # status instead of a noisy failure.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # status instead of a noisy failure. Dependabot PRs skip too — they run
+    # under the Dependabot secret store, so a secret-consuming live suite can
+    # fail on a change Dependabot cannot fix; `tests.yml` + lockfile checks are
+    # the real signal for a dependency bump.
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
     env:
       CS_WORKSPACE_CRN: ${{ vars.CS_WORKSPACE_CRN }}


### PR DESCRIPTION
## Problem

Dependabot PRs (e.g. #689, a dev-dependency bump) hard-fail the live integration jobs, blocking them on something Dependabot can't fix.

Dependabot branches live **in this repo**, so the existing fork gate — `github.event.pull_request.head.repo.full_name == github.repository` — is `true` for them, and the secret-consuming live jobs run. But Dependabot PRs execute under the **Dependabot secret store**, a separate/narrower set than Actions secrets: it carries `CS_*` but not the identity suites' `CLERK_MACHINE_TOKEN`. The `lock-context` integration suite is deliberately *fail-not-skip* (a green skip could hide a regression), so it throws when the token is absent — and the whole `Drizzle v3 integration` job goes red on a change Dependabot cannot fix. #689 tripped it because the bump touches `packages/test-kit/**`, an integration trigger path.

## Fix

Give Dependabot PRs the same clean skip fork PRs already get: add `github.actor != 'dependabot[bot]'` to the job-level gate on all five secret-consuming workflows:

- `integration-drizzle.yml`
- `integration-supabase.yml`
- `integration-prisma-next.yml`
- `prisma-next-e2e.yml`
- `prisma-example-readme-e2e.yml`

A skipped required job reports success, so the PR is no longer blocked; `tests.yml` + the frozen-lockfile / OSV checks remain the real signal for a dependency bump. Not running live, secret-backed jobs on semi-trusted Dependabot PRs is also the supply-chain-safer default (aligns with the repo's supply-chain controls).

## After merge

`@dependabot rebase` on #689 (and future Dependabot PRs) so its run picks up the updated gate and the live jobs skip cleanly.

## Notes

- CI-only change; no published package surface touched, so no changeset.
- Push events are unaffected (`github.actor` is never `dependabot[bot]` on a push to `main`).

https://claude.ai/code/session_01MxTTPaPP16m6br7Hoab94w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated integration and end-to-end checks to skip Dependabot pull requests when required secrets are unavailable.
  * Checks continue to run for pushes and eligible pull requests from the repository.
  * Preserved existing handling for pull requests from forks, ensuring workflows do not run when required credentials cannot be accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->