### PR TITLE
docs(contribute): fix the stale repo tree in CONTRIBUTE.md

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -17,8 +17,7 @@ This is a [Turborepo](https://turbo.build/) monorepo managed with [pnpm](https:/
 ├── packages/
 │   ├── stack/            <-- Main package (@cipherstash/stack)
 │   ├── cli/              <-- The `stash` CLI
-│   ├── protect/          <-- Core encryption library (re-exported via stack)
-│   └── ...               <-- schema, drizzle, nextjs, prisma-next, migrate, wizard, ...
+│   └── ...               <-- stack-drizzle, stack-supabase, stack-prisma, nextjs, migrate, wizard, ...
 ├── examples/             <-- Runnable example apps
 ├── e2e/                  <-- Cross-package end-to-end tests
 ├── skills/               <-- Agent skills


### PR DESCRIPTION
The repo-layout tree in CONTRIBUTE.md predated several package removals and the #842 rename: it listed `packages/protect/` (removed), `schema` and `drizzle` (removed legacy dirs), and `prisma-next` (now `stack-prisma` after #844). Now lists the real adapter dirs. Docs-only; no changeset (internal contributor doc, not shipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the repository structure guide to reflect the current package organization.
  * Clarified that the packages directory contains stack integrations and related tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->