### PR TITLE
docs(eql): lead the existing-database install with the stash CLI

### DIFF
--- a/packages/eql/README.md
+++ b/packages/eql/README.md
@@ -52,7 +52,20 @@ EQL is installed automatically on first boot. Pin a specific version with `:17-<
 
 ### Install into an existing database
 
-Execute the install SQL file directly:
+Use the `stash` CLI (recommended):
+
+```sh
+npx stash eql install
+```
+
+It connects using `DATABASE_URL` (or `--database-url` for a one-shot run), checks your role's
+capabilities first (`npx stash eql preflight` runs the same checks standalone), installs as a
+non-superuser, and prints any optional superuser-gated statements it skipped instead of failing
+on them. On platforms where schema changes must go through a migration tool, generate a
+migration instead: `npx stash eql migration --supabase` (or `--drizzle`).
+
+<details>
+<summary>Alternative: apply the raw SQL yourself</summary>
 
 1. Download the latest EQL install script:
 
@@ -65,6 +78,15 @@ Execute the install SQL file directly:
    ```sh
    psql -f cipherstash-encrypt.sql
    ```
+
+> [!WARNING]
+> The bundle is ~6,000 statements and `psql -f` sends one statement per protocol round trip. Over a
+> pooled or high-latency connection — or under a platform command-time ceiling (some managed
+> platforms kill commands after a fixed limit) — this can time out **partway**, leaving a
+> half-installed schema. If you cannot use the CLI, apply the file over a direct (non-pooled)
+> connection, or split it at statement boundaries and apply each chunk as a single command.
+
+</details>
 
 
 ## EQL Components


### PR DESCRIPTION
## Summary

EQL is the SQL library that CipherStash installs into a Postgres database (as the `eql_v3` schema) so encrypted values can be stored and queried. Its README told you to install it one way only: download a release SQL file and run `psql -f` on it. That way breaks on real databases — the file is about 6,000 separate SQL statements, and `psql -f` sends them one at a time over the network. On a pooled connection, a slow link, or a hosting platform that kills any command after a fixed time, the install stops halfway and leaves a broken, half-installed schema behind.

This makes `npx stash eql install` — the `stash` CLI command that installs EQL for you, in one connection, with a role-permission check first — the headline instruction, and moves the raw-SQL instructions into a collapsed section with a warning about the failure above.

## Changes

- `packages/eql/README.md`, "Install into an existing database": leads with `npx stash eql install`. Explains that it takes the database URL from `DATABASE_URL` or `--database-url` (one run only, never written to disk), runs the same role-capability checks as `npx stash eql preflight`, installs without needing a superuser, and reports the optional superuser-only statements it skipped instead of erroring. Points at `npx stash eql migration --supabase` (or `--drizzle`) for platforms where schema changes have to go through a migration tool.
- Raw-SQL steps kept word-for-word inside a `<details>` block, with a warning that names the per-statement round-trip hazard and its two workarounds: a direct (non-pooled) connection, or splitting the file at statement boundaries and applying one chunk per command.

## Verification

Docs-only; no code, no published-package surface, so no changeset. The EQL npm package's own README (`packages/eql/packages/eql/README.md`) is a separate 13-line stub and is untouched — this file is the subtree root README and ships in no tarball.

- Command and flag claims re-checked against the current CLI registry (`packages/cli/src/cli/registry.ts`): `eql preflight`, `eql install`, `eql migration` all exist, `--supabase` / `--drizzle` exist on `eql migration`, and `--database-url` is the documented one-shot, highest-precedence source.
- The hazard is from a live run: applying the 3.0.4 bundle with `psql -f` over a pooled connection hit a managed platform's 600-second command ceiling mid-bundle and half-installed the schema; recovery was 27 statement-boundary chunks applied one `psql -c` each.
- Commit signed.

## Related

Ports cipherstash/encrypt-query-language#440, which was still open when the EQL code moved into this repo and so can no longer merge there. Refs #665. Companion skill update already merged as #929.