### PR TITLE
fix(stack): drop the removed --proxy flags from the shipped README

### DIFF
--- a/.changeset/stack-readme-drop-proxy-flags.md
+++ b/.changeset/stack-readme-drop-proxy-flags.md
@@ -1,0 +1,12 @@
+---
+'@cipherstash/stack': patch
+---
+
+README only — drop the removed `--proxy` / `--no-proxy` flags from the `stash init`
+flag table.
+
+The flags went away with the EQL v2 CipherStash Proxy lifecycle: they are absent
+from the CLI command registry, and `stash init` now rejects them with an
+actionable message. `packages/cli/README.md` and the bundled `stash-cli` skill
+were already updated, but this table row in the `@cipherstash/stack` README —
+which ships in the tarball — still documented them as supported.

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -573,7 +573,6 @@ The wizard will:
 | Flag | Description |
 |------|-------------|
 | `--supabase` / `--drizzle` / `--prisma-next` | Target a specific integration's setup flow |
-| `--proxy` / `--no-proxy` | Opt in/out of the CipherStash Proxy path |
 | `--region <slug>` | Workspace region (env `STASH_REGION`); **required for non-interactive init when not already logged in** |
 
 ## Configuration


### PR DESCRIPTION
Closes #816 — the last outstanding item on criterion 8 ("Reconcile pending changesets, skills, READMEs, and the #772/#778 tracking text after the removal work lands").

## What was wrong

`packages/stack/README.md` still listed `--proxy` / `--no-proxy` in the `stash init` flag table:

```
| `--proxy` / `--no-proxy` | Opt in/out of the CipherStash Proxy path |
```

Those flags were removed with the EQL v2 CipherStash Proxy lifecycle in #825. Everything else was already correct:

- absent from `packages/cli/src/cli/registry.ts` (`init` declares exactly `--supabase`, `--drizzle`, `--prisma-next`, `--region`);
- `packages/cli/src/commands/init/index.ts:74-79` rejects them with an actionable message;
- asserted absent by `packages/cli/src/__tests__/v2-retirement.test.ts:27-32` and `packages/cli/tests/e2e/v2-retirement.e2e.test.ts:29-32`;
- `packages/cli/README.md` and `skills/stash-cli/SKILL.md` are clean.

`packages/stack/package.json` ships `README.md` in the tarball, so this row was wrong guidance reaching customer repos.

## Why nothing caught it

There is **no doc-level guard for retired flags at all**. Two things look like they should have caught this and neither is in scope:

- `packages/cli/src/__tests__/v2-retirement.test.ts:27-32` asserts `--proxy` / `--no-proxy` are absent from the **registry** — that is, from code. It never reads documentation.
- `scripts/__tests__/no-removed-eql-version-flag.test.mjs` does scan `packages/*/README.md` and `skills/*/SKILL.md`, but it is single-purpose: its matcher only ever looks for `stash eql install … --eql-version` inside fenced shell blocks. It would not have caught `--proxy` in a fenced block either. The markdown-table format is incidental.

So this class of drift can recur anywhere in the shipped docs with CI green. The follow-up worth building is a guard that takes the set of retired flag names and asserts their absence across `packages/*/README.md` + `skills/*/SKILL.md`, with the exemptions the current tree legitimately needs: the *product* CipherStash Proxy in `skills/stash-postgres` and `skills/stash-auth`, the removal-error text at `packages/cli/src/bin/main.ts:305`, and published CHANGELOGs. Left out of this PR to keep it to the one-line fix.

## Not #790

#790 also removes this row, but it is `CONFLICTING`, 177 commits behind / 58 ahead of `main`, 291 files, +10,971/−30,202, and it touches `packages/protect/README.md` and `packages/schema/README.md` — pre-rename paths that would resurrect deleted packages. Do not close #816 by merging it.

## Verification

- The table now matches `registry.ts:119-138` one-for-one — all four `init` flags, no extras — on this branch and on `origin/main`.
- `grep -i proxy packages/stack/README.md` returns nothing, so the deleted row was not the anchor for any surrounding prose.
- `git grep -E '\-\-proxy|--no-proxy'` over shipped READMEs and `skills/**`: no hits. Remaining repo hits are intentional — the *product* CipherStash Proxy in `skills/stash-postgres` and `skills/stash-auth` (explicitly framed as a different path), the removal-error text in `packages/cli/src/bin/main.ts:305`, v2 `eql_v2_configuration` in `packages/cli/src/commands/db/status.ts`, internal `docs/plans/`, the absence assertions above, and published CHANGELOGs.
- `vitest run --config scripts/vitest.config.mjs`: 14 files / 178 tests passed. Green either way on this change, per the section above.
- Biome does not process markdown, so `code:check` is a no-op on both files.
- No interaction with #844 (the `@cipherstash/prisma-next` → `@cipherstash/stack-prisma` rename, merged as `d2772b0c` after this branch was cut): it leaves `packages/stack/README.md` untouched and the `--prisma-next` flag name intact, so the row above the deletion is still accurate.

## Changeset

`@cipherstash/stack: patch`. Precedent for a README-only entry on this package is `.changeset/remove-eql-v2-drizzle-root.md:25`. `@cipherstash/stack` already carries a `minor` this release train via `.changeset/adapter-release-readiness.md`; changesets takes the max, so this adds the changelog line without disturbing the bump.

## Also verified while confirming scope

The other half of the #816 status comment — `db push` residue in `packages/wizard/README.md` — was already fixed by `0fc041ac` (#838, merged `2d7ef563`). That comment was written ~1h before #838 landed. No wizard change is needed here.