### PR TITLE
chore(eql): repoint manifests at cipherstash/stack

### DIFF
--- a/.changeset/eql-repoint-manifests-to-stack.md
+++ b/.changeset/eql-repoint-manifests-to-stack.md
@@ -1,0 +1,5 @@
+---
+'@cipherstash/eql': patch
+---
+
+Point `repository`, `repository.directory`, and `bugs.url` at `cipherstash/stack` instead of the archived `cipherstash/encrypt-query-language`. Purely metadata — no behaviour change — but required before npm's trusted publishing (already repointed at `cipherstash/stack`) can accept a release: npm rejects a publish whose manifest `repository.url` doesn't match the publishing repository.

--- a/packages/eql/crates/eql-bindings/Cargo.toml
+++ b/packages/eql/crates/eql-bindings/Cargo.toml
@@ -6,8 +6,8 @@ description = "Canonical wire types for EQL payloads — single source of truth 
 # crates.io metadata. `license` is REQUIRED by crates.io — publish fails without
 # it. The rest drive discoverability and the docs.rs / crates.io sidebar links.
 license = "MIT"
-repository = "https://github.com/cipherstash/encrypt-query-language"
-homepage = "https://github.com/cipherstash/encrypt-query-language"
+repository = "https://github.com/cipherstash/stack"
+homepage = "https://github.com/cipherstash/stack"
 readme = "README.md"
 keywords = ["encryption", "postgres", "eql", "cipherstash", "searchable"]
 categories = ["cryptography", "database"]

--- a/packages/eql/packages/eql/package.json
+++ b/packages/eql/packages/eql/package.json
@@ -10,12 +10,12 @@
     "typescript"
   ],
   "bugs": {
-    "url": "https://github.com/cipherstash/encrypt-query-language/issues"
+    "url": "https://github.com/cipherstash/stack/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cipherstash/encrypt-query-language.git",
-    "directory": "packages/eql"
+    "url": "git+https://github.com/cipherstash/stack.git",
+    "directory": "packages/eql/packages/eql"
   },
   "license": "MIT",
   "author": "CipherStash <hello@cipherstash.com>",

--- a/scripts/__tests__/eql-repository-urls.test.mjs
+++ b/scripts/__tests__/eql-repository-urls.test.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { REPO_ROOT } from './lib/repo-root.mjs'
+
+/**
+ * The EQL manifests must name THIS repository, mirroring
+ * ffi-repository-urls.test.mjs.
+ *
+ * npm trusted publishing matches `repository.url` against the repository the
+ * publish runs from, exactly: *"your package's `repository.url` field in
+ * `package.json` must exactly match your GitHub repository"*
+ * (https://docs.npmjs.com/trusted-publishers/). A stale URL does not warn and
+ * does not degrade — the publish is rejected. crates.io applies the same rule
+ * to `repository` in Cargo.toml.
+ *
+ * `repository.directory` is the quieter half. It resolves from the ROOT of the
+ * repository named in `repository.url`, so `packages/eql` addressed the real
+ * package root in the old repo and addresses nothing here, where the npm
+ * package lives at `packages/eql/packages/eql` (the subtree's own nested
+ * package.json, per the verbatim-prefix import). A stale `directory` publishes
+ * fine and silently breaks the source link on the package page — the failure
+ * that gets noticed is the wrong one, which is why both are asserted.
+ */
+
+const EQL_NPM = join(REPO_ROOT, 'packages/eql/packages/eql/package.json')
+const EQL_BINDINGS_CARGO = join(
+  REPO_ROOT,
+  'packages/eql/crates/eql-bindings/Cargo.toml',
+)
+
+/** The repository these packages publish from as of the cutover. */
+const EXPECTED = 'https://github.com/cipherstash/stack'
+
+describe('EQL manifests name this repository', () => {
+  const pkg = JSON.parse(readFileSync(EQL_NPM, 'utf8'))
+
+  it('@cipherstash/eql points repository.url at cipherstash/stack', () => {
+    expect(pkg.repository.url).toBe(`git+${EXPECTED}.git`)
+  })
+
+  it('@cipherstash/eql names its own path from the repo root', () => {
+    expect(pkg.repository.directory).toBe('packages/eql/packages/eql')
+  })
+
+  it('@cipherstash/eql sends bug reports here, not to the old repository', () => {
+    expect(pkg.bugs.url).toBe(`${EXPECTED}/issues`)
+  })
+
+  it('no reference to the old repository remains in package.json', () => {
+    expect(readFileSync(EQL_NPM, 'utf8')).not.toMatch(/encrypt-query-language/)
+  })
+
+  it('eql-bindings names this repository too', () => {
+    const cargo = readFileSync(EQL_BINDINGS_CARGO, 'utf8')
+    expect(cargo).toMatch(
+      /^repository = "https:\/\/github\.com\/cipherstash\/stack"$/m,
+    )
+    expect(cargo).toMatch(
+      /^homepage = "https:\/\/github\.com\/cipherstash\/stack"$/m,
+    )
+    expect(cargo).not.toMatch(/encrypt-query-language/)
+  })
+})


### PR DESCRIPTION
## Summary

Trusted publishing for `@cipherstash/eql` (npm) and `eql-bindings` (crates.io) is now configured against `cipherstash/stack`, but the manifests themselves still named `cipherstash/encrypt-query-language`. Both npm and crates.io reject a publish whose manifest `repository` field doesn't match the publishing repository, so a release triggered from here today would fail. This is the last blocker before EQL can actually release from `cipherstash/stack` — the "trusted publishing points at stack" step alone isn't the same as "a release can succeed here."

## Changes

- `packages/eql/packages/eql/package.json`: `repository.url` → `git+https://github.com/cipherstash/stack.git`, `repository.directory` → `packages/eql/packages/eql` (the npm package's real location under the verbatim-prefix subtree import), `bugs.url` → `https://github.com/cipherstash/stack/issues`.
- `packages/eql/crates/eql-bindings/Cargo.toml`: `repository` and `homepage` → `https://github.com/cipherstash/stack`.
- Added `scripts/__tests__/eql-repository-urls.test.mjs`, mirroring `ffi-repository-urls.test.mjs`, so a regression here fails CI instead of a future publish.
- Checked `release-plz.toml`'s prose — it doesn't reference the old repository, so it needed no change.

## Verification

- New guard test passes: `npx vitest run --config scripts/vitest.config.mjs scripts/__tests__/eql-repository-urls.test.mjs` — 5/5.
- `pnpm run code:fix` (Biome) run scoped to the changed files — no other issues.
- Three unrelated test files fail both with and without this change (`lint-no-eql-registry-pins.test.mjs`, `cargo-lock-freshness.test.mjs`, `bench-index-expressions.test.mjs`) — confirmed pre-existing on `main` via `git stash`, not caused by this PR.
- Did not run a full package build; this is a metadata-only change with no code paths reading these fields at runtime.

## Related

Part of the EQL → `cipherstash/stack` trusted-publishing cutover.