### PR TITLE
docs(release): explain the 2.0.0 alignment and the FFI publishing-repository change

### DIFF
--- a/.changeset/ffi-platform-packages-publishing-repository.md
+++ b/.changeset/ffi-platform-packages-publishing-repository.md
@@ -9,7 +9,7 @@
 
 **This is the first release of these packages published from
 `cipherstash/stack`.** Every version up to and including 0.31.0 was published
-from `cipherstash/protectjs-ffi`, which is now archived.
+from `cipherstash/protectjs-ffi`, which is archived once this release is out.
 
 If you verify npm provenance, the attested source repository changes with this
 release:
@@ -21,10 +21,14 @@ release:
 
 A verification policy that pins the source repository will reject 0.32.0 until
 it is updated. The packages, their contents and their maintainers are otherwise
-unchanged — the Rust source moved into the monorepo at
-`packages/protect-ffi/crates/protect-ffi`, and each platform package's
-`repository.url` and `repository.directory` now point there.
+unchanged: the Rust source moved into the monorepo at
+`packages/protect-ffi/crates/protect-ffi`, and each of these packages'
+`repository.url` now names `cipherstash/stack`, with `repository.directory`
+pointing at its own stub under `packages/protect-ffi/platforms/`.
 
-The binaries themselves also differ from 0.31.0 in one user-visible way: the
-Rust core's `InvariantViolation` message asks the reader to file an issue, and
-the repository it names has moved with the rest.
+`CHANGELOG.md` is also added to each package's published files, so this note and
+later ones are readable in the package you install rather than only on GitHub.
+
+The binaries themselves differ from 0.31.0 in one user-visible way: the Rust
+core's `InvariantViolation` message asks the reader to file an issue, and the
+repository it names has moved with the rest.

--- a/.changeset/ffi-platform-packages-publishing-repository.md
+++ b/.changeset/ffi-platform-packages-publishing-repository.md
@@ -1,0 +1,30 @@
+---
+'@cipherstash/protect-ffi-darwin-x64': patch
+'@cipherstash/protect-ffi-darwin-arm64': patch
+'@cipherstash/protect-ffi-win32-x64-msvc': patch
+'@cipherstash/protect-ffi-linux-x64-gnu': patch
+'@cipherstash/protect-ffi-linux-arm64-gnu': patch
+'@cipherstash/protect-ffi-linux-x64-musl': patch
+---
+
+**This is the first release of these packages published from
+`cipherstash/stack`.** Every version up to and including 0.31.0 was published
+from `cipherstash/protectjs-ffi`, which is now archived.
+
+If you verify npm provenance, the attested source repository changes with this
+release:
+
+```
+0.31.0   github.com/cipherstash/protectjs-ffi   .github/workflows/release.yml
+0.32.0   github.com/cipherstash/stack           .github/workflows/release.yml
+```
+
+A verification policy that pins the source repository will reject 0.32.0 until
+it is updated. The packages, their contents and their maintainers are otherwise
+unchanged — the Rust source moved into the monorepo at
+`packages/protect-ffi/crates/protect-ffi`, and each platform package's
+`repository.url` and `repository.directory` now point there.
+
+The binaries themselves also differ from 0.31.0 in one user-visible way: the
+Rust core's `InvariantViolation` message asks the reader to file an issue, and
+the repository it names has moved with the rest.

--- a/.changeset/ship-changelogs-in-tarballs.md
+++ b/.changeset/ship-changelogs-in-tarballs.md
@@ -1,0 +1,12 @@
+---
+'@cipherstash/stack-prisma': patch
+'@cipherstash/protect-ffi': patch
+---
+
+Ship `CHANGELOG.md` inside the published tarball. It was missing from `files`,
+so the release notes for these packages were readable on GitHub and on the npm
+web page but not in the package you actually install — which is the copy you
+have when something breaks offline, or when the repository has moved.
+
+`@cipherstash/stack-drizzle` and `@cipherstash/stack-supabase` gain it in the
+same release, as do the six `@cipherstash/protect-ffi-<platform>` packages.

