### PR TITLE
feat(cli): add a Lovable handoff target to plan and impl

### DIFF
--- a/.changeset/lovable-handoff-target.md
+++ b/.changeset/lovable-handoff-target.md
@@ -1,0 +1,5 @@
+---
+'stash': minor
+---
+
+Add a `lovable` handoff target to `stash plan` and `stash impl` (`--target lovable`, plus a new agent-target picker entry). It writes the same AGENTS.md as the editor-agent handoff — doctrine plus the per-integration skills inlined — but the next-steps guidance is Lovable-specific: commit and push the generated files through Lovable's GitHub sync, then add a Knowledge note in the Lovable project settings pointing the agent at `AGENTS.md` and `.cipherstash/setup-prompt.md`. Without repo-local guidance, Lovable's agent answers CipherStash questions from stale training data (the pre-EQL-v3 "needs a Postgres extension and superuser" story) and talks users out of a supported Supabase setup.

--- a/packages/cli/src/cli/registry.ts
+++ b/packages/cli/src/cli/registry.ts
@@ -156,7 +156,7 @@ export const registry: CommandGroup[] = [
             name: '--target',
             value: '<name>',
             description:
-              'Skip the agent-target picker and hand off directly to one of claude-code | codex | agents-md | wizard. Safe in non-TTY contexts.',
+              'Skip the agent-target picker and hand off directly to one of claude-code | codex | agents-md | lovable | wizard. Safe in non-TTY contexts.',
           },
         ],
       },
@@ -178,7 +178,7 @@ export const registry: CommandGroup[] = [
             name: '--target',
             value: '<name>',
             description:
-              'Skip the agent-target picker and hand off directly to one of claude-code | codex | agents-md | wizard. Safe in non-TTY contexts.',
+              'Skip the agent-target picker and hand off directly to one of claude-code | codex | agents-md | lovable | wizard. Safe in non-TTY contexts.',
           },
         ],
       },

