### PR TITLE
fix(scripts): eliminate repository-linter test race

### DIFF
--- a/scripts/lint-no-hardcoded-runners.mjs
+++ b/scripts/lint-no-hardcoded-runners.mjs
@@ -28,7 +28,26 @@ const TARGETS = process.argv.slice(2).length
 const NPX_TOKEN = /['"`]npx\b|(?:^|[^a-zA-Z0-9_$])npx\s+[@\w-]/
 
 async function* walk(dir) {
-  const entries = await readdir(dir, { withFileTypes: true })
+  // A directory can vanish between the parent's `readdir` and this call. The
+  // repo's own script self-tests create and delete probe packages under
+  // `packages/` (`lint-untracked-probe`, `lint-dead-shell-probe` in
+  // `lint-no-dead-package-paths.test.mjs`) while other suites run, so a walk of
+  // `packages/` can enumerate one and find it gone a moment later.
+  //
+  // Left unhandled this rejects with ENOENT, and Node exits **1** — the same
+  // code as "found a hardcoded npx". Every caller then reads a crash as a
+  // violation: CI fails naming a file that is perfectly clean, and re-running
+  // it passes. The missing-target case deliberately exits 2 for exactly this
+  // reason ("Exit 2 means the linter could not run"); this is the same
+  // distinction, one level down. There is nothing to lint in a directory that
+  // no longer exists, so skip it.
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    if (err?.code === 'ENOENT') return
+    throw err
+  }
   for (const entry of entries) {
     const full = join(dir, entry.name)
     if (entry.isDirectory()) {

--- a/scripts/vitest.config.mjs
+++ b/scripts/vitest.config.mjs
@@ -1,4 +1,26 @@
 import { defineConfig } from 'vitest/config'
+
+// `fileParallelism: false` is load-bearing, not a performance knob.
+//
+// Several of these suites mutate the real repo tree while they run:
+// `lint-no-dead-package-paths.test.mjs` creates and deletes probe package
+// directories inside the packages tree (`lint-untracked-probe`,
+// `lint-dead-shell-probe`), and `lint-no-hardcoded-runners.test.mjs` walks that
+// same tree and writes an `allowlist-probe.mjs` into `scripts/`. Run in
+// parallel, one suite's scratch state lands inside another's scan — which is
+// how a clean tree produced an `ENOENT: scandir` on a probe directory and a CI
+// failure that pointed at nothing.
+//
+// Note the probe names are deliberately written WITHOUT their directory prefix:
+// the sibling `lint-no-dead-package-paths` linter flags that shape when the
+// directory does not exist, and these only exist mid-test.
+//
+// These are eleven small files; serialising them costs a second and removes
+// the whole class of cross-suite filesystem race.
 export default defineConfig({
-  test: { include: ['scripts/__tests__/**/*.test.mjs'], pool: 'forks' },
+  test: {
+    include: ['scripts/__tests__/**/*.test.mjs'],
+    pool: 'forks',
+    fileParallelism: false,
+  },
 })


### PR DESCRIPTION
## Summary

- tolerate a directory disappearing during the hardcoded-runner linter's recursive walk
- serialize the script self-test files because several mutate the real repository tree

## Root cause

The deleted-package-shell regression test introduced in 0344e27e creates and removes a probe directory beneath packages. Vitest was running that file concurrently with the hardcoded-runner tests, whose default invocation recursively scans packages.

The scanner could enumerate the probe and then attempt to read it after the other test removed it. The unhandled ENOENT made Node exit 1, which is also the linter's violation exit code, producing a flaky CI failure despite a clean tree.

This surfaced in PR #823 as run 30409513874 / job 90442300248. The fix was previously bundled into #812; this PR extracts it so it can land independently on remove-v2.

## Verification

- pnpm exec vitest run --config scripts/vitest.config.mjs --configLoader runner (131 tests)
- pnpm exec biome check scripts/lint-no-hardcoded-runners.mjs scripts/vitest.config.mjs
- git diff --check origin/remove-v2...HEAD

No changeset: internal repository test infrastructure only.