--- a/.changeset/stack-2-0-0-version-alignment.md
+++ b/.changeset/stack-2-0-0-version-alignment.md
@@ -6,13 +6,11 @@
 '@cipherstash/wizard': major
 ---
 
-**No breaking changes in this package.** Upgrading from 1.x to 2.0.0 needs no
-code changes, and there is no migration guide to look for.
-
-The major version comes from `@cipherstash/stack-prisma`, which does have a
-breaking change this release — it moves to Prisma Next 0.17, and its own
-changelog carries the upgrade steps. These six packages share a single version
-line, so a major in any one of them takes all six to the same number:
+**Why this package went to 2.0.0.** The major version number comes from
+`@cipherstash/stack-prisma`, which moves to Prisma Next 0.17 — a breaking change
+for its consumers, with the upgrade steps in its own Major Changes entry. These
+six packages share one version line, so a major in any of them takes all six to
+the same number:
 
 - `stash`
 - `@cipherstash/stack`
@@ -22,11 +20,28 @@ line, so a major in any one of them takes all six to the same number:
 - `@cipherstash/wizard`
 
 They are versioned together on purpose. `stash init` pins the versions of the
-packages it installs, and the CLI embeds that map at build time — so if one
-package could ship without the others, the CLI would start recommending
-versions that no longer match what is published, and warn about a skew it had
-itself created.
+packages it installs and the CLI embeds that map at build time, so a package
+shipping alone would leave the CLI recommending versions that no longer match
+what is published, and warning about a skew it had itself created.
 
-**If you do not use `@cipherstash/stack-prisma`, this release is additive.**
-Read your package's own Minor and Patch entries below for what actually changed
-in it.
+**This does not mean every package in the release is drop-in.** The version
+number is shared; the changes are not. Two entries below need action from some
+users, and neither is filed under Major Changes — they are recorded at the level
+their own authors judged correct, and appear here only so you do not have to
+find them by reading the whole file:
+
+- **`@cipherstash/stack` — `clientKey` is hex-only.** A decoder fallback that
+  also accepted standard padded base64 is gone, and such a key is now rejected
+  at client construction with `invalid clientKey: expected a hex-encoded key`.
+  Hex is what `stash env` emits and what the docs have always specified, so most
+  callers are unaffected; a key pasted out of `~/.cipherstash/secretkey.json`
+  (which stores base64) is not. See "Adopt protect-ffi 0.31.0" under Patch
+  Changes. That entry also narrows which `error.code` values DynamoDB
+  operations report.
+- **`stash` — `stash eql validate` lost `--exclude-operator-family`,** and two
+  checks that used to exit 1 no longer do. A script passing that flag, or a CI
+  gate relying on those exit codes, needs updating. See the `eql validate` entry
+  under Minor Changes.
+
+If you use neither `@cipherstash/stack-prisma` nor either of those, upgrading
+1.x → 2.0.0 needs no code changes.

--- a/.changeset/stack-2-0-0-version-alignment.md
+++ b/.changeset/stack-2-0-0-version-alignment.md
@@ -25,23 +25,23 @@ shipping alone would leave the CLI recommending versions that no longer match
 what is published, and warning about a skew it had itself created.
 
 **This does not mean every package in the release is drop-in.** The version
-number is shared; the changes are not. Two entries below need action from some
-users, and neither is filed under Major Changes — they are recorded at the level
-their own authors judged correct, and appear here only so you do not have to
-find them by reading the whole file:
+number is shared; the changes are not. Two changes elsewhere in this release
+need action from some users, and neither is filed under Major Changes — each is
+recorded at the level its own author judged correct. They are named here so you
+do not have to read six changelogs to find them:
 
 - **`@cipherstash/stack` — `clientKey` is hex-only.** A decoder fallback that
   also accepted standard padded base64 is gone, and such a key is now rejected
   at client construction with `invalid clientKey: expected a hex-encoded key`.
   Hex is what `stash env` emits and what the docs have always specified, so most
   callers are unaffected; a key pasted out of `~/.cipherstash/secretkey.json`