--- a/packages/cli/src/commands/impl/__tests__/how-to-proceed.test.ts
+++ b/packages/cli/src/commands/impl/__tests__/how-to-proceed.test.ts
@@ -26,16 +26,28 @@ const claudeOnly: InitState = { agents: makeAgents(true, false) }
 const codexOnly: InitState = { agents: makeAgents(false, true) }
 
 describe('howToProceed — buildOptions', () => {
-  it('offers all four targets in implement mode', () => {
+  it('offers all five targets in implement mode', () => {
     const opts = buildOptions(noAgents, 'implement')
     const values = opts.map((o) => o.value)
-    expect(values).toEqual(['claude-code', 'codex', 'agents-md', 'wizard'])
+    expect(values).toEqual([
+      'claude-code',
+      'codex',
+      'agents-md',
+      'lovable',
+      'wizard',
+    ])
   })
 
-  it('offers all four targets in plan mode', () => {
+  it('offers all five targets in plan mode', () => {
     const opts = buildOptions(noAgents, 'plan')
     const values = opts.map((o) => o.value)
-    expect(values).toEqual(['claude-code', 'codex', 'agents-md', 'wizard'])
+    expect(values).toEqual([
+      'claude-code',
+      'codex',
+      'agents-md',
+      'lovable',
+      'wizard',
+    ])
   })
 
   it('reflects detection state in hints regardless of mode', () => {

--- a/packages/cli/src/commands/impl/steps/__tests__/handoff-agents-md.test.ts
+++ b/packages/cli/src/commands/impl/steps/__tests__/handoff-agents-md.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { InitState } from '../../../init/types.js'
+
+// Same seam as the handoff-codex test. This step launches nothing — it writes
+// the artifacts for an editor agent (Cursor / Windsurf / Cline) and prints the
+// guidance — so the unit under test is the honesty contract between
+// `writeAgentsMd`'s result, the recorded delivery, and the note.
+const availableSkills = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/install-skills.js', () => ({ availableSkills }))
+const writeAgentsMd = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/handoff-helpers.js', () => ({
+  AGENTS_MD_REL_PATH: 'AGENTS.md',
+  writeAgentsMd,
+  writeArtifacts: vi.fn(),
+}))
+const buildAgentsMdBody = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/build-agents-md.js', () => ({ buildAgentsMdBody }))
+vi.mock('@clack/prompts', () => ({
+  note: vi.fn(),
+  log: { success: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+import * as p from '@clack/prompts'
+import { writeArtifacts } from '../../../init/lib/handoff-helpers.js'
+import { handoffAgentsMdStep } from '../handoff-agents-md.js'
+
+const state = { integration: 'drizzle' } as unknown as InitState
+
+const noteBody = () => String(vi.mocked(p.note).mock.calls[0][0])
+const agentsMdMode = () => vi.mocked(buildAgentsMdBody).mock.calls[0][1]
+const delivery = () => vi.mocked(writeArtifacts).mock.calls[0][3]
+const handoffRecorded = () => vi.mocked(writeArtifacts).mock.calls[0][2]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  writeAgentsMd.mockReturnValue(true)
+  availableSkills.mockReturnValue(['stash-encryption', 'stash-drizzle'])
+})
+
+describe('when AGENTS.md was written', () => {
+  it('inlines the skills — these agents do not auto-load skill directories', async () => {
+    await handoffAgentsMdStep.run(state)
+    expect(agentsMdMode()).toBe('doctrine-plus-skills')
+    expect(handoffRecorded()).toBe('agents-md')
+    expect(delivery()).toEqual({
+      installed: [],
+      inlined: ['stash-encryption', 'stash-drizzle'],
+      failed: [],
+    })
+  })
+
+  it('tells the user their editor agent picks the file up automatically', async () => {
+    await handoffAgentsMdStep.run(state)
+    const body = noteBody()
+    expect(body).toContain('pick up AGENTS.md automatically')
+    expect(body).toContain('.cipherstash/setup-prompt.md')
+  })
+})
+
+describe('when AGENTS.md could not be written', () => {
+  beforeEach(() => {
+    writeAgentsMd.mockReturnValue(false)
+  })
+
+  it('records the skills as failed, not inlined', async () => {
+    await handoffAgentsMdStep.run(state)
+    expect(delivery()).toEqual({
+      installed: [],
+      inlined: [],
+      failed: ['stash-encryption', 'stash-drizzle'],
+    })
+  })
+
+  it('does not claim an agent will pick up a file that was never written', async () => {
+    await handoffAgentsMdStep.run(state)
+    const body = noteBody()
+    expect(body).toContain('could not be written')
+    expect(body).not.toContain('pick up AGENTS.md automatically')
+  })
+})

--- a/packages/cli/src/commands/impl/steps/__tests__/handoff-lovable.test.ts
+++ b/packages/cli/src/commands/impl/steps/__tests__/handoff-lovable.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { InitState } from '../../../init/types.js'
+
+// Same seam as the handoff-codex test, minus the launch: Lovable's agent runs
+// in Lovable's cloud, so this step only writes files and prints guidance. The
+// unit under test is the honesty contract between `writeAgentsMd`'s result,
+// the delivery recorded into the artifacts, and what the note tells the user
+// to do next.
+const availableSkills = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/install-skills.js', () => ({ availableSkills }))
+const writeAgentsMd = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/handoff-helpers.js', () => ({
+  AGENTS_MD_REL_PATH: 'AGENTS.md',
+  writeAgentsMd,
+  writeArtifacts: vi.fn(),
+}))
+const buildAgentsMdBody = vi.hoisted(() => vi.fn())
+vi.mock('../../../init/lib/build-agents-md.js', () => ({ buildAgentsMdBody }))
+vi.mock('@clack/prompts', () => ({
+  note: vi.fn(),
+  log: { success: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+import * as p from '@clack/prompts'
+import { writeArtifacts } from '../../../init/lib/handoff-helpers.js'
+import { handoffLovableStep } from '../handoff-lovable.js'
+
+const state = { integration: 'supabase' } as unknown as InitState
+
+const noteBody = () => String(vi.mocked(p.note).mock.calls[0][0])
+const agentsMdMode = () => vi.mocked(buildAgentsMdBody).mock.calls[0][1]
+const inlinedList = () => vi.mocked(buildAgentsMdBody).mock.calls[0][2]
+const delivery = () => vi.mocked(writeArtifacts).mock.calls[0][3]
+const handoffRecorded = () => vi.mocked(writeArtifacts).mock.calls[0][2]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  writeAgentsMd.mockReturnValue(true)
+  availableSkills.mockReturnValue(['stash-encryption', 'stash-supabase'])
+})
+
+describe('when AGENTS.md was written', () => {
+  it('inlines the per-integration skills — Lovable does not load skill directories', async () => {
+    await handoffLovableStep.run(state)
+    expect(agentsMdMode()).toBe('doctrine-plus-skills')
+    expect(inlinedList()).toEqual(['stash-encryption', 'stash-supabase'])
+  })
+
+  it('records the skills as inlined under the lovable handoff', async () => {
+    await handoffLovableStep.run(state)
+    expect(handoffRecorded()).toBe('lovable')
+    expect(delivery()).toEqual({
+      installed: [],
+      inlined: ['stash-encryption', 'stash-supabase'],
+      failed: [],
+    })
+  })
+
+  it('walks the user through the GitHub sync and the Knowledge pointer', async () => {
+    // Lovable only sees the repo through its GitHub sync and does not
+    // auto-load AGENTS.md, so both halves have to be in the note or the
+    // guidance never reaches the agent.
+    await handoffLovableStep.run(state)
+    const body = noteBody()
+    expect(body).toContain('Commit and push')
+    expect(body).toContain('Settings → Knowledge')
+    expect(body).toContain('.cipherstash/setup-prompt.md')
+  })
+})
+
+// The failure arm is the whole point of the honesty contract: telling the
+// user to commit a file that was never written sends them hunting for it.
+describe('when AGENTS.md could not be written', () => {
+  beforeEach(() => {
+    writeAgentsMd.mockReturnValue(false)
+  })
+
+  it('records the skills as failed, not inlined', async () => {
+    await handoffLovableStep.run(state)
+    expect(delivery()).toEqual({
+      installed: [],
+      inlined: [],
+      failed: ['stash-encryption', 'stash-supabase'],
+    })
+  })
+
+  it('says the write failed instead of telling the user to commit it', async () => {
+    await handoffLovableStep.run(state)
+    const body = noteBody()
+    expect(body).toContain('could not be written')
+    expect(body).not.toContain('Commit and push')
+  })
+
+  it('still points at the artifacts that did land', async () => {
+    await handoffLovableStep.run(state)
+    const body = noteBody()
+    expect(body).toContain('.cipherstash/setup-prompt.md')
+    expect(body).toContain('.cipherstash/context.json')
+  })
+})
+
+// A stripped CLI build ships no skills. AGENTS.md still carries the doctrine,
+// so the guidance stands — there is just nothing to inline.
+it('records an empty delivery when this build ships no skills', async () => {
+  availableSkills.mockReturnValue([])
+  await handoffLovableStep.run(state)
+  expect(delivery()).toEqual({ installed: [], inlined: [], failed: [] })
+  expect(noteBody()).toContain('Settings → Knowledge')
+})

--- a/packages/cli/src/commands/impl/steps/__tests__/how-to-proceed-dispatch.test.ts
+++ b/packages/cli/src/commands/impl/steps/__tests__/how-to-proceed-dispatch.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import type { HandoffChoice, InitState } from '../../../init/types.js'
+
+// `buildOptions` / `defaultChoice` / `resolveTarget` are pure and covered in
+// `impl/__tests__/how-to-proceed.test.ts`. What is NOT covered there is the
+// dispatch arm: a pre-resolved `state.handoff` must skip the picker and run
+// the matching step. Misrouting or dropping an arm would otherwise pass CI.
+const runs = vi.hoisted(() => ({
+  'claude-code': vi.fn(async (s: InitState) => s),
+  codex: vi.fn(async (s: InitState) => s),
+  'agents-md': vi.fn(async (s: InitState) => s),
+  lovable: vi.fn(async (s: InitState) => s),
+  wizard: vi.fn(async (s: InitState) => s),
+}))
+vi.mock('../handoff-claude.js', () => ({
+  handoffClaudeStep: { run: runs['claude-code'] },
+}))
+vi.mock('../handoff-codex.js', () => ({
+  handoffCodexStep: { run: runs.codex },
+}))
+vi.mock('../handoff-agents-md.js', () => ({
+  handoffAgentsMdStep: { run: runs['agents-md'] },
+}))
+vi.mock('../handoff-lovable.js', () => ({
+  handoffLovableStep: { run: runs.lovable },
+}))
+vi.mock('../handoff-wizard.js', () => ({
+  handoffWizardStep: { run: runs.wizard },
+}))
+const select = vi.hoisted(() => vi.fn())
+vi.mock('@clack/prompts', () => ({
+  select,
+  isCancel: vi.fn(() => false),
+  note: vi.fn(),
+  log: { success: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+import { HANDOFF_CHOICES, howToProceedStep } from '../how-to-proceed.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// Table-driven off HANDOFF_CHOICES so a new target that reaches the picker
+// without a dispatch arm fails here rather than at runtime.
+for (const choice of HANDOFF_CHOICES) {
+  it(`routes a pre-resolved \`${choice}\` state to its own step, without a prompt`, async () => {
+    await howToProceedStep.run({ handoff: choice } as InitState)
+
+    expect(runs[choice]).toHaveBeenCalledTimes(1)
+    // The dispatched step must see the resolved choice on the state.
+    expect(runs[choice].mock.calls[0][0].handoff).toBe(choice)
+    // Every other arm stays untouched.
+    for (const other of HANDOFF_CHOICES) {
+      if (other !== choice) expect(runs[other]).not.toHaveBeenCalled()
+    }
+    // A pre-resolved target is what makes the command non-TTY safe.
+    expect(select).not.toHaveBeenCalled()
+  })
+}
+
+it('runs the picked step when the picker is used', async () => {
+  const picked: HandoffChoice = 'lovable'
+  select.mockResolvedValueOnce(picked)
+
+  await howToProceedStep.run({ agents: undefined } as InitState)
+
+  expect(select).toHaveBeenCalledTimes(1)
+  expect(runs.lovable).toHaveBeenCalledTimes(1)
+  expect(runs.lovable.mock.calls[0][0].handoff).toBe('lovable')
+})

--- a/packages/cli/src/commands/impl/steps/handoff-agents-md.ts
+++ b/packages/cli/src/commands/impl/steps/handoff-agents-md.ts
@@ -46,15 +46,27 @@ export const handoffAgentsMdStep: HandoffStep = {
       failed: written ? [] : inlinable,
     })
 
+    // Same honesty rule as the Lovable step: only claim AGENTS.md exists
+    // when the write succeeded (writeAgentsMd already logged the warning).
     p.note(
-      [
-        `Rules at ${AGENTS_MD_REL_PATH}`,
-        `Action plan at ${SETUP_PROMPT_REL_PATH}`,
-        `Context at ${CONTEXT_REL_PATH}`,
-        '',
-        'Cursor / Windsurf / Cline pick up AGENTS.md automatically.',
-        `Open your agent and point it at ${SETUP_PROMPT_REL_PATH} to start.`,
-      ].join('\n'),
+      written
+        ? [
+            `Rules at ${AGENTS_MD_REL_PATH}`,
+            `Action plan at ${SETUP_PROMPT_REL_PATH}`,
+            `Context at ${CONTEXT_REL_PATH}`,
+            '',
+            'Cursor / Windsurf / Cline pick up AGENTS.md automatically.',
+            `Open your agent and point it at ${SETUP_PROMPT_REL_PATH} to start.`,
+          ].join('\n')
+        : [
+            `${AGENTS_MD_REL_PATH} could not be written (see the warning above).`,
+            `Action plan at ${SETUP_PROMPT_REL_PATH}`,
+            `Context at ${CONTEXT_REL_PATH}`,
+            '',
+            'Fix the file permissions and re-run this command so the rules',
+            `land in ${AGENTS_MD_REL_PATH}, then open your agent and point it`,
+            `at ${SETUP_PROMPT_REL_PATH} to start.`,
+          ].join('\n'),
       'Drive your editor agent',
     )
 

--- a/packages/cli/src/commands/impl/steps/handoff-lovable.ts
+++ b/packages/cli/src/commands/impl/steps/handoff-lovable.ts
@@ -1,0 +1,68 @@
+import * as p from '@clack/prompts'
+import { buildAgentsMdBody } from '../../init/lib/build-agents-md.js'
+import {
+  AGENTS_MD_REL_PATH,
+  writeAgentsMd,
+  writeArtifacts,
+} from '../../init/lib/handoff-helpers.js'
+import { availableSkills } from '../../init/lib/install-skills.js'
+import {
+  CONTEXT_REL_PATH,
+  SETUP_PROMPT_REL_PATH,
+} from '../../init/lib/write-context.js'
+import type { HandoffStep, InitState } from '../../init/types.js'
+
+/**
+ * Write `AGENTS.md`, `.cipherstash/context.json`, and
+ * `.cipherstash/setup-prompt.md` for a Lovable project, then stop.
+ *
+ * Same artifacts as the AGENTS.md handoff — Lovable's agent runs in
+ * Lovable's cloud, not on this machine, so there is nothing to launch.
+ * What differs is how the files reach the agent: Lovable only sees the
+ * repo through its GitHub sync, so the guidance tells the user to commit
+ * and push, then add a Knowledge pointer in the Lovable project settings.
+ * That pointer matters because Lovable does not auto-load AGENTS.md the
+ * way Cursor/Windsurf do — without it the agent answers CipherStash
+ * questions from stale training data (the pre-EQL-v3 "needs a Postgres
+ * extension and superuser" story) instead of the inlined skills.
+ */
+export const handoffLovableStep: HandoffStep = {
+  id: 'handoff-lovable',
+  name: 'Write AGENTS.md for Lovable',
+  async run(state: InitState): Promise<InitState> {
+    const cwd = process.cwd()
+    const integration = state.integration ?? 'postgresql'
+
+    const inlinable = availableSkills(integration)
+    const managed = buildAgentsMdBody(
+      integration,
+      'doctrine-plus-skills',
+      inlinable,
+    )
+    const written = writeAgentsMd(cwd, managed)
+
+    writeArtifacts(cwd, state, 'lovable', {
+      installed: [],
+      inlined: written ? inlinable : [],
+      failed: written ? [] : inlinable,
+    })
+
+    p.note(
+      [
+        `Rules at ${AGENTS_MD_REL_PATH}`,
+        `Action plan at ${SETUP_PROMPT_REL_PATH}`,
+        `Context at ${CONTEXT_REL_PATH}`,
+        '',
+        'Lovable only sees these files through its GitHub sync:',
+        `1. Commit and push ${AGENTS_MD_REL_PATH} and .cipherstash/`,
+        '2. In Lovable: Settings → Knowledge, add:',
+        `   "Follow ${AGENTS_MD_REL_PATH} for all CipherStash work.`,
+        `   Start from ${SETUP_PROMPT_REL_PATH}."`,
+        `3. Ask the Lovable agent to read ${SETUP_PROMPT_REL_PATH} and begin.`,
+      ].join('\n'),
+      'Drive the Lovable agent',
+    )
+
+    return state
+  },
+}

--- a/packages/cli/src/commands/impl/steps/handoff-lovable.ts
+++ b/packages/cli/src/commands/impl/steps/handoff-lovable.ts
@@ -47,19 +47,32 @@ export const handoffLovableStep: HandoffStep = {
       failed: written ? [] : inlinable,
     })
 
+    // The note must reflect what was actually written: telling the user to
+    // commit an AGENTS.md that failed to write sends them hunting for a
+    // file that does not exist (writeAgentsMd already logged the warning).
     p.note(
-      [
-        `Rules at ${AGENTS_MD_REL_PATH}`,
-        `Action plan at ${SETUP_PROMPT_REL_PATH}`,
-        `Context at ${CONTEXT_REL_PATH}`,
-        '',
-        'Lovable only sees these files through its GitHub sync:',
-        `1. Commit and push ${AGENTS_MD_REL_PATH} and .cipherstash/`,
-        '2. In Lovable: Settings → Knowledge, add:',
-        `   "Follow ${AGENTS_MD_REL_PATH} for all CipherStash work.`,
-        `   Start from ${SETUP_PROMPT_REL_PATH}."`,
-        `3. Ask the Lovable agent to read ${SETUP_PROMPT_REL_PATH} and begin.`,
-      ].join('\n'),
+      written
+        ? [
+            `Rules at ${AGENTS_MD_REL_PATH}`,
+            `Action plan at ${SETUP_PROMPT_REL_PATH}`,
+            `Context at ${CONTEXT_REL_PATH}`,
+            '',
+            'Lovable only sees these files through its GitHub sync:',
+            `1. Commit and push ${AGENTS_MD_REL_PATH} and .cipherstash/`,
+            '2. In Lovable: Settings → Knowledge, add:',
+            `   "Follow ${AGENTS_MD_REL_PATH} for all CipherStash work.`,
+            `   Start from ${SETUP_PROMPT_REL_PATH}."`,
+            `3. Ask the Lovable agent to read ${SETUP_PROMPT_REL_PATH} and begin.`,
+          ].join('\n')
+        : [
+            `${AGENTS_MD_REL_PATH} could not be written (see the warning above).`,
+            `Action plan at ${SETUP_PROMPT_REL_PATH}`,
+            `Context at ${CONTEXT_REL_PATH}`,
+            '',
+            'Fix the file permissions and re-run this command so the rules',
+            `land in ${AGENTS_MD_REL_PATH}, then commit, push, and add the`,
+            'Knowledge pointer in Lovable (Settings → Knowledge).',
+          ].join('\n'),
       'Drive the Lovable agent',
     )
 

--- a/packages/cli/src/commands/impl/steps/how-to-proceed.ts
+++ b/packages/cli/src/commands/impl/steps/how-to-proceed.ts
@@ -9,6 +9,7 @@ import {
 import { handoffAgentsMdStep } from './handoff-agents-md.js'
 import { handoffClaudeStep } from './handoff-claude.js'
 import { handoffCodexStep } from './handoff-codex.js'
+import { handoffLovableStep } from './handoff-lovable.js'
 import { handoffWizardStep } from './handoff-wizard.js'
 
 /**
@@ -20,6 +21,7 @@ export const HANDOFF_CHOICES: readonly HandoffChoice[] = [
   'claude-code',
   'codex',
   'agents-md',
+  'lovable',
   'wizard',
 ] as const
 
@@ -92,6 +94,11 @@ export function buildOptions(
       hint: 'works with Cursor, Windsurf, Cline, and more',
     },
     {
+      value: 'lovable',
+      label: 'Write AGENTS.md for Lovable',
+      hint: 'push via GitHub sync, then add a Knowledge pointer in Lovable',
+    },
+    {
       value: 'wizard',
       label: 'Use the CipherStash Agent',
       hint: 'our hosted setup wizard (runs `stash wizard`)',
@@ -136,6 +143,8 @@ export const howToProceedStep: HandoffStep = {
         return handoffCodexStep.run(next)
       case 'agents-md':
         return handoffAgentsMdStep.run(next)
+      case 'lovable':
+        return handoffLovableStep.run(next)
       case 'wizard':
         return handoffWizardStep.run(next)
     }

--- a/packages/cli/src/commands/init/lib/__tests__/setup-prompt.test.ts
+++ b/packages/cli/src/commands/init/lib/__tests__/setup-prompt.test.ts
@@ -716,5 +716,58 @@ describe('renderSetupPrompt — honours what the handoff actually wrote', () => 
       expect(out).toContain('cipherstash.com/docs')
       expect(out).not.toContain('.claude/skills/')
     })
+
+    for (const handoff of ['agents-md', 'lovable'] as const) {
+      it(`${handoff} with every skill failed does not point at AGENTS.md (${mode})`, () => {
+        // For these handoffs the skills are inlined INTO AGENTS.md, so
+        // all-failed means writeAgentsMd itself failed — the file does
+        // not exist and the prompt must not send the agent to it.
+        const out = renderSetupPrompt({
+          ...baseCtx,
+          mode,
+          handoff,
+          skills: {
+            installed: [],
+            inlined: [],
+            failed: ['stash-encryption', 'stash-cli'],
+          },
+        })
+        expect(out).toContain('could not be installed')
+        expect(out).not.toContain('AGENTS.md')
+        expect(out).toContain('cipherstash.com/docs')
+      })
+    }
+
+    it(`codex with every skill failed still points at AGENTS.md (${mode})`, () => {
+      // Codex writes its durable rules to AGENTS.md separately from the
+      // skills, so the file exists even when every skill copy failed.
+      const out = renderSetupPrompt({
+        ...baseCtx,
+        mode,
+        handoff: 'codex',
+        skills: {
+          installed: [],
+          inlined: [],
+          failed: ['stash-encryption', 'stash-cli'],
+        },
+      })
+      expect(out).toContain('could not be installed')
+      expect(out).toContain('the durable rules are in `AGENTS.md`')
+    })
+
+    it(`lovable with inlined skills names the GitHub-synced AGENTS.md (${mode})`, () => {
+      const out = renderSetupPrompt({
+        ...baseCtx,
+        mode,
+        handoff: 'lovable',
+        skills: {
+          installed: [],
+          inlined: ['stash-encryption', 'stash-supabase'],
+          failed: [],
+        },
+      })
+      expect(out).toContain('synced into Lovable via GitHub')
+      expect(out).toContain('`stash-supabase`')
+    })
   }
 })

--- a/packages/cli/src/commands/init/lib/setup-prompt.ts
+++ b/packages/cli/src/commands/init/lib/setup-prompt.ts
@@ -256,10 +256,16 @@ function skillsLoadedLines(
   const delivered = [...skills.installed, ...skills.inlined]
   if (delivered.length === 0) {
     if (skills.failed.length > 0) {
+      // Only the codex handoff writes its durable rules to AGENTS.md
+      // separately from the skills, so only there can the file exist when
+      // every skill failed. For agents-md and lovable the skills are
+      // inlined INTO AGENTS.md — all-failed means the file itself was not
+      // written, and pointing the agent at it would name a file that does
+      // not exist.
       return [
         '## Rules',
         '',
-        wroteAgentsMd
+        handoff === 'codex'
           ? 'The skills could not be installed (the destination was not writable) — the durable rules are in `AGENTS.md`; read it, and consult https://cipherstash.com/docs for the API details the skills would have carried.'
           : 'The skills could not be installed (the destination was not writable) — consult https://cipherstash.com/docs for the encryption API, schema rules, and the rollout/cutover lifecycle.',
       ]

--- a/packages/cli/src/commands/init/lib/setup-prompt.ts
+++ b/packages/cli/src/commands/init/lib/setup-prompt.ts
@@ -173,6 +173,8 @@ function checked(line: string): string {
  */
 function rulesLocation(handoff: HandoffChoice, skills: SkillsDelivery): string {
   if (handoff === 'agents-md') return '`AGENTS.md` (Cursor / Windsurf / Cline)'
+  if (handoff === 'lovable')
+    return '`AGENTS.md` (synced into Lovable via GitHub)'
   const dir =
     handoff === 'claude-code' ? '`.claude/skills/`' : '`.codex/skills/`'
   const inlined = 'inlined in `AGENTS.md` under "## Skill references"'
@@ -249,7 +251,8 @@ function skillsLoadedLines(
   handoff: HandoffChoice,
   skills: SkillsDelivery,
 ): string[] {
-  const wroteAgentsMd = handoff === 'codex' || handoff === 'agents-md'
+  const wroteAgentsMd =
+    handoff === 'codex' || handoff === 'agents-md' || handoff === 'lovable'
   const delivered = [...skills.installed, ...skills.inlined]
   if (delivered.length === 0) {
     if (skills.failed.length > 0) {

--- a/packages/cli/src/commands/init/types.ts
+++ b/packages/cli/src/commands/init/types.ts
@@ -59,7 +59,12 @@ export interface SchemaDef {
   columns: ColumnDef[]
 }
 
-export type HandoffChoice = 'claude-code' | 'codex' | 'agents-md' | 'wizard'
+export type HandoffChoice =
+  | 'claude-code'
+  | 'codex'
+  | 'agents-md'
+  | 'lovable'
+  | 'wizard'
 
 /**
  * Whether the handoff agent should produce a plan first (`plan`) or go

--- a/packages/cli/src/commands/plan/index.ts
+++ b/packages/cli/src/commands/plan/index.ts
@@ -335,7 +335,7 @@ export async function planCommand(
       // agent-target picker, so name `--target` here rather than letting
       // the user re-discover the flag on the next exit-cleanly hint.
       p.outro(
-        `${planLine}. Review it, then run \`${cli} impl --target <claude-code|codex|agents-md|wizard>\` to implement. The \`--target\` flag is required when running non-interactively.`,
+        `${planLine}. Review it, then run \`${cli} impl --target <${HANDOFF_CHOICES.join('|')}>\` to implement. The \`--target\` flag is required when running non-interactively.`,
       )
     }
   } catch (err) {

--- a/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
+++ b/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
@@ -81,6 +81,8 @@ describe('stash impl — non-TTY safety (BUGS.md reproducer)', () => {
     expect(r.timedOut).toBe(false)
     expect(r.exitCode).toBe(0)
     expect(r.stdout).toContain('--target')
-    expect(r.stdout).toContain('claude-code | codex | agents-md | wizard')
+    expect(r.stdout).toContain(
+      'claude-code | codex | agents-md | lovable | wizard',
+    )
   })
 })

--- a/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
+++ b/packages/cli/tests/e2e/impl-non-tty.e2e.test.ts
@@ -72,17 +72,22 @@ describe('stash impl — non-TTY safety (BUGS.md reproducer)', () => {
     expect(combined).toContain('wizard')
   })
 
-  it('`impl --help` documents the --target flag and its values', async () => {
-    // The global banner no longer inlines per-command flags; the --target
-    // escape hatch is documented under `impl --help` (rendered from the
-    // command-descriptor registry).
-    const r = await runPiped(['impl', '--help'], { timeoutMs: 5_000 })
+  // `plan` and `impl` each carry their own --target descriptor in the
+  // registry, so both need asserting — dropping a target from one of them
+  // would otherwise ship silently.
+  for (const command of ['impl', 'plan'] as const) {
+    it(`\`${command} --help\` documents the --target flag and its values`, async () => {
+      // The global banner no longer inlines per-command flags; the --target
+      // escape hatch is documented under the command's own --help (rendered
+      // from the command-descriptor registry).
+      const r = await runPiped([command, '--help'], { timeoutMs: 5_000 })
 
-    expect(r.timedOut).toBe(false)
-    expect(r.exitCode).toBe(0)
-    expect(r.stdout).toContain('--target')
-    expect(r.stdout).toContain(
-      'claude-code | codex | agents-md | lovable | wizard',
-    )
-  })
+      expect(r.timedOut).toBe(false)
+      expect(r.exitCode).toBe(0)
+      expect(r.stdout).toContain('--target')
+      expect(r.stdout).toContain(
+        'claude-code | codex | agents-md | lovable | wizard',
+      )
+    })
+  }
 })

--- a/skills/stash-cli/SKILL.md
+++ b/skills/stash-cli/SKILL.md
@@ -131,7 +131,7 @@ There is **no global `--non-interactive` or `--json` flag** (and no global `--ye
 |---|---|
 | Region (`auth login`, `init`) | `--region <slug>` or `STASH_REGION` |
 | Database URL (all `db` / `eql` / `schema` commands) | `--database-url <url>` or `DATABASE_URL` |
-| Agent target (`plan`, `impl`) | `--target <claude-code\|codex\|agents-md\|wizard>` |
+| Agent target (`plan`, `impl`) | `--target <claude-code\|codex\|agents-md\|lovable\|wizard>` |
 | Dual-write confirmation (`encrypt backfill`) | `--confirm-dual-writes-deployed` |
 | Machine-readable output | `--json` on `status`, `manifest`, `auth login`, `auth regions` |
 
@@ -267,7 +267,7 @@ Each column carries `path: "new" | "migrate"`. `stash impl` parses this to rende
 
 To re-plan, delete `.cipherstash/plan.md` first — otherwise the agent is told to revise it rather than start fresh. `--complete-rollout` is the escape hatch for databases with no deployed application (local dev, sandboxes, test DBs); it's only safe when nothing in production writes to that database.
 
-**The outro reports what actually happened.** The plan file is written by the handed-off agent, so `plan` verifies it on disk before claiming anything: `Plan drafted at .cipherstash/plan.md` appears only when the file exists after the handoff. If a launched agent exits without writing it, `plan` errors and **exits non-zero**. Deferred handoffs — `--target agents-md`, or a Claude Code / Codex target whose CLI isn't installed — end with `No plan drafted yet` and exit 0: the plan lands later, when you drive the agent yourself. A pre-existing plan the run didn't modify is reported as `left unchanged by this run`, not drafted. Either way, check that `.cipherstash/plan.md` exists before acting on it.
+**The outro reports what actually happened.** The plan file is written by the handed-off agent, so `plan` verifies it on disk before claiming anything: `Plan drafted at .cipherstash/plan.md` appears only when the file exists after the handoff. If a launched agent exits without writing it, `plan` errors and **exits non-zero**. Deferred handoffs — `--target agents-md`, `--target lovable`, or a Claude Code / Codex target whose CLI isn't installed — end with `No plan drafted yet` and exit 0: the plan lands later, when you drive the agent yourself. The `lovable` target writes the same AGENTS.md (with the skills inlined) but its next steps go through Lovable's GitHub sync: commit and push the generated files, then add a Knowledge note in the Lovable project settings pointing the agent at `AGENTS.md` and `.cipherstash/setup-prompt.md` — Lovable does not auto-load AGENTS.md the way Cursor or Windsurf do. A pre-existing plan the run didn't modify is reported as `left unchanged by this run`, not drafted. Either way, check that `.cipherstash/plan.md` exists before acting on it.
 
 ### `impl` — execute
 


### PR DESCRIPTION
Closes cipherstash/stack#873.

## Why

A customer hit a wall setting up CipherStash in Lovable. Lovable's agent — with no repo-local guidance available — answered from stale training data: it claimed CipherStash needs a Postgres extension (EQL) plus ZeroKMS "installed on the managed database", concluded a real setup was impossible, and built a hand-rolled AES-GCM + deterministic-HMAC scheme instead. Every claim is wrong today: EQL v3 is plain SQL, installs as a non-superuser on Supabase (Lovable's backend), and ZeroKMS is hosted — nothing installs in the database.

Nothing in `stash init` targeted Lovable, so there was no way to get correct guidance in front of its agent.

<img src="https://github.com/user-attachments/assets/c873f1a8-af70-4e96-9a9e-4b6b06ea09d4 " alt="image" width="911" data-linear-height="976" />

## What

Adds a `lovable` handoff target to `stash plan` / `stash impl` (`--target lovable` plus a new agent-target picker entry).

* Reuses the editor-agent inline path: writes `AGENTS.md` with the doctrine plus the per-integration skills inlined, and the usual `.cipherstash/context.json` + `.cipherstash/setup-prompt.md`.
* Lovable-specific next steps in the handoff note: Lovable only sees the repo through its GitHub sync, and does not auto-load `AGENTS.md` the way Cursor/Windsurf do — so the guidance is to commit and push, then add a Knowledge note in the Lovable project settings pointing the agent at `AGENTS.md` and `.cipherstash/setup-prompt.md`.
* `plan`'s non-TTY outro now derives its target list from `HANDOFF_CHOICES` instead of a hard-coded string.
* Registry help text, `skills/stash-cli/SKILL.md`, and tests updated; `stash` minor changeset included.

## Verification

* `pnpm --filter stash test` — 1207 passed
* `pnpm --filter stash test:e2e` — 100 passed
* `pnpm run code:check` — no errors
* `stash manifest --json` resolves the new `--target` value (skills doc checked against it)

## Summary by CodeRabbit

## New Features

* Added Lovable as a supported handoff target for planning and implementation.
* Added Lovable-specific setup guidance, generated files, skills, and follow-up instructions.
* Added guidance for syncing project files through GitHub and configuring Lovable Knowledge.

## Bug Fixes

* Improved messaging when setup files or skills cannot be written, including clear recovery instructions.

## Documentation

* Updated command help and workflow documentation to include Lovable support.

## Summary by CodeRabbit

* **New Features**
  * Added Lovable as a handoff target for `plan` and `impl` commands.
  * Lovable handoffs now generate project guidance and setup instructions, including GitHub synchronization and Knowledge configuration.
  * Added Lovable to interactive target selection and command help.
* **Bug Fixes**
  * Improved messaging when guidance files cannot be written, with clearer recovery instructions.
  * Updated fallback messages to accurately reflect which setup content is available.
* **Tests**
  * Added coverage for Lovable handoffs, target selection, and file-write failure scenarios.