### PR TITLE
docs: require signed commits, rename CONTRIBUTE.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,72 @@ Then navigate to one of the examples in `examples/` and follow its README.
 
 5. **Add a changeset** if your change affects a published package's public behaviour (see below).
 
+6. **Sign your commits** — every commit in a pull request must be signed (see below).
+
+## Signing Your Commits
+
+**All commits must be cryptographically signed.** This is a hard requirement: pull
+requests containing unsigned commits will not be merged. Signing ties each commit to
+a verified identity, which matters for a repository whose packages ship as
+dependencies into other people's applications — an unsigned commit is an unattributable
+change in a supply chain.
+
+GitHub shows a **Verified** badge next to signed commits. If a commit in your PR
+doesn't have one, it needs to be re-signed.
+
+### Set up signing
+
+You can sign with SSH (simplest if you already push over SSH) or GPG.
+
+**SSH signing** (Git >= 2.34):
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Then add the same public key to your GitHub account as a **Signing Key**
+(Settings → SSH and GPG keys → New SSH key → key type "Signing Key"). A key
+registered only as an authentication key will not produce a Verified badge.
+
+**GPG signing:**
+
+```bash
+gpg --full-generate-key                       # if you don't already have a key
+gpg --list-secret-keys --keyid-format=long    # copy the key ID
+git config --global user.signingkey <KEY_ID>
+git config --global commit.gpgsign true
+```
+
+Then export the public key (`gpg --armor --export <KEY_ID>`) and add it to GitHub
+under Settings → SSH and GPG keys → New GPG key.
+
+The email on your signing key must match the email in your Git config and be a
+verified email on your GitHub account, or GitHub will mark the commit
+**Unverified** rather than **Verified**.
+
+Full instructions: [GitHub — signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
+### Fixing unsigned commits
+
+If you've already pushed unsigned commits, sign them retroactively and force-push
+to your branch:
+
+```bash
+# Sign the last N commits (replace N with the number of commits in your PR)
+git rebase --exec 'git commit --amend --no-edit -S' -i HEAD~N
+
+# Or sign every commit on your branch relative to main
+git rebase --exec 'git commit --amend --no-edit -S' main
+
+git push --force-with-lease
+```
+
+Force-pushing rewrites history on your branch. Only do this on your own PR branch,
+never on `main`, and check with the maintainers first if anyone else has based work
+on your branch.
+
 ## Publish Process (via Changesets)
 
 We use [**Changesets**](https://github.com/changesets/changesets) to manage versioning and publication to npm.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ npm install @cipherstash/stack   # or: yarn / pnpm / bun add @cipherstash/stack
 
 ## Contributing · Security · License
 
-Contributions are welcome — see [CONTRIBUTE.md][contribute]. For our security policy and responsible
+Contributions are welcome — see [CONTRIBUTING.md][contribute]. For our security policy and responsible
 disclosure, see [SECURITY.md][security-policy]. [MIT licensed][license].
 
 <!-- Link definitions — keep all URLs here. CipherStash links carry README UTM params. -->
@@ -384,6 +384,6 @@ disclosure, see [SECURITY.md][security-policy]. [MIT licensed][license].
 [eql]: https://github.com/cipherstash/encrypt-query-language
 [discord]: https://discord.gg/5qwXUFb6PB
 [examples]: https://github.com/cipherstash/stack/tree/main/examples
-[contribute]: https://github.com/cipherstash/stack/blob/main/CONTRIBUTE.md
+[contribute]: https://github.com/cipherstash/stack/blob/main/CONTRIBUTING.md
 [security-policy]: https://github.com/cipherstash/stack/blob/main/SECURITY.md
 [license]: https://github.com/cipherstash/stack/blob/main/LICENSE.md

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -353,7 +353,7 @@ npm install @cipherstash/stack   # or: yarn / pnpm / bun add @cipherstash/stack
 
 ## Contributing · Security · License
 
-Contributions are welcome — see [CONTRIBUTE.md][contribute]. For our security policy and responsible
+Contributions are welcome — see [CONTRIBUTING.md][contribute]. For our security policy and responsible
 disclosure, see [SECURITY.md][security-policy]. [MIT licensed][license].
 
 <!-- Link definitions — keep all URLs here. CipherStash links carry README UTM params. -->
@@ -384,6 +384,6 @@ disclosure, see [SECURITY.md][security-policy]. [MIT licensed][license].
 [eql]: https://github.com/cipherstash/encrypt-query-language
 [discord]: https://discord.gg/5qwXUFb6PB
 [examples]: https://github.com/cipherstash/stack/tree/main/examples
-[contribute]: https://github.com/cipherstash/stack/blob/main/CONTRIBUTE.md
+[contribute]: https://github.com/cipherstash/stack/blob/main/CONTRIBUTING.md
 [security-policy]: https://github.com/cipherstash/stack/blob/main/SECURITY.md
 [license]: https://github.com/cipherstash/stack/blob/main/LICENSE.md

--- a/scripts/lint-no-dead-package-paths.mjs
+++ b/scripts/lint-no-dead-package-paths.mjs
@@ -19,7 +19,7 @@ const TARGETS = process.argv.slice(2).length
       'CLAUDE.md',
       'README.md',
       'SECURITY.md',
-      'CONTRIBUTE.md',
+      'CONTRIBUTING.md',
       'docs',
       '.github',
       'skills',


### PR DESCRIPTION
A third-party PR landed recently with unsigned commits. Two reasons that happened, and this fixes both.

## 1. The guidelines never said signing was required

Adds a **Signing Your Commits** section to the contributor guidelines, plus a step in "Making Changes" pointing at it. It covers:

- The requirement itself — every commit in a PR must be signed, unsigned PRs don't merge — and why it matters for a repo whose packages ship as dependencies into other people's apps.
- SSH signing setup, including the gotcha that a key registered on GitHub as an *authentication* key won't produce a Verified badge; it has to be added as a **Signing Key**.
- GPG signing setup.
- The signing-key email must match the Git config email and be verified on GitHub, or commits show as **Unverified** rather than **Verified**.
- How to retroactively sign already-pushed commits (`git rebase --exec 'git commit --amend --no-edit -S' main` + `--force-with-lease`), with a warning to only force-push your own PR branch.

## 2. Contributors were probably never shown the file

The file was named `CONTRIBUTE.md`. GitHub only surfaces its "Contributing guidelines" prompt on new issues and PRs for `CONTRIBUTING.md` (in the repo root, `.github/`, or `docs/`), so the document was effectively invisible to drive-by contributors.

Renamed to `CONTRIBUTING.md` and updated the inbound references:

- `README.md`
- `packages/stack/README.md`
- the target list in `scripts/lint-no-dead-package-paths.mjs`

`node scripts/lint-no-dead-package-paths.mjs` passes; `biome check` clean on the touched files.

Closes #881.