-  (which stores base64) is not. See "Adopt protect-ffi 0.31.0" under Patch
-  Changes. That entry also narrows which `error.code` values DynamoDB
-  operations report.
+  (which stores base64) is not. The full entry is "Adopt protect-ffi 0.31.0" in
+  the **`@cipherstash/stack`** changelog; it also narrows which `error.code`
+  values DynamoDB operations report.
 - **`stash` — `stash eql validate` lost `--exclude-operator-family`,** and two
   checks that used to exit 1 no longer do. A script passing that flag, or a CI
-  gate relying on those exit codes, needs updating. See the `eql validate` entry
-  under Minor Changes.
+  gate relying on those exit codes, needs updating. The full entry is under
+  `eql validate` in the **`stash`** changelog.
 
 If you use neither `@cipherstash/stack-prisma` nor either of those, upgrading
 1.x → 2.0.0 needs no code changes.

--- a/.changeset/stack-2-0-0-version-alignment.md
+++ b/.changeset/stack-2-0-0-version-alignment.md
@@ -1,0 +1,32 @@
+---
+'stash': major
+'@cipherstash/stack': major
+'@cipherstash/stack-drizzle': major
+'@cipherstash/stack-supabase': major
+'@cipherstash/wizard': major
+---
+
+**No breaking changes in this package.** Upgrading from 1.x to 2.0.0 needs no
+code changes, and there is no migration guide to look for.
+
+The major version comes from `@cipherstash/stack-prisma`, which does have a
+breaking change this release — it moves to Prisma Next 0.17, and its own
+changelog carries the upgrade steps. These six packages share a single version
+line, so a major in any one of them takes all six to the same number:
+
+- `stash`
+- `@cipherstash/stack`
+- `@cipherstash/stack-drizzle`
+- `@cipherstash/stack-supabase`
+- `@cipherstash/stack-prisma`
+- `@cipherstash/wizard`
+
+They are versioned together on purpose. `stash init` pins the versions of the
+packages it installs, and the CLI embeds that map at build time — so if one
+package could ship without the others, the CLI would start recommending
+versions that no longer match what is published, and warn about a skew it had
+itself created.
+
+**If you do not use `@cipherstash/stack-prisma`, this release is additive.**
+Read your package's own Minor and Patch entries below for what actually changed
+in it.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @cipherstash/cli
+# stash
 
 ## 1.0.0
 

--- a/packages/protect-ffi/CHANGELOG.md
+++ b/packages/protect-ffi/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## About the entries below 0.31.0
+## About 0.31.0 and earlier
 
-Everything from `[0.31.0]` down was written by hand, under an `[Unreleased]`
+Every entry from `[0.31.0]` down was written by hand, under an `[Unreleased]`
 heading that an npm `version` lifecycle hook promoted on release. Those entries
 follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with a
 `Breaking` heading added for the pre-1.0 convention of shipping breaking changes
@@ -13,16 +13,19 @@ monorepo, Changesets generates every entry above this heading from the
 changesets in a release, in its own format.
 
 <!--
-This section sits BELOW the generated entries on purpose, and nothing may be
-added between `# Changelog` and the first release heading.
+This section is deliberately BELOW the generated entries, and any prose added
+between `# Changelog` and the first release heading must carry its own `##`
+heading — otherwise it is absorbed into the newest release.
 
-`changeset version` splices each new release in directly after the `# Changelog`
-line. Prose placed there is not a preamble: it lands inside the newest release's
-section, beneath its heading, and publishes to npm as part of those release
-notes. This section used to be there, and shipped as thirteen lines of the
-0.32.0 entry — ending with an instruction addressed to contributors.
+`changeset version` splices each release in directly after the `# Changelog`
+line. Headingless prose there is not a preamble: it lands inside that release's
+section, beneath its heading, and reads as part of those notes. This section
+used to be there and shipped as thirteen lines of the 0.32.0 entry, ending with
+an instruction addressed to contributors — see PR #913. A heading is what stops
+that, because it terminates the preceding section.
 
