### PR TITLE
feat(cli): per-column EQL v3 domain picker in stash schema build

### DIFF
--- a/.changeset/schema-build-v3-domain-picker.md
+++ b/.changeset/schema-build-v3-domain-picker.md
@@ -4,8 +4,10 @@
 
 `stash schema build` now picks a concrete EQL v3 domain per column
 (`TextSearch`, `IntegerOrd`, `TextEq`, …) instead of the legacy v2
-"searchable capabilities" toggle. Boolean and JSON columns are assigned
-their single storage-only domain automatically; other columns default to
-the widest searchable domain, matching the previous behaviour. The
-internal `SearchOp` capability tuple and the `v3DomainFactory` translation
-shim are removed, unblocking EQL v2 removal (#707, #751).
+"searchable capabilities" toggle. Boolean columns are assigned the
+storage-only `types.Boolean` domain automatically, while JSON columns are
+assigned the queryable `types.Json` domain, with encrypted containment and
+selector queries. Other columns default to the widest searchable domain,
+matching the previous behaviour. The internal `SearchOp` capability tuple
+and the `v3DomainFactory` translation shim are removed, unblocking EQL v2
+removal (#707, #751).

--- a/.changeset/schema-build-v3-domain-picker.md
+++ b/.changeset/schema-build-v3-domain-picker.md
@@ -1,0 +1,11 @@
+---
+'stash': patch
+---
+
+`stash schema build` now picks a concrete EQL v3 domain per column
+(`TextSearch`, `IntegerOrd`, `TextEq`, …) instead of the legacy v2
+"searchable capabilities" toggle. Boolean and JSON columns are assigned
+their single storage-only domain automatically; other columns default to
+the widest searchable domain, matching the previous behaviour. The
+internal `SearchOp` capability tuple and the `v3DomainFactory` translation
+shim are removed, unblocking EQL v2 removal (#707, #751).

--- a/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
+++ b/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
@@ -47,20 +47,31 @@ describe('generateClientFromSchemas', () => {
 // unions, so enumeration is complete — a fast-check property would sample the
 // same finite set and add nothing (and `packages/cli` has no fast-check dep).
 const ALL_DOMAINS: import('../types.js').V3Domain[] = [
-  'Text', 'TextEq', 'TextOrd', 'TextMatch', 'TextSearch',
-  'Integer', 'IntegerEq', 'IntegerOrd',
-  'Date', 'DateEq', 'DateOrd',
-  'Boolean', 'Json',
+  'Text',
+  'TextEq',
+  'TextOrd',
+  'TextMatch',
+  'TextSearch',
+  'Integer',
+  'IntegerEq',
+  'IntegerOrd',
+  'Date',
+  'DateEq',
+  'DateOrd',
+  'Boolean',
+  'Json',
 ]
 
-describe.each(['postgresql', 'drizzle'] as const)(
-  'generateClientFromSchemas domain round-trip (%s)',
-  (integration) => {
-    it.each(ALL_DOMAINS)('emits types.%s verbatim', (domain) => {
-      const s: SchemaDef[] = [{ tableName: 'x', columns: [{ name: 'c', domain }] }]
-      expect(generateClientFromSchemas(integration, s)).toContain(
-        `c: types.${domain}('c'),`,
-      )
-    })
-  },
-)
+describe.each([
+  'postgresql',
+  'drizzle',
+] as const)('generateClientFromSchemas domain round-trip (%s)', (integration) => {
+  it.each(ALL_DOMAINS)('emits types.%s verbatim', (domain) => {
+    const s: SchemaDef[] = [
+      { tableName: 'x', columns: [{ name: 'c', domain }] },
+    ]
+    expect(generateClientFromSchemas(integration, s)).toContain(
+      `c: types.${domain}('c'),`,
+    )
+  })
+})

--- a/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
+++ b/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { SchemaDef } from '../types.js'
+import { generateClientFromSchemas } from '../utils.js'
+
+const schemas: SchemaDef[] = [
+  {
+    tableName: 'users',
+    columns: [
+      { name: 'email', domain: 'TextSearch' },
+      { name: 'age', domain: 'IntegerOrd' },
+      { name: 'verified', domain: 'Boolean' },
+    ],
+  },
+]
+
+describe('generateClientFromSchemas', () => {
+  it('emits the chosen v3 domain factory per column (generic/postgresql)', () => {
+    const out = generateClientFromSchemas('postgresql', schemas)
+    expect(out).toContain("email: types.TextSearch('email'),")
+    expect(out).toContain("age: types.IntegerOrd('age'),")
+    expect(out).toContain("verified: types.Boolean('verified'),")
+    expect(out).toContain("from '@cipherstash/stack/v3'")
+    expect(out).toContain('EncryptionV3(')
+  })
+
+  it('emits the chosen v3 domain factory per column (drizzle)', () => {
+    const out = generateClientFromSchemas('drizzle', schemas)
+    expect(out).toContain("email: types.TextSearch('email'),")
+    expect(out).toContain("age: types.IntegerOrd('age'),")
+    expect(out).toContain('extractEncryptionSchemaV3')
+    expect(out).toContain("from '@cipherstash/stack-drizzle/v3'")
+  })
+
+  it('carries no residual v2 capability vocabulary', () => {
+    const generic = generateClientFromSchemas('postgresql', schemas)
+    const drizzle = generateClientFromSchemas('drizzle', schemas)
+    for (const out of [generic, drizzle]) {
+      expect(out).not.toMatch(/searchOps/)
+      expect(out).not.toMatch(/freeTextSearch|orderAndRange|\.equality\(/)
+    }
+  })
+})
+
+// Exhaustive round-trip over the closed V3Domain union: the sample fixtures
+// above only exercise 3 of 13 domains, so every domain is proven to emit
+// verbatim through both generators. `V3Domain` and `DataType` are finite closed
+// unions, so enumeration is complete — a fast-check property would sample the
+// same finite set and add nothing (and `packages/cli` has no fast-check dep).
+const ALL_DOMAINS: import('../types.js').V3Domain[] = [
+  'Text', 'TextEq', 'TextOrd', 'TextMatch', 'TextSearch',
+  'Integer', 'IntegerEq', 'IntegerOrd',
+  'Date', 'DateEq', 'DateOrd',
+  'Boolean', 'Json',
+]
+
+describe.each(['postgresql', 'drizzle'] as const)(
+  'generateClientFromSchemas domain round-trip (%s)',
+  (integration) => {
+    it.each(ALL_DOMAINS)('emits types.%s verbatim', (domain) => {
+      const s: SchemaDef[] = [{ tableName: 'x', columns: [{ name: 'c', domain }] }]
+      expect(generateClientFromSchemas(integration, s)).toContain(
+        `c: types.${domain}('c'),`,
+      )
+    })
+  },
+)

--- a/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
+++ b/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
@@ -39,6 +39,16 @@ describe('generateClientFromSchemas', () => {
       expect(out).not.toMatch(/freeTextSearch|orderAndRange|\.equality\(/)
     }
   })
+
+  it('routes supabase through the generic generator, not drizzle', () => {
+    // `supabase` and `postgresql` share generateGenericFromSchemas; a misroute
+    // (dropping the `case 'supabase':` fallthrough, or routing it to drizzle)
+    // is otherwise uncovered — the other cases only exercise postgresql/drizzle.
+    const out = generateClientFromSchemas('supabase', schemas)
+    expect(out).toContain("email: types.TextSearch('email'),")
+    expect(out).toContain("from '@cipherstash/stack/v3'")
+    expect(out).not.toContain('@cipherstash/stack-drizzle')
+  })
 })
 
 // Exhaustive round-trip over the closed V3Domain union: the sample fixtures

--- a/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
+++ b/packages/cli/src/commands/init/__tests__/utils-codegen.test.ts
@@ -49,6 +49,15 @@ describe('generateClientFromSchemas', () => {
     expect(out).toContain("from '@cipherstash/stack/v3'")
     expect(out).not.toContain('@cipherstash/stack-drizzle')
   })
+
+  it('throws for prisma-next instead of returning an undefined client', () => {
+    // prisma-next is unreachable from schema/build.ts, but the switch must stay
+    // total: fail loudly rather than silently returning undefined (which would
+    // write a broken client file) if a caller ever routes it here.
+    expect(() => generateClientFromSchemas('prisma-next', schemas)).toThrow(
+      /does not generate a prisma-next client/,
+    )
+  })
 })
 
 // Exhaustive round-trip over the closed V3Domain union: the sample fixtures

--- a/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const selectMock = vi.fn()
+const multiselectMock = vi.fn()
+const confirmMock = vi.fn()
+const CANCEL = Symbol('clack.cancel')
+vi.mock('@clack/prompts', () => ({
+  select: (...a: unknown[]) => selectMock(...a),
+  multiselect: (...a: unknown[]) => multiselectMock(...a),
+  confirm: (...a: unknown[]) => confirmMock(...a),
+  isCancel: (v: unknown) => v === CANCEL,
+  log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+}))
+
+const queryMock = vi.fn()
+vi.mock('pg', () => ({
+  default: {
+    Client: vi.fn(() => ({
+      connect: vi.fn(async () => {}),
+      query: queryMock,
+      end: vi.fn(async () => {}),
+    })),
+  },
+}))
+
+const { buildSchemasFromDatabase } = await import('../introspect.js')
+const { generateClientFromSchemas } = await import('../../utils.js')
+
+describe('build flow (introspect → pick → codegen)', () => {
+  beforeEach(() => {
+    selectMock.mockReset()
+    multiselectMock.mockReset()
+    confirmMock.mockReset()
+    queryMock.mockResolvedValue({
+      rows: [
+        { table_name: 'users', column_name: 'email', data_type: 'text', udt_name: 'text' },
+        { table_name: 'orders', column_name: 'total', data_type: 'integer', udt_name: 'int4' },
+      ],
+    })
+  })
+
+  it('walks two tables and emits a v3 client with the chosen domains', async () => {
+    selectMock
+      .mockResolvedValueOnce('users').mockResolvedValueOnce('TextEq') // table 1 + email
+      .mockResolvedValueOnce('orders').mockResolvedValueOnce('IntegerOrd') // table 2 + total
+    multiselectMock
+      .mockResolvedValueOnce(['email'])
+      .mockResolvedValueOnce(['total'])
+    confirmMock.mockResolvedValueOnce(true) // "encrypt columns in another table?"
+
+    const schemas = await buildSchemasFromDatabase('postgresql://x')
+    expect(schemas).toHaveLength(2)
+
+    const out = generateClientFromSchemas('postgresql', schemas!)
+    expect(out).toContain("email: types.TextEq('email'),")
+    expect(out).toContain("total: types.IntegerOrd('total'),")
+    expect(out).not.toMatch(/searchOps|v3DomainFactory/)
+  })
+
+  it('stops after the first table when the user declines another', async () => {
+    selectMock.mockResolvedValueOnce('users').mockResolvedValueOnce('TextEq')
+    multiselectMock.mockResolvedValueOnce(['email'])
+    confirmMock.mockResolvedValueOnce(false) // decline "another table?"
+
+    const schemas = await buildSchemasFromDatabase('postgresql://x')
+    expect(schemas).toEqual([
+      { tableName: 'users', columns: [{ name: 'email', domain: 'TextEq' }] },
+    ])
+  })
+
+  it('returns undefined for an empty public schema', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    expect(await buildSchemasFromDatabase('postgresql://x')).toBeUndefined()
+  })
+})

--- a/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
@@ -63,8 +63,9 @@ describe('build flow (introspect → pick → codegen)', () => {
 
     const schemas = await buildSchemasFromDatabase('postgresql://x')
     expect(schemas).toHaveLength(2)
+    if (!schemas) throw new Error('expected schemas to be defined')
 
-    const out = generateClientFromSchemas('postgresql', schemas!)
+    const out = generateClientFromSchemas('postgresql', schemas)
     expect(out).toContain("email: types.TextEq('email'),")
     expect(out).toContain("total: types.IntegerOrd('total'),")
     expect(out).not.toMatch(/searchOps|v3DomainFactory/)

--- a/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
@@ -34,16 +34,28 @@ describe('build flow (introspect → pick → codegen)', () => {
     confirmMock.mockReset()
     queryMock.mockResolvedValue({
       rows: [
-        { table_name: 'users', column_name: 'email', data_type: 'text', udt_name: 'text' },
-        { table_name: 'orders', column_name: 'total', data_type: 'integer', udt_name: 'int4' },
+        {
+          table_name: 'users',
+          column_name: 'email',
+          data_type: 'text',
+          udt_name: 'text',
+        },
+        {
+          table_name: 'orders',
+          column_name: 'total',
+          data_type: 'integer',
+          udt_name: 'int4',
+        },
       ],
     })
   })
 
   it('walks two tables and emits a v3 client with the chosen domains', async () => {
     selectMock
-      .mockResolvedValueOnce('users').mockResolvedValueOnce('TextEq') // table 1 + email
-      .mockResolvedValueOnce('orders').mockResolvedValueOnce('IntegerOrd') // table 2 + total
+      .mockResolvedValueOnce('users')
+      .mockResolvedValueOnce('TextEq') // table 1 + email
+      .mockResolvedValueOnce('orders')
+      .mockResolvedValueOnce('IntegerOrd') // table 2 + total
     multiselectMock
       .mockResolvedValueOnce(['email'])
       .mockResolvedValueOnce(['total'])

--- a/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/build-flow.integration.test.ts
@@ -86,4 +86,22 @@ describe('build flow (introspect → pick → codegen)', () => {
     queryMock.mockResolvedValueOnce({ rows: [] })
     expect(await buildSchemasFromDatabase('postgresql://x')).toBeUndefined()
   })
+
+  it('returns undefined when the database connection/introspection fails', async () => {
+    // introspectDatabase throws → buildSchemasFromDatabase catches, stops the
+    // spinner, logs the error, and returns undefined rather than propagating.
+    queryMock.mockReset()
+    queryMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+    expect(await buildSchemasFromDatabase('postgresql://x')).toBeUndefined()
+  })
+
+  it('returns undefined when the "another table?" prompt is cancelled', async () => {
+    // Distinct from declining (false): cancelling (Ctrl-C) mid-loop must abort
+    // the whole build, not return the tables gathered so far.
+    selectMock.mockResolvedValueOnce('users').mockResolvedValueOnce('TextEq')
+    multiselectMock.mockResolvedValueOnce(['email'])
+    confirmMock.mockResolvedValueOnce(CANCEL) // cancel the "another table?" prompt
+
+    expect(await buildSchemasFromDatabase('postgresql://x')).toBeUndefined()
+  })
 })

--- a/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as p from '@clack/prompts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   candidateDomains,
   defaultDomain,
@@ -44,7 +44,13 @@ describe('pgTypeToDataType', () => {
 describe('candidateDomains', () => {
   it('offers the full text ladder for strings', () => {
     const values = candidateDomains('string').map((o) => o.value)
-    expect(values).toEqual(['Text', 'TextEq', 'TextOrd', 'TextMatch', 'TextSearch'])
+    expect(values).toEqual([
+      'Text',
+      'TextEq',
+      'TextOrd',
+      'TextMatch',
+      'TextSearch',
+    ])
   })
 
   it('offers the integer ladder for numbers', () => {
@@ -97,9 +103,24 @@ describe('selectTableColumns', () => {
     {
       tableName: 'users',
       columns: [
-        { columnName: 'email', dataType: 'text', udtName: 'text', isEqlEncrypted: false },
-        { columnName: 'age', dataType: 'integer', udtName: 'int4', isEqlEncrypted: false },
-        { columnName: 'verified', dataType: 'boolean', udtName: 'bool', isEqlEncrypted: false },
+        {
+          columnName: 'email',
+          dataType: 'text',
+          udtName: 'text',
+          isEqlEncrypted: false,
+        },
+        {
+          columnName: 'age',
+          dataType: 'integer',
+          udtName: 'int4',
+          isEqlEncrypted: false,
+        },
+        {
+          columnName: 'verified',
+          dataType: 'boolean',
+          udtName: 'bool',
+          isEqlEncrypted: false,
+        },
       ],
     },
   ]
@@ -160,7 +181,12 @@ describe('selectTableColumns', () => {
       {
         tableName: 'accounts',
         columns: [
-          { columnName: 'ssn', dataType: 'text', udtName: 'eql_v2_encrypted', isEqlEncrypted: true },
+          {
+            columnName: 'ssn',
+            dataType: 'text',
+            udtName: 'eql_v2_encrypted',
+            isEqlEncrypted: true,
+          },
         ],
       },
     ]

--- a/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  candidateDomains,
+  defaultDomain,
+  pgTypeToDataType,
+} from '../introspect.js'
+
+describe('pgTypeToDataType', () => {
+  it('maps integer/float/numeric udt names to number', () => {
+    for (const udt of ['int2', 'int4', 'int8', 'float4', 'float8', 'numeric']) {
+      expect(pgTypeToDataType(udt)).toBe('number')
+    }
+  })
+
+  it('maps bool to boolean, date/timestamp to date, json/jsonb to json', () => {
+    expect(pgTypeToDataType('bool')).toBe('boolean')
+    expect(pgTypeToDataType('date')).toBe('date')
+    expect(pgTypeToDataType('timestamptz')).toBe('date')
+    expect(pgTypeToDataType('jsonb')).toBe('json')
+  })
+
+  it('falls back to string for unknown udt names', () => {
+    expect(pgTypeToDataType('citext')).toBe('string')
+  })
+})
+
+describe('candidateDomains', () => {
+  it('offers the full text ladder for strings', () => {
+    const values = candidateDomains('string').map((o) => o.value)
+    expect(values).toEqual(['Text', 'TextEq', 'TextOrd', 'TextMatch', 'TextSearch'])
+  })
+
+  it('offers the integer ladder for numbers', () => {
+    const values = candidateDomains('number').map((o) => o.value)
+    expect(values).toEqual(['Integer', 'IntegerEq', 'IntegerOrd'])
+  })
+
+  it('offers the date ladder for dates', () => {
+    const values = candidateDomains('date').map((o) => o.value)
+    expect(values).toEqual(['Date', 'DateEq', 'DateOrd'])
+  })
+
+  it('offers a single storage-only domain for boolean and json', () => {
+    expect(candidateDomains('boolean').map((o) => o.value)).toEqual(['Boolean'])
+    expect(candidateDomains('json').map((o) => o.value)).toEqual(['Json'])
+  })
+
+  it('gives every option a label and a hint', () => {
+    for (const opt of candidateDomains('string')) {
+      expect(opt.label.length).toBeGreaterThan(0)
+      expect(opt.hint.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('defaultDomain', () => {
+  it('defaults to the widest searchable domain per type', () => {
+    expect(defaultDomain('string')).toBe('TextSearch')
+    expect(defaultDomain('number')).toBe('IntegerOrd')
+    expect(defaultDomain('date')).toBe('DateOrd')
+    expect(defaultDomain('boolean')).toBe('Boolean')
+    expect(defaultDomain('json')).toBe('Json')
+  })
+
+  it('always returns a member of that type candidate set', () => {
+    for (const dt of ['string', 'number', 'date', 'boolean', 'json'] as const) {
+      const values = candidateDomains(dt).map((o) => o.value)
+      expect(values).toContain(defaultDomain(dt))
+    }
+  })
+})

--- a/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
@@ -1,9 +1,26 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as p from '@clack/prompts'
 import {
   candidateDomains,
   defaultDomain,
   pgTypeToDataType,
+  selectTableColumns,
 } from '../introspect.js'
+
+const selectMock = vi.fn()
+const multiselectMock = vi.fn()
+// Real clack signals cancellation by returning a unique symbol that `isCancel`
+// checks by identity. Model that faithfully with a sentinel so cancellation
+// branches are reachable — a hardcoded `isCancel: () => false` would make them
+// structurally untestable.
+const CANCEL = Symbol('clack.cancel')
+vi.mock('@clack/prompts', () => ({
+  select: (...args: unknown[]) => selectMock(...args),
+  multiselect: (...args: unknown[]) => multiselectMock(...args),
+  isCancel: (v: unknown) => v === CANCEL,
+  log: { info: vi.fn(), success: vi.fn() },
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+}))
 
 describe('pgTypeToDataType', () => {
   it('maps integer/float/numeric udt names to number', () => {
@@ -67,5 +84,97 @@ describe('defaultDomain', () => {
       const values = candidateDomains(dt).map((o) => o.value)
       expect(values).toContain(defaultDomain(dt))
     }
+  })
+})
+
+describe('selectTableColumns', () => {
+  beforeEach(() => {
+    selectMock.mockReset()
+    multiselectMock.mockReset()
+  })
+
+  const tables = [
+    {
+      tableName: 'users',
+      columns: [
+        { columnName: 'email', dataType: 'text', udtName: 'text', isEqlEncrypted: false },
+        { columnName: 'age', dataType: 'integer', udtName: 'int4', isEqlEncrypted: false },
+        { columnName: 'verified', dataType: 'boolean', udtName: 'bool', isEqlEncrypted: false },
+      ],
+    },
+  ]
+
+  it('assigns the per-column domain chosen at the select prompt', async () => {
+    // 1st select: which table. Then one select per multi-domain column.
+    selectMock
+      .mockResolvedValueOnce('users') // table pick
+      .mockResolvedValueOnce('TextEq') // email domain
+      .mockResolvedValueOnce('IntegerOrd') // age domain
+    // boolean has a single domain → no prompt for it.
+    multiselectMock.mockResolvedValueOnce(['email', 'age', 'verified'])
+
+    const schema = await selectTableColumns(tables)
+
+    expect(schema).toEqual({
+      tableName: 'users',
+      columns: [
+        { name: 'email', domain: 'TextEq' },
+        { name: 'age', domain: 'IntegerOrd' },
+        { name: 'verified', domain: 'Boolean' },
+      ],
+    })
+  })
+
+  it('does not prompt for single-domain (boolean/json) columns', async () => {
+    selectMock.mockResolvedValueOnce('users')
+    multiselectMock.mockResolvedValueOnce(['verified'])
+
+    const schema = await selectTableColumns(tables)
+
+    // Only the table pick consumed a select; the boolean column did not.
+    expect(selectMock).toHaveBeenCalledTimes(1)
+    expect(schema?.columns).toEqual([{ name: 'verified', domain: 'Boolean' }])
+  })
+
+  it('returns undefined when the table prompt is cancelled', async () => {
+    selectMock.mockResolvedValueOnce(CANCEL)
+    expect(await selectTableColumns(tables)).toBeUndefined()
+  })
+
+  it('returns undefined when the column multiselect is cancelled', async () => {
+    selectMock.mockResolvedValueOnce('users')
+    multiselectMock.mockResolvedValueOnce(CANCEL)
+    expect(await selectTableColumns(tables)).toBeUndefined()
+  })
+
+  it('returns undefined when a per-column domain prompt is cancelled', async () => {
+    selectMock
+      .mockResolvedValueOnce('users') // table pick
+      .mockResolvedValueOnce(CANCEL) // email domain → cancelled
+    multiselectMock.mockResolvedValueOnce(['email', 'age'])
+    expect(await selectTableColumns(tables)).toBeUndefined()
+  })
+
+  it('pre-selects eql-encrypted columns and still assigns them a domain', async () => {
+    const withEql = [
+      {
+        tableName: 'accounts',
+        columns: [
+          { columnName: 'ssn', dataType: 'text', udtName: 'eql_v2_encrypted', isEqlEncrypted: true },
+        ],
+      },
+    ]
+    selectMock
+      .mockResolvedValueOnce('accounts') // table pick
+      .mockResolvedValueOnce('TextSearch') // ssn domain
+    multiselectMock.mockResolvedValueOnce(['ssn'])
+
+    const schema = await selectTableColumns(withEql)
+
+    // The "detected N pre-selected" notice fired for the eql column…
+    expect(p.log.info).toHaveBeenCalled()
+    // …and the column is mapped through pgTypeToDataType('eql_v2_encrypted')
+    // which falls back to 'string', so it still receives its chosen domain.
+    expect(schema?.columns).toEqual([{ name: 'ssn', domain: 'TextSearch' }])
   })
 })

--- a/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
@@ -1,5 +1,7 @@
+import { types } from '@cipherstash/stack/eql/v3'
 import * as p from '@clack/prompts'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DataType } from '../../types.js'
 import {
   candidateDomains,
   defaultDomain,
@@ -202,5 +204,36 @@ describe('selectTableColumns', () => {
     // …and the column is mapped through pgTypeToDataType('eql_v2_encrypted')
     // which falls back to 'string', so it still receives its chosen domain.
     expect(schema?.columns).toEqual([{ name: 'ssn', domain: 'TextSearch' }])
+  })
+})
+
+describe('v3 domain drift guard', () => {
+  // The picker's V3Domain names are a curated subset of the factory names on
+  // the real `types` namespace from `@cipherstash/stack/eql/v3` — codegen emits
+  // `types.<domain>(...)`, so a domain the picker offers that no longer exists
+  // upstream would generate a client that fails to compile in the user's repo.
+  // This asserts every offered domain resolves to a real factory, so a rename
+  // or removal in stack fails here (in CI) rather than silently. It is the
+  // enforced counterpart to the reviewer's "avoid drift" concern; a plain type
+  // alias is not enough because `packages/cli` has no `tsc --noEmit` step (its
+  // build is tsup + Biome + vitest, none of which check an unused type).
+  it('every domain the picker can offer is a real @cipherstash/stack/eql/v3 factory', () => {
+    const dataTypes: DataType[] = [
+      'string',
+      'number',
+      'boolean',
+      'date',
+      'json',
+    ]
+    const offered = dataTypes.flatMap((dt) =>
+      candidateDomains(dt).map((o) => o.value),
+    )
+
+    for (const domain of offered) {
+      expect(
+        types,
+        `@cipherstash/stack/eql/v3 has no "${domain}" factory — the picker would emit types.${domain}(...) which no longer exists`,
+      ).toHaveProperty(domain)
+    }
   })
 })

--- a/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/introspect.test.ts
@@ -93,6 +93,14 @@ describe('defaultDomain', () => {
       expect(values).toContain(defaultDomain(dt))
     }
   })
+
+  it('returns the last value of a supplied candidate list (array overload)', () => {
+    // The picker loop passes its already-computed options through this branch;
+    // asserts it reads the widest (last), not the narrowest (first).
+    expect(defaultDomain([{ value: 'TextEq' }, { value: 'TextSearch' }])).toBe(
+      'TextSearch',
+    )
+  })
 })
 
 describe('selectTableColumns', () => {
@@ -204,6 +212,30 @@ describe('selectTableColumns', () => {
     // …and the column is mapped through pgTypeToDataType('eql_v2_encrypted')
     // which falls back to 'string', so it still receives its chosen domain.
     expect(schema?.columns).toEqual([{ name: 'ssn', domain: 'TextSearch' }])
+  })
+
+  it('pre-selects the widest searchable domain as the per-column default', async () => {
+    // Asserts the ARGS to the domain prompt, not just its return: the picker
+    // must pass initialValue: defaultDomain(options) so the widest searchable
+    // domain is pre-highlighted. Regressing to options[0] (narrowest) or
+    // dropping initialValue would still return the mocked value and pass every
+    // other test — only this one catches it.
+    selectMock
+      .mockResolvedValueOnce('users') // table pick
+      .mockResolvedValueOnce('TextSearch') // email domain
+      .mockResolvedValueOnce('IntegerOrd') // age domain
+    multiselectMock.mockResolvedValueOnce(['email', 'age'])
+
+    await selectTableColumns(tables)
+
+    expect(selectMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ initialValue: 'TextSearch' }),
+    )
+    expect(selectMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ initialValue: 'IntegerOrd' }),
+    )
   })
 })
 

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -201,24 +201,33 @@ export async function selectTableColumns(
 
   if (p.isCancel(selectedColumns)) return undefined
 
-  const searchable = await p.confirm({
-    message:
-      'Enable searchable encryption on these columns? (you can fine-tune indexes later)',
-    initialValue: true,
-  })
-
-  if (p.isCancel(searchable)) return undefined
-
-  const columns: ColumnDef[] = selectedColumns.map((colName) => {
+  const columns: ColumnDef[] = []
+  for (const colName of selectedColumns) {
     const dbCol = table.columns.find((c) => c.columnName === colName)
     if (!dbCol) {
       // Unreachable — multiselect only emits values from the source array.
       throw new Error(`Column ${colName} not found in table ${selectedTable}`)
     }
     const dataType = pgTypeToDataType(dbCol.udtName)
-    const searchOps = searchable ? allSearchOps(dataType) : []
-    return { name: colName, dataType, searchOps }
-  })
+    const options = candidateDomains(dataType)
+
+    // Single-domain types (boolean, json) have nothing to choose — assign the
+    // only domain without interrupting the user with a one-option prompt.
+    if (options.length === 1) {
+      columns.push({ name: colName, domain: options[0].value })
+      continue
+    }
+
+    const domain = await p.select<V3Domain>({
+      message: `Encryption domain for "${colName}" (${dataType})?`,
+      options,
+      initialValue: defaultDomain(dataType),
+    })
+
+    if (p.isCancel(domain)) return undefined
+
+    columns.push({ name: colName, domain })
+  }
 
   p.log.success(
     `Schema defined: ${selectedTable} with ${columns.length} encrypted column${columns.length !== 1 ? 's' : ''}`,

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -111,6 +111,11 @@ export async function introspectDatabase(
 export function candidateDomains(
   dataType: DataType,
 ): Array<{ value: V3Domain; label: string; hint: string }> {
+  // Hints show capability + the operators/functions each domain answers.
+  // EQL v3 emits `eql_v3.*()` function calls for comparison/match (not native
+  // SQL operators); JSON is the exception, using real `@>` (containment) and
+  // `->` (selector) operators. The bracketed sets below are logical shorthand
+  // matching the Drizzle-facing operator names, grounded in the v3 sql-dialect.
   switch (dataType) {
     case 'string':
       return [
@@ -119,38 +124,46 @@ export function candidateDomains(
           label: 'Text',
           hint: 'storage only — encrypt/decrypt, no queries',
         },
-        { value: 'TextEq', label: 'TextEq', hint: 'equality (=, IN)' },
+        { value: 'TextEq', label: 'TextEq', hint: 'equality (=, <>, IN)' },
         {
           value: 'TextOrd',
           label: 'TextOrd',
-          hint: 'equality + order/range (<, >, BETWEEN, sort)',
+          hint: 'equality + order/range (=, <, >, <=, >=, BETWEEN, ORDER BY)',
         },
         {
           value: 'TextMatch',
           label: 'TextMatch',
-          hint: 'free-text match only',
+          hint: 'free-text match only (matches())',
         },
         {
           value: 'TextSearch',
           label: 'TextSearch',
-          hint: 'equality + order/range + free-text',
+          hint: 'equality + order/range + free-text (=, <, >, BETWEEN, ORDER BY, matches())',
         },
       ]
     case 'number':
       return [
         { value: 'Integer', label: 'Integer', hint: 'storage only' },
-        { value: 'IntegerEq', label: 'IntegerEq', hint: 'equality (=, IN)' },
+        {
+          value: 'IntegerEq',
+          label: 'IntegerEq',
+          hint: 'equality (=, <>, IN)',
+        },
         {
           value: 'IntegerOrd',
           label: 'IntegerOrd',
-          hint: 'equality + order/range',
+          hint: 'equality + order/range (=, <, >, <=, >=, BETWEEN, ORDER BY)',
         },
       ]
     case 'date':
       return [
         { value: 'Date', label: 'Date', hint: 'storage only' },
-        { value: 'DateEq', label: 'DateEq', hint: 'equality (=, IN)' },
-        { value: 'DateOrd', label: 'DateOrd', hint: 'equality + order/range' },
+        { value: 'DateEq', label: 'DateEq', hint: 'equality (=, <>, IN)' },
+        {
+          value: 'DateOrd',
+          label: 'DateOrd',
+          hint: 'equality + order/range (=, <, >, <=, >=, BETWEEN, ORDER BY)',
+        },
       ]
     case 'boolean':
       return [{ value: 'Boolean', label: 'Boolean', hint: 'storage only' }]
@@ -159,7 +172,7 @@ export function candidateDomains(
         {
           value: 'Json',
           label: 'Json',
-          hint: 'encrypted-JSONB containment + selectors',
+          hint: 'encrypted-JSONB containment + selectors (@>, ->; =, <, >, BETWEEN, ORDER BY at a path)',
         },
       ]
   }

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -167,13 +167,19 @@ export function candidateDomains(
 /**
  * The default domain pre-selected in the picker: the widest searchable domain
  * for the type. Mirrors the pre-v3 scaffold, which enabled every capability on
- * every selected column by default. Derived from `candidateDomains` (whose
- * lists are ordered narrowest→widest) so the "widest is the default" invariant
- * has a single source of truth — reordering a candidate list moves the default
- * with it, and the two can never silently drift.
+ * every selected column by default. Reads the last entry of the `candidateDomains`
+ * list (ordered narrowest→widest) so the "widest is the default" invariant has a
+ * single source of truth — reordering a candidate list moves the default with it,
+ * and the two can never silently drift.
+ *
+ * Accepts either a `DataType` (looks the candidates up) or an already-computed
+ * candidate list, so a caller that already holds the options — like the picker
+ * loop — can reuse them instead of recomputing `candidateDomains`.
  */
-export function defaultDomain(dataType: DataType): V3Domain {
-  const options = candidateDomains(dataType)
+export function defaultDomain(
+  from: DataType | Array<{ value: V3Domain }>,
+): V3Domain {
+  const options = Array.isArray(from) ? from : candidateDomains(from)
   return options[options.length - 1].value
 }
 
@@ -247,7 +253,7 @@ export async function selectTableColumns(
     const domain = await p.select<V3Domain>({
       message: `Encryption domain for "${colName}" (${dataType})?`,
       options,
-      initialValue: defaultDomain(dataType),
+      initialValue: defaultDomain(options),
     })
 
     if (p.isCancel(domain)) return undefined

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -113,17 +113,37 @@ export function candidateDomains(
   switch (dataType) {
     case 'string':
       return [
-        { value: 'Text', label: 'Text', hint: 'storage only — encrypt/decrypt, no queries' },
+        {
+          value: 'Text',
+          label: 'Text',
+          hint: 'storage only — encrypt/decrypt, no queries',
+        },
         { value: 'TextEq', label: 'TextEq', hint: 'equality (=, IN)' },
-        { value: 'TextOrd', label: 'TextOrd', hint: 'equality + order/range (<, >, BETWEEN, sort)' },
-        { value: 'TextMatch', label: 'TextMatch', hint: 'free-text match only' },
-        { value: 'TextSearch', label: 'TextSearch', hint: 'equality + order/range + free-text' },
+        {
+          value: 'TextOrd',
+          label: 'TextOrd',
+          hint: 'equality + order/range (<, >, BETWEEN, sort)',
+        },
+        {
+          value: 'TextMatch',
+          label: 'TextMatch',
+          hint: 'free-text match only',
+        },
+        {
+          value: 'TextSearch',
+          label: 'TextSearch',
+          hint: 'equality + order/range + free-text',
+        },
       ]
     case 'number':
       return [
         { value: 'Integer', label: 'Integer', hint: 'storage only' },
         { value: 'IntegerEq', label: 'IntegerEq', hint: 'equality (=, IN)' },
-        { value: 'IntegerOrd', label: 'IntegerOrd', hint: 'equality + order/range' },
+        {
+          value: 'IntegerOrd',
+          label: 'IntegerOrd',
+          hint: 'equality + order/range',
+        },
       ]
     case 'date':
       return [
@@ -134,7 +154,13 @@ export function candidateDomains(
     case 'boolean':
       return [{ value: 'Boolean', label: 'Boolean', hint: 'storage only' }]
     case 'json':
-      return [{ value: 'Json', label: 'Json', hint: 'encrypted-JSONB containment + selectors' }]
+      return [
+        {
+          value: 'Json',
+          label: 'Json',
+          hint: 'encrypted-JSONB containment + selectors',
+        },
+      ]
   }
 }
 

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -1,6 +1,6 @@
 import * as p from '@clack/prompts'
 import pg from 'pg'
-import type { ColumnDef, DataType, SchemaDef, SearchOp } from '../types.js'
+import type { ColumnDef, DataType, SchemaDef, V3Domain } from '../types.js'
 
 export interface DbColumn {
   columnName: string
@@ -99,12 +99,56 @@ export async function introspectDatabase(
   }
 }
 
-function allSearchOps(dataType: DataType): SearchOp[] {
-  const ops: SearchOp[] = ['equality', 'orderAndRange']
-  if (dataType === 'string') {
-    ops.push('freeTextSearch')
+/**
+ * The v3 domains offerable for a scaffolded column of the given `DataType`,
+ * ordered narrowest→widest so the interactive picker reads as an escalating
+ * ladder. Each domain's query capability is fixed by its type — there is no
+ * capability tuple. `boolean` and `json` have exactly one domain (storage
+ * only); numeric and date types collapse to the `Integer*` / `Date*` families
+ * because `pgTypeToDataType` carries no width/precision signal.
+ */
+export function candidateDomains(
+  dataType: DataType,
+): Array<{ value: V3Domain; label: string; hint: string }> {
+  switch (dataType) {
+    case 'string':
+      return [
+        { value: 'Text', label: 'Text', hint: 'storage only — encrypt/decrypt, no queries' },
+        { value: 'TextEq', label: 'TextEq', hint: 'equality (=, IN)' },
+        { value: 'TextOrd', label: 'TextOrd', hint: 'equality + order/range (<, >, BETWEEN, sort)' },
+        { value: 'TextMatch', label: 'TextMatch', hint: 'free-text match only' },
+        { value: 'TextSearch', label: 'TextSearch', hint: 'equality + order/range + free-text' },
+      ]
+    case 'number':
+      return [
+        { value: 'Integer', label: 'Integer', hint: 'storage only' },
+        { value: 'IntegerEq', label: 'IntegerEq', hint: 'equality (=, IN)' },
+        { value: 'IntegerOrd', label: 'IntegerOrd', hint: 'equality + order/range' },
+      ]
+    case 'date':
+      return [
+        { value: 'Date', label: 'Date', hint: 'storage only' },
+        { value: 'DateEq', label: 'DateEq', hint: 'equality (=, IN)' },
+        { value: 'DateOrd', label: 'DateOrd', hint: 'equality + order/range' },
+      ]
+    case 'boolean':
+      return [{ value: 'Boolean', label: 'Boolean', hint: 'storage only' }]
+    case 'json':
+      return [{ value: 'Json', label: 'Json', hint: 'encrypted-JSONB containment + selectors' }]
   }
-  return ops
+}
+
+/**
+ * The default domain pre-selected in the picker: the widest searchable domain
+ * for the type. Mirrors the pre-v3 scaffold, which enabled every capability on
+ * every selected column by default. Derived from `candidateDomains` (whose
+ * lists are ordered narrowest→widest) so the "widest is the default" invariant
+ * has a single source of truth — reordering a candidate list moves the default
+ * with it, and the two can never silently drift.
+ */
+export function defaultDomain(dataType: DataType): V3Domain {
+  const options = candidateDomains(dataType)
+  return options[options.length - 1].value
 }
 
 /**

--- a/packages/cli/src/commands/init/lib/introspect.ts
+++ b/packages/cli/src/commands/init/lib/introspect.ts
@@ -103,9 +103,10 @@ export async function introspectDatabase(
  * The v3 domains offerable for a scaffolded column of the given `DataType`,
  * ordered narrowest→widest so the interactive picker reads as an escalating
  * ladder. Each domain's query capability is fixed by its type — there is no
- * capability tuple. `boolean` and `json` have exactly one domain (storage
- * only); numeric and date types collapse to the `Integer*` / `Date*` families
- * because `pgTypeToDataType` carries no width/precision signal.
+ * capability tuple. `boolean` has exactly one storage-only domain; `json` has
+ * exactly one queryable domain (encrypted containment + selectors). Numeric
+ * and date types collapse to the `Integer*` / `Date*` families because
+ * `pgTypeToDataType` carries no width/precision signal.
  */
 export function candidateDomains(
   dataType: DataType,

--- a/packages/cli/src/commands/init/types.ts
+++ b/packages/cli/src/commands/init/types.ts
@@ -80,7 +80,7 @@ export interface InitState {
   /** Schema definitions written to the encryption client. Carries every
    *  table the user picked during introspection (or the single placeholder
    *  for empty databases). The generated client file is still the canonical
-   *  source for the full set of column types and search ops. */
+   *  source for the full set of column domains. */
   schemas?: SchemaDef[]
   /** Names of env keys observed in `.env*` files at init time. Never the
    *  values. Set by build-schema (so the baseline context.json has them);

--- a/packages/cli/src/commands/init/types.ts
+++ b/packages/cli/src/commands/init/types.ts
@@ -6,12 +6,32 @@ export type Integration = 'drizzle' | 'supabase' | 'prisma-next' | 'postgresql'
 
 export type DataType = 'string' | 'number' | 'boolean' | 'date' | 'json'
 
-export type SearchOp = 'equality' | 'orderAndRange' | 'freeTextSearch'
+/**
+ * A concrete EQL v3 domain factory name on the `types` namespace
+ * (`@cipherstash/stack/eql/v3`). v3 has no chainable capability tuners — a
+ * column's query capabilities are fixed by which domain you pick. The scaffold
+ * offers the subset below; the full numeric/date lattice
+ * (Smallint/Bigint/Numeric/Real/Double/Timestamp) is left to the user's real
+ * schema files, exactly as `pgTypeToDataType` collapses those types today.
+ */
+export type V3Domain =
+  | 'Text'
+  | 'TextEq'
+  | 'TextOrd'
+  | 'TextMatch'
+  | 'TextSearch'
+  | 'Integer'
+  | 'IntegerEq'
+  | 'IntegerOrd'
+  | 'Date'
+  | 'DateEq'
+  | 'DateOrd'
+  | 'Boolean'
+  | 'Json'
 
 export interface ColumnDef {
   name: string
-  dataType: DataType
-  searchOps: SearchOp[]
+  domain: V3Domain
 }
 
 export interface SchemaDef {

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -338,6 +338,17 @@ export function generateClientFromSchemas(
     case 'supabase':
     case 'postgresql':
       return generateGenericFromSchemas(schemas)
+    case 'prisma-next':
+      // `schema build` doesn't scaffold a prisma-next client — that integration
+      // uses its own per-domain constructors (`cipherstash.TextSearch()` …) and
+      // a migration-based flow, not the `types.*` client this emits. It never
+      // reaches here (schema/build.ts only produces 'supabase' | 'postgresql'),
+      // but fail loudly rather than writing an `undefined` client if it ever
+      // does. Naming every case also keeps the switch exhaustive, so a new
+      // Integration can't silently fall through to `undefined` again.
+      throw new Error(
+        '`stash schema build` does not generate a prisma-next client; use `stash plan` → `stash impl` instead.',
+      )
   }
 }
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import type { DataType, Integration, SchemaDef, SearchOp } from './types.js'
+import type { Integration, SchemaDef } from './types.js'
 
 /**
  * Checks if a package is installed and loadable from the current project.
@@ -264,67 +264,14 @@ function toCamelCase(str: string): string {
   return str.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
 }
 
-/**
- * Map a column's v2-style capability request ({@link DataType} plus the set of
- * requested {@link SearchOp}s) to the name of the concrete EQL **v3** domain
- * factory on the `types` namespace (e.g. `'TextSearch'`, `'IntegerOrd'`).
- *
- * v3 has no chainable capability tuners — each domain's query capabilities are
- * FIXED by the type — so a `{ equality, orderAndRange, freeTextSearch }` request
- * does not map mechanically to a flag object; it picks the domain whose fixed
- * capability set is the tightest match. The mapping mirrors the capability sets
- * in `@cipherstash/stack/eql/v3` (`columns.ts`):
- *
- *   storage-only  → `Text` / `Integer` / `Date` / …    (no searchOps)
- *   equality      → `TextEq` / `IntegerEq` / `DateEq`   (EQUALITY_ONLY)
- *   order & range → `TextOrd` / `IntegerOrd` / `DateOrd` (ORDER_AND_RANGE, also answers equality)
- *   free-text     → `TextMatch` (MATCH_ONLY), or `TextSearch` when combined with eq/ord (TEXT_SEARCH)
- *
- * `boolean` and `json` each have a single domain (no searchable variants), so
- * their searchOps are informational only.
- *
- * The numeric `DataType` collapses to the `Integer*` family — the scaffold has
- * no width/precision signal to distinguish `Numeric`/`Real`/`Double`/`Bigint`,
- * exactly as the v2 scaffold collapsed every number to one `dataType: 'number'`.
- * The user's real schema files stay authoritative; they pick the precise domain.
- */
-function v3DomainFactory(dataType: DataType, searchOps: SearchOp[]): string {
-  const eq = searchOps.includes('equality')
-  const ord = searchOps.includes('orderAndRange')
-  const text = searchOps.includes('freeTextSearch')
-
-  switch (dataType) {
-    case 'json':
-      return 'Json'
-    case 'boolean':
-      // Boolean is storage-only in v3 — no eq/ord/match domain exists.
-      return 'Boolean'
-    case 'number':
-      if (ord) return 'IntegerOrd'
-      if (eq) return 'IntegerEq'
-      return 'Integer'
-    case 'date':
-      if (ord) return 'DateOrd'
-      if (eq) return 'DateEq'
-      return 'Date'
-    case 'string':
-      if (text && (eq || ord)) return 'TextSearch'
-      if (text) return 'TextMatch'
-      if (ord) return 'TextOrd'
-      if (eq) return 'TextEq'
-      return 'Text'
-  }
-}
-
 function generateDrizzleFromSchemas(schemas: SchemaDef[]): string {
   const tableDefs = schemas.map((schema) => {
     const varName = `${toCamelCase(schema.tableName)}Table`
     const schemaVarName = `${toCamelCase(schema.tableName)}Schema`
 
-    const columnDefs = schema.columns.map((col) => {
-      const factory = v3DomainFactory(col.dataType, col.searchOps)
-      return `  ${col.name}: types.${factory}('${col.name}'),`
-    })
+    const columnDefs = schema.columns.map(
+      (col) => `  ${col.name}: types.${col.domain}('${col.name}'),`,
+    )
 
     return `export const ${varName} = pgTable('${schema.tableName}', {
   id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
@@ -353,10 +300,9 @@ function generateGenericFromSchemas(schemas: SchemaDef[]): string {
   const tableDefs = schemas.map((schema) => {
     const varName = `${toCamelCase(schema.tableName)}Table`
 
-    const columnDefs = schema.columns.map((col) => {
-      const factory = v3DomainFactory(col.dataType, col.searchOps)
-      return `  ${col.name}: types.${factory}('${col.name}'),`
-    })
+    const columnDefs = schema.columns.map(
+      (col) => `  ${col.name}: types.${col.domain}('${col.name}'),`,
+    )
 
     return `export const ${varName} = encryptedTable('${schema.tableName}', {
 ${columnDefs.join('\n')}

--- a/skills/stash-cli/SKILL.md
+++ b/skills/stash-cli/SKILL.md
@@ -458,7 +458,7 @@ Not implemented — prints a warning and exits. Placeholder for future encrypt-c
 
 #### `schema build`
 
-Connects to the database, lets you select tables and columns, asks about searchable indexes, and generates a typed encryption client. Flags: `--supabase`, `--database-url`.
+Connects to the database, lets you select tables and columns, and for each column picks a concrete EQL v3 domain (`TextSearch`, `IntegerOrd`, `TextEq`, …) — defaulting to the widest searchable domain for the column's type, with `boolean`/`json` columns assigned their single storage-only domain automatically — then generates a typed encryption client. Flags: `--supabase`, `--database-url`.
 
 For AI-guided integration that edits your existing schema files in place, prefer `stash plan` → `stash impl`.
 

--- a/skills/stash-cli/SKILL.md
+++ b/skills/stash-cli/SKILL.md
@@ -458,7 +458,7 @@ Not implemented — prints a warning and exits. Placeholder for future encrypt-c
 
 #### `schema build`
 
-Connects to the database, lets you select tables and columns, and for each column picks a concrete EQL v3 domain (`TextSearch`, `IntegerOrd`, `TextEq`, …) — defaulting to the widest searchable domain for the column's type, with `boolean`/`json` columns assigned their single storage-only domain automatically — then generates a typed encryption client. Flags: `--supabase`, `--database-url`.
+Connects to the database, lets you select tables and columns, and for each column picks a concrete EQL v3 domain (`TextSearch`, `IntegerOrd`, `TextEq`, …) — defaulting to the widest searchable domain for the column's type. Boolean columns are assigned the storage-only `types.Boolean` domain automatically; JSON columns are assigned the queryable `types.Json` domain, which supports encrypted containment and selector queries. Flags: `--supabase`, `--database-url`.
 
 For AI-guided integration that edits your existing schema files in place, prefer `stash plan` → `stash impl`.
 


### PR DESCRIPTION
## What

Replaces the v2 capability-tuple column picker in `stash schema build` with a per-column **EQL v3 domain picker**, and deletes the `SearchOp` / `allSearchOps` / `v3DomainFactory` bridge.

Previously the introspect → pick → codegen path carried a v2 `SearchOp[]` tuple through an intermediate `ColumnDef` and translated it to a v3 domain name at codegen time. This moves the domain decision up into the interactive picker — the user chooses a concrete v3 domain per column (candidates filtered by the column's Postgres type) — stores it directly on `ColumnDef`, and has codegen read it verbatim.

## Why

Unblocks the EQL v2 removal (cipherstash/stack#707, cipherstash/stack#751): no v2 capability vocabulary remains in the `schema build` path.

## Behaviour

* Each selected column picks a concrete v3 domain (`TextSearch`, `IntegerOrd`, `TextEq`, …) via a `select` prompt, with capability-descriptive hints.
* Defaults preserve the previous posture: widest searchable domain per type (`string`→`TextSearch`, `number`→`IntegerOrd`, `date`→`DateOrd`).
* `boolean`→`Boolean` and `json`→`Json` are single storage-only domains, assigned without a prompt.
* `pgTypeToDataType`'s coarse 5-type collapse is unchanged (out of scope: widening to the full numeric/date lattice).
* No change to `stash init` / `generatePlaceholderClient`.

## Tests

* `introspect.test.ts` — `pgTypeToDataType`, `candidateDomains`, `defaultDomain`, and the rewritten `selectTableColumns` (every cancellation branch + eql-pre-selected path, `@clack/prompts` mocked).
* `utils-codegen.test.ts` — both generators, plus an `it.each` round-trip over all 13 `V3Domain` values; asserts no `searchOps` residue.
* `build-flow.integration.test.ts` — real `buildSchemasFromDatabase` → real `generateClientFromSchemas` with only `pg` and `@clack/prompts` mocked (multi-table loop, early-exit, empty-schema edges).

## Verification

* `pnpm --filter stash build` — clean, no type errors
* `pnpm --filter stash test` — 815 pass (56 files)
* `pnpm run code:check` — exit 0
* CodeRabbit review — 0 findings

## Docs / changeset

* Updated the `schema build` description in `skills/stash-cli/SKILL.md` to describe the domain picker.
* Added a `stash` patch changeset.

## Summary by CodeRabbit

* **New Features**
  * `schema build` now assigns a specific encryption domain to each selected column.
  * Boolean and JSON columns are automatically assigned their supported storage domain.
  * Generated clients now use the selected domain mappings for PostgreSQL and Drizzle integrations.
* **Documentation**
  * Updated CLI guidance to describe per-column domain selection and defaults.
* **Bug Fixes**
  * Preserved existing encrypted-column selections during schema setup.

## Summary by CodeRabbit

* **New Features**
  * `schema build` now lets you select an encryption domain for each column.
  * Boolean and JSON columns are automatically assigned compatible storage domains.
  * Generated clients now use the selected column domains for encryption configuration.
* **Documentation**
  * Updated CLI guidance to describe the per-column domain selection workflow.

## Summary by CodeRabbit

* **New Features**
  * `stash schema build` now lets you choose an encryption domain for each selected column.
  * Boolean and JSON columns are assigned their supported domain automatically.
  * Generated encryption clients now use the selected EQL v3 domains for each column.
* **Documentation**
  * Updated CLI guidance to describe per-column domain selection and generation flow.