### PR TITLE
fix(biome): align the config schema with the version actually installed

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
One line. `code:check` currently exits 1 on `main` for a reason unrelated to any code in the tree.

```
biome.json:2:14 deserialize
  i The configuration schema version does not match the CLI version 2.5.3
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
```

`package.json` has required `^2.5.3` and `pnpm-lock.yaml` has resolved 2.5.3 since before this was noticed; only `biome.json` was left behind at 2.5.2.

**Why it has stayed hidden:** a `node_modules` that still holds 2.5.2 passes. It fails the moment the tree is brought in line with its own lockfile — which is what `pnpm install --frozen-lockfile` does on every CI run. Found while running a plain `pnpm install` on a branch off main.

Extracted from #915 so it does not wait on a large review.