-Guidance for contributors belongs in AGENTS.md, not here.
+Since 0.32.0 this file is in the package's `files` list, so anything here also
+ships inside the npm tarball. Guidance for contributors belongs in AGENTS.md.
 -->
 
 ## [0.31.0] - 2026-07-27

--- a/packages/protect-ffi/CHANGELOG.md
+++ b/packages/protect-ffi/CHANGELOG.md
@@ -1,18 +1,29 @@
 # Changelog
 
-All notable changes to this project are documented in this file.
+## About the entries below 0.31.0
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-While the project is pre-1.0, breaking changes are released as minor version
-bumps and called out under a `Breaking` heading — an addition to the standard
-Keep a Changelog categories (Added/Changed/Deprecated/Removed/Fixed/Security).
+Everything from `[0.31.0]` down was written by hand, under an `[Unreleased]`
+heading that an npm `version` lifecycle hook promoted on release. Those entries
+follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with a
+`Breaking` heading added for the pre-1.0 convention of shipping breaking changes
+as minor bumps.
 
-Entries from 0.31.0 down were written by hand under an `[Unreleased]` heading
-and promoted on release by an npm `version` lifecycle hook. That hook is gone:
-since this package moved into the `cipherstash/stack` monorepo, Changesets
-generates each entry from the changesets in a release, and appends it below in
-its own format. Write a changeset, not a section here.
+That hook is gone. Since this package moved into the `cipherstash/stack`
+monorepo, Changesets generates every entry above this heading from the
+changesets in a release, in its own format.
+
+<!--
+This section sits BELOW the generated entries on purpose, and nothing may be
+added between `# Changelog` and the first release heading.
+
+`changeset version` splices each new release in directly after the `# Changelog`
+line. Prose placed there is not a preamble: it lands inside the newest release's
+section, beneath its heading, and publishes to npm as part of those release
+notes. This section used to be there, and shipped as thirteen lines of the
+0.32.0 entry — ending with an instruction addressed to contributors.
+
+Guidance for contributors belongs in AGENTS.md, not here.
+-->
 
 ## [0.31.0] - 2026-07-27
 

--- a/packages/protect-ffi/package.json
+++ b/packages/protect-ffi/package.json
@@ -73,7 +73,8 @@
     "dist/wasm/protect_ffi_bg.wasm.d.ts",
     "dist/wasm/protect_ffi_inline.js",
     "dist/wasm/errors.js",
-    "dist/wasm/errors.d.ts"
+    "dist/wasm/errors.d.ts",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "library",

