### PR TITLE
docs(skills): teach the PSL expression-index form Prisma Next 0.17 added

### DIFF
--- a/.changeset/prisma-skill-psl-expression-indexes.md
+++ b/.changeset/prisma-skill-psl-expression-indexes.md
@@ -2,4 +2,4 @@
 'stash': patch
 ---
 
-Correct the bundled `stash-prisma` and `stash-indexing` skills for Prisma Next 0.17's functional-index support: `@@index` now takes an `expression` argument, so the `eql_v3.*` functional indexes are declared directly in `schema.prisma` (expression indexes require a `name` or `map`; `options` requires `type`) instead of hand-written raw-SQL migration operations. `rawSql` remains the home of the post-build `ANALYZE` and the fallback for DDL that PSL cannot carry.
+Correct the bundled `stash-prisma` and `stash-indexing` skills for Prisma Next 0.17's functional-index support: `@@index` now takes an `expression` argument, so the `eql_v3.*` functional indexes are declared directly in `schema.prisma` (expression indexes require a `name` or `map`) instead of hand-written raw-SQL migration operations. Also documents the physical-name rule (`name:` gains a content-hash suffix, `map:` pins the exact name), the TS contract form (`type` requires `options`), and that `CREATE INDEX CONCURRENTLY` cannot run through the migration runner's transaction — via `rawSql` or otherwise.

--- a/.changeset/prisma-skill-psl-expression-indexes.md
+++ b/.changeset/prisma-skill-psl-expression-indexes.md
@@ -1,0 +1,5 @@
+---
+'stash': patch
+---
+
+Correct the bundled `stash-prisma` and `stash-indexing` skills for Prisma Next 0.17's functional-index support: `@@index` now takes an `expression` argument, so the `eql_v3.*` functional indexes are declared directly in `schema.prisma` (expression indexes require a `name` or `map`; `options` requires `type`) instead of hand-written raw-SQL migration operations. `rawSql` remains the home of the post-build `ANALYZE` and the fallback for DDL that PSL cannot carry.

--- a/skills/stash-indexing/SKILL.md
+++ b/skills/stash-indexing/SKILL.md
@@ -255,7 +255,7 @@ Index not being used:
 **The integrations emit the query operators for you — none applies index DDL on its own. Making sure these indexes exist is always your job.** This skill is the general model — recipes, engagement rules, verification. How to apply it in a specific integration lives in that integration's skill:
 
 - **Drizzle** — `encryptedIndexes(t)` from `@cipherstash/stack-drizzle` derives the recommended indexes for every encrypted column in the table, or declare individual expression indexes in the schema DSL. See `stash-drizzle` § Indexing Encrypted Columns.
-- **Prisma Next** — Prisma's schema language cannot express functional indexes; the DDL goes in a migration in the adapter's flow. See `stash-prisma`.
+- **Prisma Next** — since Prisma Next 0.17, `@@index(expression: "eql_v3.eq_term(email)", name: "users_email_eq", type: "btree")` declares a functional index directly in `schema.prisma`; the accompanying `ANALYZE` rides a raw-SQL migration operation. See `stash-prisma` § Indexing encrypted columns.
 - **Supabase** — a `supabase/migrations/` file; no superuser needed (see above). See `stash-supabase`.
 - **Raw SQL / plain PostgreSQL** — the recipes in this skill, in whatever migration tool owns the schema. Never ad-hoc in production. The predicates those indexes serve are in `stash-postgres`.
 

--- a/skills/stash-prisma/SKILL.md
+++ b/skills/stash-prisma/SKILL.md
@@ -221,8 +221,18 @@ fields list or an `expression`; an expression index **requires `name` or
 argument requires `type`. The expression string is the entire element list
 between the parens of `CREATE INDEX`, inserted verbatim — which is why the
 Json recipe carries its own parens and the `jsonb_path_ops` opclass. TS-authored
-contracts have the same surface: `index({ expression, name, type })` alongside
-the column factories.
+contracts have the same surface: `index({ expression, name })` alongside the
+column factories — and there, passing `type` makes `options` required (use
+`options: {}` when you have none).
+
+`name:` is a logical name, not the physical one: the index is created as
+`<name>_<8-hex content hash>` (`users_email_eq` lands as e.g.
+`users_email_eq_1a2b3c4d`), so when verifying with `EXPLAIN` or querying
+`pg_indexes`, match on the prefix rather than the exact string. `map:` pins
+the exact physical name instead — but the planner emits a drift warning
+whenever `map:` is combined with an expression body, so prefer `name:` and
+prefix-matching unless you must adopt an index that already exists under a
+bare name.
 
 `ANALYZE` is still part of the recipe — an expression index has no statistics
 until it runs, and PSL cannot express it — so it rides a raw-SQL operation
