### PR TITLE
fix(release): publish the FFI tarballs by path, not GitHub shorthand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,12 @@ jobs:
             if npm view "${name}@${version}" version >/dev/null 2>&1; then
               echo "${name}@${version} already published — skipping"
             else
-              npm publish --access public --provenance "$tgz"
+              # "./" is load-bearing: npm classifies a bare `dir/file.tgz`
+              # argument as a GitHub `owner/repo` shorthand before it considers
+              # it a file, then dies in `git ls-remote` — which is exactly how
+              # the first 2.0.0 release attempt failed. A path-ish spec is only
+              # treated as a tarball when it starts with ./, ../, / or file:.
+              npm publish --access public --provenance "./$tgz"
             fi
             published+=("${name}@${version}")
           done


### PR DESCRIPTION
## What happened

The 2.0.0 release run (#859's merge) failed in **Publish FFI packages** on the first platform tarball:

```
npm error command git --no-replace-objects ls-remote ssh://git@github.com/ffi-dist/cipherstash-protect-ffi-darwin-arm64-0.32.0.tgz.git
npm error git@github.com: Permission denied (publickey).
```

`npm publish` received the bare relative path `ffi-dist/<name>.tgz`. npm's spec parser classifies an `owner/repo`-shaped argument as a **GitHub shorthand** before it considers it a file, so it tried to `git ls-remote` a repository named after the tarball. A spec is only treated as a local tarball when it starts with `./`, `../`, `/` or `file:`.

## Fix

One line: `npm publish --access public --provenance "./$tgz"`, with a comment explaining why the `./` is load-bearing. Nothing else in the step uses the path as a package spec (the `tar` reads and `npm view` probes are unaffected).

## What this does and doesn't prove

- The run died before npm ever talked to the registry, so **trusted publishing was never exercised** — this fix is necessary for the next attempt but not yet proven sufficient. Worth `npm trust list <pkg>` on the seven FFI packages before retrying (per AGENTS.md, each configuration must also allow `npm publish`).
- `ffi-preflight.yml` couldn't have caught this: it dry-runs `changeset publish`, and this custom step has no dry-run path.

Companion to #920 (which re-arms the release as 1.1.0). This must merge before the next Version Packages PR does, or the release fails the same way again.