--- a/packages/protect-ffi/platforms/darwin-arm64/package.json
+++ b/packages/protect-ffi/platforms/darwin-arm64/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/protect-ffi/platforms/darwin-x64/package.json
+++ b/packages/protect-ffi/platforms/darwin-x64/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/protect-ffi/platforms/linux-arm64-gnu/package.json
+++ b/packages/protect-ffi/platforms/linux-arm64-gnu/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/protect-ffi/platforms/linux-x64-gnu/package.json
+++ b/packages/protect-ffi/platforms/linux-x64-gnu/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/protect-ffi/platforms/linux-x64-musl/package.json
+++ b/packages/protect-ffi/platforms/linux-x64-musl/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/protect-ffi/platforms/win32-x64-msvc/package.json
+++ b/packages/protect-ffi/platforms/win32-x64-msvc/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "index.node",
   "files": [
-    "index.node"
+    "index.node",
+    "CHANGELOG.md"
   ],
   "neon": {
     "type": "binary",

--- a/packages/stack-drizzle/package.json
+++ b/packages/stack-drizzle/package.json
@@ -30,7 +30,8 @@
 	"sideEffects": false,
 	"files": [
 		"dist",
-		"README.md"
+		"README.md",
+		"CHANGELOG.md"
 	],
 	"exports": {
 		".": {

--- a/packages/stack-prisma/CHANGELOG.md
+++ b/packages/stack-prisma/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @cipherstash/prisma-next
+# @cipherstash/stack-prisma
 
 ## 1.0.0
 

--- a/packages/stack-prisma/package.json
+++ b/packages/stack-prisma/package.json
@@ -62,7 +62,8 @@
 	"files": [
 		"dist",
 		"src",
-		"README.md"
+		"README.md",
+		"CHANGELOG.md"
 	],
 	"scripts": {
 		"build": "tsup",

--- a/packages/stack-supabase/package.json
+++ b/packages/stack-supabase/package.json
@@ -29,7 +29,8 @@
 	"sideEffects": false,
 	"files": [
 		"dist",
-		"README.md"
+		"README.md",
+		"CHANGELOG.md"
 	],
 	"exports": {
 		".": {


### PR DESCRIPTION
Three defects found auditing #859's release notes. All three are in what consumers read on npm, and all three are fixed by changing what #859 will regenerate — merge this before merging #859.

## 1. Five packages ship a major with nothing to show for it

`stash`, `@cipherstash/stack`, `stack-drizzle`, `stack-supabase` and `wizard` go 1.0.0 → 2.0.0 carrying only Minor and Patch entries. `@cipherstash/wizard@2.0.0` is a heading followed by two blank lines — on npm that reads as lost release notes, not "nothing changed".

The one real breaking change is `@cipherstash/stack-prisma` (Prisma Next 0.17). The other five inherit its number through the Changesets `fixed` group, and nothing in 485 lines of release notes said so. A `stack-drizzle` user would see 2.0.0, go looking for the migration guide, and find patch notes.

`.changeset/stack-2-0-0-version-alignment.md` says it in the changelog itself — where they will actually look, rather than in a PR description that is not published — and explains why the six are versioned together: `stash init` pins the versions it installs and the CLI embeds that map at build time, so a package shipping alone would leave the CLI recommending versions that no longer match what is published (#661, `d8039141`).

## 2. The six platform packages had no entry at all

0.32.0 is the **first release of these packages published from `cipherstash/stack`**. The attested provenance repository changes with it:

```
0.31.0   github.com/cipherstash/protectjs-ffi   .github/workflows/release.yml
0.32.0   github.com/cipherstash/stack           .github/workflows/release.yml
```

A verification policy pinning the source repository rejects 0.32.0 until updated. The wrapper's patch note covers the repository repoint, but it sits 270 lines down and the six platform packages — the ones a provenance checker actually installs — had empty sections.

`.changeset/ffi-platform-packages-publishing-repository.md` gives all six the note.

## 3. The CHANGELOG preamble was publishing as release notes

`changeset version` splices each release directly after the `# Changelog` line, so the hand-written preamble beneath it landed **inside** the newest section, under its heading. In #859 that is body lines 296–309: thirteen lines rendered as part of 0.32.0, ending with

> Write a changeset, not a section here.

— an instruction addressed to contributors, about to publish to npm. It would have recurred every release.

Moved below the generated entries, where it explains the file's two halves and cannot be swept again, with a comment recording why nothing may sit between `# Changelog` and the first release heading.

## Verification

Ran `changeset version` for real and rolled it back:

- seven FFI packages still land on **0.32.0**, six Stack packages on **2.0.0** — these changesets add prose, not version bumps
- `@cipherstash/wizard@2.0.0` and each platform package's `0.32.0` are no longer empty
- no preamble text remains inside the 0.32.0 section
- `pnpm run test:scripts` — 416 passing

## Not fixed here

- **Five private packages are listed under "# Releases"** in #859 (`e2e`, `basic-example`, `prisma-example`, `bench`, `test-kit`) under a preamble saying packages "will be published to npm automatically". They will not — they are `private`. That is `changesets/action` template behaviour, not something a changeset can correct.
- **Prettier reformatted historical entries** in the protect-ffi CHANGELOG during generation, dropping indentation from four continuation lines and breaking list rendering for already-published 0.28–0.31 notes.
- **`packages/stack/src/diagnostics.ts:26`** still says its changeset "is parked as `.deferred` until the publishing cutover". Stale since #910.
- **`@cipherstash/nextjs`** is at 4.1.2 in this repo and 4.3.0 on npm — two minors published from somewhere else. Unrelated to this release, but worth knowing.