@@ -244,8 +254,15 @@ rawSql({
 })
 ```
 
-(`rawSql` also remains the fallback for index DDL itself if you need something
-PSL doesn't carry — `CREATE INDEX CONCURRENTLY`, for instance.)
+`rawSql` also remains the fallback for index DDL PSL doesn't carry — with one
+hard exception: **`CREATE INDEX CONCURRENTLY` cannot run through the migration
+flow at all.** The runner wraps every apply in a single transaction, and
+Postgres rejects `CONCURRENTLY` inside a transaction block (error `25001`), so
+a `rawSql` operation carrying it fails deterministically. This rarely matters
+here: under the rollout timing in `stash-indexing`, these indexes are built
+while the encrypted column is new or freshly backfilled, where a plain
+`CREATE INDEX` is correct. If a table is genuinely too hot for that, the
+concurrent build has to happen outside the migration runner.
 
 Everything above works as a non-superuser role (Supabase included); only the
 ORE-flavour (`_ord_ore`) ordering opclass is superuser-gated. For the full

--- a/skills/stash-prisma/SKILL.md
+++ b/skills/stash-prisma/SKILL.md
@@ -191,63 +191,69 @@ Two things are Prisma-Next-specific:
 
 The adapter emits the encrypted query operators, but **no index DDL** — without
 functional indexes over the `eql_v3.*` extractors, every encrypted predicate
-sequential-scans. Two facts shape where the DDL goes:
-
-- **`schema.prisma` cannot express functional indexes** (`@@index` takes
-  fields, not expressions), so the schema file is not an option.
-- Prisma Next migrations execute **raw SQL operations**, so an index migration
-  is just an operation whose statements are the `CREATE INDEX` recipes —
-  authored in the same migration history that installs the EQL bundle, applied
-  by the same `prisma-next migrate`. Never run index DDL out-of-band.
+sequential-scans. Since Prisma Next 0.17, `@@index` takes an `expression`
+argument, so the indexes are declared in `schema.prisma` next to the columns
+they serve and ride the same `prisma-next migration plan` / `prisma-next
+migrate` flow as everything else. Never run index DDL out-of-band.
 
 One index per capability the column's domain carries:
 
-```sql
--- cipherstash.TextEq / TextSearch: equality
-CREATE INDEX users_email_eq ON users USING btree (eql_v3.eq_term(email));
--- cipherstash.*Ord / TextSearch: ordering + range (on numeric/date/timestamp
--- _ord domains this one index serves = too; TextOrd needs the eq_term index
--- above as well)
-CREATE INDEX users_created_at_ord ON users USING btree (eql_v3.ord_term(created_at));
--- cipherstash.TextMatch / TextSearch: free-text match
-CREATE INDEX users_bio_match ON users USING gin (eql_v3.match_term(bio));
--- cipherstash.Json: containment
-CREATE INDEX users_profile_json
-  ON users USING gin ((eql_v3.to_ste_vec_query(profile)::jsonb) jsonb_path_ops);
+```prisma
+model User {
+  // ... fields, including the encrypted columns ...
 
-ANALYZE users;
+  // cipherstash.TextEq / TextSearch: equality
+  @@index(expression: "eql_v3.eq_term(email)", name: "users_email_eq", type: "btree")
+  // cipherstash.*Ord / TextSearch: ordering + range (on numeric/date/timestamp
+  // _ord domains this one index serves = too; TextOrd needs the eq_term index
+  // above as well)
+  @@index(expression: "eql_v3.ord_term(created_at)", name: "users_created_at_ord", type: "btree")
+  // cipherstash.TextMatch / TextSearch: free-text match
+  @@index(expression: "eql_v3.match_term(bio)", name: "users_bio_match", type: "gin")
+  // cipherstash.Json: containment
+  @@index(expression: "(eql_v3.to_ste_vec_query(profile)::jsonb) jsonb_path_ops", name: "users_profile_json", type: "gin")
+}
 ```
 
