### PR TITLE
stash doctor: an absent optional package is a skipped check, not a pass

### DIFF
--- a/.changeset/doctor-optional-absent-is-not-a-pass.md
+++ b/.changeset/doctor-optional-absent-is-not-a-pass.md
@@ -1,0 +1,10 @@
+---
+'stash': patch
+---
+
+`stash doctor` no longer reports "All checks passed." when `@cipherstash/stack`
+is absent. The package is an optional peer, so running `doctor` before `stash
+init` skips the encryption check entirely — the row already said so, but the
+outro claimed a pass for a check that never ran. It now ends with "stash doctor
+could not run every check.", the same line an unprobeable install gets, and
+still exits 0: an absent optional package is recoverable, not a failure.

--- a/packages/cli/src/commands/doctor/index.ts
+++ b/packages/cli/src/commands/doctor/index.ts
@@ -40,7 +40,7 @@ interface Probe {
 
 const PROBES: Probe[] = [
   {
-    label: 'Encryption engine (@cipherstash/stack → protect-ffi)',
+    label: messages.doctor.encryptionProbeLabel,
     pkg: '@cipherstash/stack',
     subpath: './diagnostics',
     optional: true,
@@ -55,7 +55,7 @@ const PROBES: Probe[] = [
     },
   },
   {
-    label: 'Auth (@cipherstash/auth)',
+    label: messages.doctor.authProbeLabel,
     pkg: '@cipherstash/auth',
     async force() {
       // No counterpart call needed. This package's entry is `module.exports =
@@ -177,7 +177,12 @@ export async function doctorCommand(): Promise<void> {
             ? messages.doctor.notInstalledOptional
             : messages.doctor.notInstalled,
         )
-        if (!probe.optional) failed = true
+        // The row stays green — absence before `stash init` is expected, and
+        // the detail already says so — but the check did not RUN, which is the
+        // same thing the too-old arm below records. Without this the outro said
+        // every check passed while one of the two never executed.
+        if (probe.optional) incomplete = true
+        else failed = true
       } else if (isSubpathUnavailable(err, probe)) {
         report('warn', probe.label, messages.doctor.cannotProbe)
         incomplete = true

--- a/packages/cli/src/messages.ts
+++ b/packages/cli/src/messages.ts
@@ -26,6 +26,15 @@ export const messages = {
     title: 'stash doctor',
     /** Leader of the platform check line; the `<platform>-<arch>` is appended. */
     platformLabel: 'Platform',
+    /**
+     * Probe row labels. Here rather than inline in `commands/doctor/index.ts`
+     * because both E2E suites match a row as `<label> — <detail>`: the detail
+     * halves were already constants while the labels were copied into each
+     * suite, so a copy tweak broke the tests from a file they don't name.
+     */
+    encryptionProbeLabel:
+      'Encryption engine (@cipherstash/stack → protect-ffi)',
+    authProbeLabel: 'Auth (@cipherstash/auth)',
     allChecksPassed: 'All checks passed.',
     /** Row detail when a probe reached the loader and no platform binary was there. */
     nativeBinaryMissing: 'native binary missing',

--- a/packages/cli/tests/e2e/doctor-missing-binary.e2e.test.ts
+++ b/packages/cli/tests/e2e/doctor-missing-binary.e2e.test.ts
@@ -35,7 +35,7 @@ interface Target {
 const TARGETS: Target[] = [
   {
     pkg: '@cipherstash/protect-ffi',
-    label: 'Encryption engine (@cipherstash/stack → protect-ffi)',
+    label: messages.doctor.encryptionProbeLabel,
     // `src/load.cts`'s debug arm — a local cargo build sitting beside `lib/`.
     // A contributor who has run `pnpm run debug` has one, and without this the
     // fixture would load the binding it means to be missing.
@@ -43,7 +43,7 @@ const TARGETS: Target[] = [
   },
   {
     pkg: '@cipherstash/auth',
-    label: 'Auth (@cipherstash/auth)',
+    label: messages.doctor.authProbeLabel,
     // napi's local-build arm, tried before the platform package.
     extra: String.raw`|(?:^|[\\/])stack-auth-node\.node$`,
   },

--- a/packages/cli/tests/e2e/doctor-probe-classification.e2e.test.ts
+++ b/packages/cli/tests/e2e/doctor-probe-classification.e2e.test.ts
@@ -26,9 +26,8 @@ import { render } from '../helpers/pty.js'
 // the code and message pasted on. A fixture like that keeps passing when Node
 // changes either, which is the whole risk being covered.
 
-/** Mirrors the probe labels in `src/commands/doctor/index.ts`. */
-const ENCRYPTION_LABEL = 'Encryption engine (@cipherstash/stack → protect-ffi)'
-const AUTH_LABEL = 'Auth (@cipherstash/auth)'
+const ENCRYPTION_LABEL = messages.doctor.encryptionProbeLabel
+const AUTH_LABEL = messages.doctor.authProbeLabel
 
 interface Unresolve {
   /** The bare specifier to divert. */
@@ -125,7 +124,11 @@ describe.skipIf(!hooksAvailable)('stash doctor — probe classification', () => 
     expect(r.output).toContain(
       `${ENCRYPTION_LABEL} — ${messages.doctor.notInstalledOptional}`,
     )
-    expect(r.output).toContain(messages.doctor.allChecksPassed)
+    // Recoverable, so exit 0 and a green row — but the encryption check did not
+    // run, and the outro must not say it passed. Same distinction the too-old
+    // arm makes below; this arm predates it and claimed a pass.
+    expect(r.output).toContain(messages.doctor.checksIncomplete)
+    expect(r.output).not.toContain(messages.doctor.allChecksPassed)
     expect(r.output).not.toContain('Fatal error')
     // The optional package's absence must not be dressed up as a missing
     // binary — that would send the user to a reinstall for a package they


### PR DESCRIPTION
Stacked on #883 — base is that branch, so this diff is one commit. Both fixes are for issues that predate it and that it leaves untouched; a review of #883 surfaced them, but neither is a regression from it.

## An absent `@cipherstash/stack` ended the run with "All checks passed."

It is an optional peer, so this is the plain `npx stash doctor` path in a project that has not run `stash init`. The row already said `not installed (run \`stash init\`)` — and then the outro claimed a pass for a check that never executed. That is the one line of doctor's output a user has no way to second-guess.

It now ends with `checksIncomplete` ("stash doctor could not run every check."), which is the line the too-old-to-probe arm already uses for exactly this distinction — #883 introduced that vocabulary for the structurally identical case and did not apply it here. Exit code stays 0 and the row stays green: absence before `init` is recoverable, not a failure, and dressing it up as one would send users to a reinstall for a package they simply have not installed yet.

## The probe labels were hard-coded in three places

`packages/cli/AGENTS.md`: *"Strings that tests assert on live in `src/messages.ts` … **Don't** hard-code the new wording in a test."* Both E2E suites match a row as `<label> — <detail>`. The detail halves were already constants; the labels were copied into each suite, one of them under a `/** Mirrors the probe labels in \`src/commands/doctor/index.ts\`. */` comment conceding the drift.

Moved to `messages.doctor.encryptionProbeLabel` / `authProbeLabel`. The same file's caveat — *"Add to `messages.ts` only when a test actually asserts on the string"* — is what makes this the right call rather than premature extraction.

## Tests

`doctor-probe-classification.e2e.test.ts` asserted the old outro, so it changes with the behaviour. Verified non-vacuous: reverting the one-line prod change and rebuilding fails that test and nothing else. `doctor.e2e.test.ts` still asserts `All checks passed.` on a healthy install, which is the other half — this change must not touch the case where both probes ran.

- CLI unit 1243 passed / 16 skipped
- CLI e2e 108 passed (20 files)
- `turbo typecheck` 3/3, `biome check --diagnostic-level=error` clean

## Notes for the reviewer

- Changeset is a `stash` patch — the outro wording is user-visible in a real scenario.
- No skill changes: `skills/stash-cli` describes `doctor` generically (one table row, one troubleshooting line) and names no output strings. Command and flag surface unchanged.
- Merge #883 first, or retarget this to `main` — the label move rebases onto `main` cleanly, but the outro fix does not, since `checksIncomplete` does not exist there.