-The `ANALYZE` is part of the recipe — an expression index has no statistics
-until it runs. Works as a non-superuser role (Supabase included); only the
+Three rules the interpreter enforces: an `@@index` takes exactly one of a
+fields list or an `expression`; an expression index **requires `name` or
+`map`** (no default name can be derived from an expression); and an `options`
+argument requires `type`. The expression string is the entire element list
+between the parens of `CREATE INDEX`, inserted verbatim — which is why the
+Json recipe carries its own parens and the `jsonb_path_ops` opclass. TS-authored
+contracts have the same surface: `index({ expression, name, type })` alongside
+the column factories.
+
+`ANALYZE` is still part of the recipe — an expression index has no statistics
+until it runs, and PSL cannot express it — so it rides a raw-SQL operation
+(`rawSql` from `@prisma/orm-postgres/migration`) in the migration that
+introduces the indexes:
+
+```typescript
+rawSql({
+  id: 'analyze.users',
+  label: 'Refresh statistics for the new expression indexes',
+  operationClass: 'additive',
+  target: {
+    id: 'postgres',
+    details: { schema: 'public', objectType: 'table', name: 'users' },
+  },
+  precheck: [],
+  execute: [{ description: 'refresh statistics', sql: 'ANALYZE "public"."users"' }],
+  postcheck: [],
+})
+```
+
+(`rawSql` also remains the fallback for index DDL itself if you need something
+PSL doesn't carry — `CREATE INDEX CONCURRENTLY`, for instance.)
+
+Everything above works as a non-superuser role (Supabase included); only the
 ORE-flavour (`_ord_ore`) ordering opclass is superuser-gated. For the full
 model — which domains take which index, engagement rules, `EXPLAIN`
 verification, rollout timing — see the `stash-indexing` skill. For encrypted
 predicates written as raw SQL rather than through the `cipherstash:*`
 operators — operand casts to `eql_v3.query_*`, per-driver parameter binding —
 see the `stash-postgres` skill.
-
-In a migration, the recipes ride a raw-SQL operation (`rawSql` from
-`@prisma/orm-postgres/migration`) in the migration's `operations`:
-
-```typescript
-rawSql({
-  id: 'index.users.encrypted',
-  label: 'Index encrypted columns on users',
-  operationClass: 'additive',
-  target: {
-    id: 'postgres',
-    details: { schema: 'public', objectType: 'index', name: 'users_email_eq', table: 'users' },
-  },
-  precheck: [],
-  execute: [
-    { description: 'equality index',
-      sql: 'CREATE INDEX IF NOT EXISTS users_email_eq ON "public"."users" USING btree (eql_v3.eq_term(email))' },
-    { description: 'refresh statistics', sql: 'ANALYZE "public"."users"' },
-  ],
-  postcheck: [],
-})
-```
 
 ## Writing and reading encrypted values
 


### PR DESCRIPTION
Closes cipherstash/stack#895.

The `stash-prisma` skill's "Indexing encrypted columns" section claimed `schema.prisma` **cannot express functional indexes** and prescribed hand-written `rawSql` operations as the only path. True on 0.16; false since cipherstash/stack#749 moved us to Prisma Next 0.17.

Verified against the installed `@prisma/orm-family-sql@0.17.0` dist (interpreter's `indexModelSpec`): `@@index` accepts `expression`, `where`, `unique`, `name`/`map`, `type`, `options`, with three enforced rules — expression XOR fields, expression requires `name`/`map`, `options` requires `type`. The expression string is the whole element list between the `CREATE INDEX` parens, inserted verbatim (target-postgres `pgRenderCreateIndex`).

Changes:

* `skills/stash-prisma`: the four capability recipes are now `@@index(expression:)` blocks in `schema.prisma`; the interpreter's three rules are stated; the Json recipe explains why it carries its own parens and opclass. `rawSql` stays for `ANALYZE` (PSL has no form for it — an expression index has no statistics until it runs) and as the fallback for DDL PSL can't carry (`CREATE INDEX CONCURRENTLY`).
* `skills/stash-indexing`: the per-integration pointer for Prisma Next updated from "schema language cannot express functional indexes" to the `@@index(expression:)` form.
* **Changeset**: `stash` patch — `skills/` ships in the tarball.

Auto-deriving these indexes from the codec (no user-authored index at all) is cipherstash/stack#896.